### PR TITLE
Catch IOError when reading core-agent's manifest.json

### DIFF
--- a/src/scout_apm/core/core_agent_manager.py
+++ b/src/scout_apm/core/core_agent_manager.py
@@ -200,7 +200,7 @@ class CoreAgentManifest:
         self.valid = False
         try:
             self.parse()
-        except (ValueError, TypeError, OSError) as e:
+        except (ValueError, TypeError, OSError, IOError) as e:
             logger.debug('Error parsing Core Agent Manifest: %s', repr(e))
 
     def parse(self):


### PR DESCRIPTION
If for any reason the manifest.json file isn't present or can't be opened, we
should catch that error.