### PR TITLE
Initial Celery Support

### DIFF
--- a/src/scout_apm/celery/__init__.py
+++ b/src/scout_apm/celery/__init__.py
@@ -11,13 +11,12 @@ def prerun_callback(sender=None, headers=None, body=None, **kwargs):
 
     tr = TrackedRequest.instance()
     tr.mark_real_request()
-    tr.start_span(operation='Queue/Default')
-    tr.start_span(operation=('Job/' + name))
+    span = tr.start_span(operation=('Job/' + name))
+    span.tag('queue', 'default')
 
 
 def postrun_callback(sender=None, headers=None, body=None, **kwargs):
     tr = TrackedRequest.instance()
-    tr.stop_span()
     tr.stop_span()
 
 
@@ -25,8 +24,6 @@ def install():
     installed = scout_apm.core.install()
     if installed is False:
         return
-
-    print('Installing ScoutAPM Celery Instruments')
 
     task_prerun.connect(prerun_callback)
     task_postrun.connect(postrun_callback)

--- a/src/scout_apm/celery/__init__.py
+++ b/src/scout_apm/celery/__init__.py
@@ -1,0 +1,32 @@
+import scout_apm.core
+from scout_apm.core.tracked_request import TrackedRequest
+
+from celery.signals import task_prerun, task_postrun
+
+
+# TODO: Capture queue.
+# https://stackoverflow.com/questions/22385297/how-to-get-the-queue-in-which-a-task-was-run-celery?utm_medium=organic&utm_source=google_rich_qa&utm_campaign=google_rich_qa
+def prerun_callback(sender=None, headers=None, body=None, **kwargs):
+    name = kwargs['task'].name
+
+    tr = TrackedRequest.instance()
+    tr.mark_real_request()
+    tr.start_span(operation='Queue/Default')
+    tr.start_span(operation=('Job/' + name))
+
+
+def postrun_callback(sender=None, headers=None, body=None, **kwargs):
+    tr = TrackedRequest.instance()
+    tr.stop_span()
+    tr.stop_span()
+
+
+def install():
+    installed = scout_apm.core.install()
+    if installed is False:
+        return
+
+    print('Installing ScoutAPM Celery Instruments')
+
+    task_prerun.connect(prerun_callback)
+    task_postrun.connect(postrun_callback)


### PR DESCRIPTION
This is pretty bare bones currently, and hasn't been tested in very many cases, but it works well capturing my example Celery.  Note, that this currently relies on an unreleased version of the binary core-agent that will be released soon.

Tested on Python 3.6 with Celery 4.1.0.

