### PR TITLE
Initial Flask Support

### DIFF
--- a/src/scout_apm/core/socket.py
+++ b/src/scout_apm/core/socket.py
@@ -121,7 +121,7 @@ class CoreAgentSocket(threading.Thread):
         try:
             data = json.dumps(msg)
         except (ValueError, TypeError) as e:
-            log.debug('Exception when serializing command message: %s' % repr(e))
+            logger.debug('Exception when serializing command message: %s' % repr(e))
             return False
 
         try:

--- a/src/scout_apm/flask/__init__.py
+++ b/src/scout_apm/flask/__init__.py
@@ -1,0 +1,63 @@
+from flask import current_app, request, g, send_from_directory
+from flask.globals import _request_ctx_stack
+
+from datetime import datetime
+
+
+class ScoutApm(object):
+    def __init__(self, app=None):
+        self.app = app
+        if app is not None:
+            self.init_app(app)
+
+    def init_app(self, app):
+        app.before_request(self.process_request)
+        app.after_request(self.process_response)
+        app.teardown_request(self.teardown_request)
+
+        # Monkey-patch the Flask.dispatch_request method
+        app.dispatch_request = self.dispatch_request
+
+    def dispatch_request(self):
+        """Modified version of Flask.dispatch_request to call process_view."""
+
+        print("Dispatch Request")
+        req = _request_ctx_stack.top.request
+        app = current_app
+
+        if req.routing_exception is not None:
+            app.raise_routing_exception(req)
+
+        rule = req.url_rule
+
+        # if we provide automatic options for this URL and the
+        # request came with the OPTIONS method, reply automatically
+        if getattr(rule, 'provide_automatic_options', False) \
+           and req.method == 'OPTIONS':
+            return app.make_default_options_response()
+
+        # otherwise dispatch to the handler for that endpoint
+        view_func = app.view_functions[rule.endpoint]
+        view_func = self.process_view(app, view_func, req.view_args)
+
+        return view_func(**req.view_args)
+
+    def process_request(self):
+        print("Process Request")
+
+    def process_view(self, app, view_func, view_kwargs):
+        """ This method is called just before the flask view is called.
+        This is done by the dispatch_request method.
+        """
+        print("Process View:", view_func.__module__, view_func.__name__)
+        #  __import__('pdb').set_trace()
+        return view_func
+
+    def process_response(self, response):
+        print("Process Response")
+        return response
+
+    def teardown_request(self, exc):
+        print("Teardown Request")
+
+

--- a/src/scout_apm/flask/__init__.py
+++ b/src/scout_apm/flask/__init__.py
@@ -1,4 +1,4 @@
-from flask import current_app, request, g, send_from_directory
+from flask import current_app
 from flask.globals import _request_ctx_stack
 
 import scout_apm.core
@@ -75,7 +75,9 @@ class ScoutApm(object):
         This is done by the dispatch_request method.
         """
         operation = view_func.__module__ + '.' + view_func.__name__
-        return self.trace_view_function(view_func, ('Controller', {"path": req.path, "name": operation}))
+        return self.trace_view_function(
+                        view_func,
+                        ('Controller', {'path': req.path, 'name': operation}))
 
     def trace_view_function(self, func, info):
         try:

--- a/src/scout_apm/flask/sqlalchemy.py
+++ b/src/scout_apm/flask/sqlalchemy.py
@@ -1,0 +1,13 @@
+from scout_apm.core.monkey import monkeypatch_method
+from scout_apm.core.tracked_request import TrackedRequest
+import scout_apm.sqlalchemy
+
+from sqlalchemy import event
+from flask_sqlalchemy import SQLAlchemy
+
+def instrument_sqlalchemy(db):
+    @monkeypatch_method(SQLAlchemy)
+    def get_engine(original, self, *args, **kwargs):
+        engine = original(*args, **kwargs)
+        scout_apm.sqlalchemy.instrument_sqlalchemy(engine)
+        return engine

--- a/src/scout_apm/sqlalchemy/__init__.py
+++ b/src/scout_apm/sqlalchemy/__init__.py
@@ -1,0 +1,18 @@
+from scout_apm.core.tracked_request import TrackedRequest
+
+from sqlalchemy import event
+
+def instrument_sqlalchemy(engine):
+    def before_cursor_execute(conn, cursor, statement, parameters, context, executemany):
+        tr = TrackedRequest.instance()
+        span = tr.start_span(operation='SQL/Query')
+        span.tag('db.statement', statement)
+
+    def after_cursor_execute(conn, cursor, statement, parameters, context, executemany):
+        tr = TrackedRequest.instance()
+        tr.stop_span()
+
+    if getattr(engine, "_scout_instrumented", False) != True:
+        event.listen(engine, 'before_cursor_execute', before_cursor_execute)
+        event.listen(engine, 'after_cursor_execute', after_cursor_execute)
+        setattr(engine, "_scout_instrumented", True)


### PR DESCRIPTION
This is a WIP still, but it works in my test env (flask 0.12.2) with a trivial app.

Once finished, will close #5 

### Next Steps

* [ ] Instrument common libraries (SQLAlchemy, Jinja, others?)
* [ ] More complex apps (check that these all work as expected)
  * [ ] App Factories
  * [ ] Multiple apps in same namespace
  * [ ] Blueprint endpoints
  * [ ] Other extensions
* [ ] Test older versions of Flask
* [ ] Extract shared wrapping code (very similar to several spots in the Django instruments).
* [ ] CI Tests
* [ ] Documentation
  * [ ] Logging


### My Trivial App

```python
from flask import Flask
from scout_apm.flask import ScoutApm

app = Flask(__name__)

ScoutApm(app)

app.config['SCOUT_MONITOR'] = True
app.config['SCOUT_KEY'] = 'xxx'
app.config['SCOUT_NAME'] = 'My Flask App'

@app.route('/')
def hello_world():
    return 'Hello, World!'
```