### PR TITLE
Add simple ContextManager and Decorator for custom instrumentation

### DIFF
--- a/src/scout_apm/api/__init__.py
+++ b/src/scout_apm/api/__init__.py
@@ -1,0 +1,43 @@
+from scout_apm.core.tracked_request import TrackedRequest
+
+import sys
+import logging
+
+
+# Logging
+logger = logging.getLogger(__name__)
+
+
+# Python 2 (and very early 3.x) didn't have ContextDecorator, so define it for ourselves
+if sys.version_info < (3, 2):
+    import functools
+
+    class ContextDecorator(object):
+        def __call__(self, f):
+            @functools.wraps(f)
+            def decorated(*args, **kwds):
+                with self:
+                    return f(*args, **kwds)
+            return decorated
+else:
+    from contextlib import ContextDecorator
+
+
+class instrument(ContextDecorator):
+    def __init__(self, operation):
+        self.operation = operation
+
+    def __enter__(self):
+        tr = TrackedRequest.instance()
+        self.span = tr.start_span(operation=self.operation)
+        return self
+
+    def __exit__(self, *exc):
+        tr = TrackedRequest.instance()
+        tr.stop_span()
+        return False
+
+    def tag(self, key, value):
+        if self.span is not None:
+            self.span.tag(key, value)
+

--- a/src/scout_apm/api/__init__.py
+++ b/src/scout_apm/api/__init__.py
@@ -24,12 +24,15 @@ else:
 
 
 class instrument(ContextDecorator):
-    def __init__(self, operation):
-        self.operation = operation
+    def __init__(self, operation, kind='Custom', tags={}):
+        self.operation = kind + '/' + operation
+        self.tags = tags
 
     def __enter__(self):
         tr = TrackedRequest.instance()
         self.span = tr.start_span(operation=self.operation)
+        for key, value in self.tags.items():
+            self.tag(key, value)
         return self
 
     def __exit__(self, *exc):

--- a/src/scout_apm/api/tracing.py
+++ b/src/scout_apm/api/tracing.py
@@ -1,0 +1,12 @@
+from contextlib import ContextDecorator
+
+class instrument(ContextDecorator):
+    def __enter__(self):
+        print('Starting')
+        return self
+
+    def __exit__(self, *exc):
+        print('Finishing')
+        return False
+
+

--- a/tests/scout_apm_tests/api/instrument_test.py
+++ b/tests/scout_apm_tests/api/instrument_test.py
@@ -1,0 +1,26 @@
+import scout_apm.api
+from scout_apm.core.tracked_request import TrackedRequest
+
+
+def test_context_manager_instrument():
+    # Save TR here, so it doesn't disappear on us when span finishes
+    tr = TrackedRequest.instance()
+
+    with scout_apm.api.instrument("Test ContextMgr") as instrument:
+        instrument.tag("foo", "bar")
+
+    span = tr.complete_spans[-1]
+    assert(span.operation == "Test ContextMgr")
+
+
+def test_decoration_instrument():
+    # Save TR here, so it doesn't disappear on us when span finishes
+    tr = TrackedRequest.instance()
+
+    @scout_apm.api.instrument("Test Decorator")
+    def test():
+        a = 1
+    test()
+
+    span = tr.complete_spans[-1]
+    assert(span.operation == "Test Decorator")

--- a/tests/scout_apm_tests/api/instrument_test.py
+++ b/tests/scout_apm_tests/api/instrument_test.py
@@ -6,21 +6,71 @@ def test_context_manager_instrument():
     # Save TR here, so it doesn't disappear on us when span finishes
     tr = TrackedRequest.instance()
 
-    with scout_apm.api.instrument("Test ContextMgr") as instrument:
-        instrument.tag("foo", "bar")
+    with scout_apm.api.instrument('Test ContextMgr') as instrument:
+        instrument.tag('foo', 'bar')
 
     span = tr.complete_spans[-1]
-    assert(span.operation == "Test ContextMgr")
+    assert(span.operation == 'Custom/Test ContextMgr')
 
 
 def test_decoration_instrument():
     # Save TR here, so it doesn't disappear on us when span finishes
     tr = TrackedRequest.instance()
 
-    @scout_apm.api.instrument("Test Decorator")
+    @scout_apm.api.instrument('Test Decorator')
     def test():
         a = 1
     test()
 
     span = tr.complete_spans[-1]
-    assert(span.operation == "Test Decorator")
+    assert(span.operation == 'Custom/Test Decorator')
+
+
+def test_context_manager_instrument_with_kind():
+    # Save TR here, so it doesn't disappear on us when span finishes
+    tr = TrackedRequest.instance()
+
+    with scout_apm.api.instrument('Get', kind='Redis') as instrument:
+        instrument.tag('foo', 'bar')
+
+    span = tr.complete_spans[-1]
+    assert(span.operation == 'Redis/Get')
+
+
+def test_decoration_instrument_with_kind():
+    # Save TR here, so it doesn't disappear on us when span finishes
+    tr = TrackedRequest.instance()
+
+    @scout_apm.api.instrument('GET example.com', kind='HTTP')
+    def test():
+        a = 1
+    test()
+
+    span = tr.complete_spans[-1]
+    assert(span.operation == 'HTTP/GET example.com')
+
+
+def test_context_manager_default_tags():
+    # Save TR here, so it doesn't disappear on us when span finishes
+    tr = TrackedRequest.instance()
+
+    with scout_apm.api.instrument('tag test', tags={'x': 99}):
+        a = 1
+
+    span = tr.complete_spans[-1]
+    assert(len(span.tags) == 1)
+    assert(span.tags['x'] == 99)
+
+
+def test_decoration_default_tags():
+    # Save TR here, so it doesn't disappear on us when span finishes
+    tr = TrackedRequest.instance()
+
+    @scout_apm.api.instrument('tag test', tags={'x': 99})
+    def test():
+        a = 1
+    test()
+
+    span = tr.complete_spans[-1]
+    assert(len(span.tags) == 1)
+    assert(span.tags['x'] == 99)


### PR DESCRIPTION
An easy API to instrument specific spans of code:

```
import scout_apm.api

@scout_apm.api.instrument("Custom/MyCalculation")
def my_calc(self, x, y):
  pass

# or as a context manager:

def my_other_calc(self, x, y):
  with scout_apm.api.instrument("Custom/MyOtherCalculation") as instrument:
    instrument.tag("user_id", "1")
    pass
```

Questions:

* Should this be named `instrument`, or something more specific
* Should we limit the type prefix to be exactly "Custom"? If that string is high arity, it doesn't display well on the server. Elsewhere in the instrumentation it's "SQL" or "Template" or similar. Fixed strings.