### PR TITLE
Default a None timestamp in any Command to now

### DIFF
--- a/src/scout_apm/core/commands.py
+++ b/src/scout_apm/core/commands.py
@@ -7,6 +7,11 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+# A constant that represents an "unknown" date. Fallback, and will be rejected
+# by the CoreAgent. But important to avoid exceptions if a None timestamp is
+# passed to a Command.
+INVALID_DATE = datetime.datetime(year=2000, month=1, day=1)
+
 
 class Register:
     def __init__(self, *args, **kwargs):
@@ -25,7 +30,7 @@ class Register:
 
 class StartSpan:
     def __init__(self, *args, **kwargs):
-        self.timestamp = kwargs.get('timestamp') or datetime.utcnow()
+        self.timestamp = kwargs.get('timestamp') or INVALID_DATE
         self.request_id = kwargs.get('request_id', None)
         self.span_id = kwargs.get('span_id', None)
         self.parent = kwargs.get('parent', None)
@@ -45,7 +50,7 @@ class StopSpan:
     def __init__(self, *args, **kwargs):
         self.request_id = kwargs.get('request_id', None)
         self.span_id = kwargs.get('span_id', None)
-        self.timestamp = kwargs.get('timestamp') or datetime.utcnow()
+        self.timestamp = kwargs.get('timestamp') or INVALID_DATE
 
     def message(self):
         return {'StopSpan': {
@@ -57,7 +62,7 @@ class StopSpan:
 
 class StartRequest:
     def __init__(self, *args, **kwargs):
-        self.timestamp = kwargs.get('timestamp') or datetime.utcnow()
+        self.timestamp = kwargs.get('timestamp') or INVALID_DATE
         self.request_id = kwargs.get('request_id', None)
 
     def message(self):
@@ -69,7 +74,7 @@ class StartRequest:
 
 class FinishRequest:
     def __init__(self, *args, **kwargs):
-        self.timestamp = kwargs.get('timestamp') or datetime.utcnow()
+        self.timestamp = kwargs.get('timestamp') or INVALID_DATE
         self.request_id = kwargs.get('request_id', None)
 
     def message(self):
@@ -81,7 +86,7 @@ class FinishRequest:
 
 class TagSpan:
     def __init__(self, *args, **kwargs):
-        self.timestamp = kwargs.get('timestamp') or datetime.utcnow()
+        self.timestamp = kwargs.get('timestamp') or INVALID_DATE
         self.request_id = kwargs.get('request_id', None)
         self.span_id = kwargs.get('span_id', None)
         self.tag = kwargs.get('tag', None)
@@ -99,7 +104,7 @@ class TagSpan:
 
 class TagRequest:
     def __init__(self, *args, **kwargs):
-        self.timestamp = kwargs.get('timestamp') or datetime.utcnow()
+        self.timestamp = kwargs.get('timestamp') or INVALID_DATE
         self.request_id = kwargs.get('request_id', None)
         self.tag = kwargs.get('tag', None)
         self.value = kwargs.get('value', None)
@@ -117,7 +122,7 @@ class ApplicationEvent:
     def __init__(self, *args, **kwargs):
         self.event_type = kwargs.get('event_type', '')
         self.event_value = kwargs.get('event_value', '')
-        self.timestamp = kwargs.get('timestamp') or datetime.utcnow()
+        self.timestamp = kwargs.get('timestamp') or INVALID_DATE
         self.source = kwargs.get('source', '')
 
     def message(self):

--- a/src/scout_apm/core/commands.py
+++ b/src/scout_apm/core/commands.py
@@ -176,10 +176,19 @@ class BatchCommand:
                                         tag=key,
                                         value=span.tags[key]))
             # Span End
+            if span.end_time is None:
+                logger.debug("Invalid Request, span_id: %s had a None end_time", span.span_id)
+                return None
+
             commands.append(StopSpan(timestamp=span.end_time,
                                      request_id=span.request_id,
                                      span_id=span.span_id))
         # Request Finish
+        if request.end_time is None:
+            logger.debug("Invalid Request, request_id: %s had a None end_time", request.req_id)
+            return None
+
         commands.append(FinishRequest(timestamp=request.end_time,
                                       request_id=request.req_id))
+
         return BatchCommand(commands)

--- a/src/scout_apm/core/commands.py
+++ b/src/scout_apm/core/commands.py
@@ -25,7 +25,7 @@ class Register:
 
 class StartSpan:
     def __init__(self, *args, **kwargs):
-        self.timestamp = kwargs.get('timestamp', datetime.utcnow())
+        self.timestamp = kwargs.get('timestamp') or datetime.utcnow()
         self.request_id = kwargs.get('request_id', None)
         self.span_id = kwargs.get('span_id', None)
         self.parent = kwargs.get('parent', None)
@@ -43,9 +43,9 @@ class StartSpan:
 
 class StopSpan:
     def __init__(self, *args, **kwargs):
-        self.timestamp = kwargs.get('timestamp', datetime.utcnow())
         self.request_id = kwargs.get('request_id', None)
         self.span_id = kwargs.get('span_id', None)
+        self.timestamp = kwargs.get('timestamp') or datetime.utcnow()
 
     def message(self):
         return {'StopSpan': {
@@ -57,7 +57,7 @@ class StopSpan:
 
 class StartRequest:
     def __init__(self, *args, **kwargs):
-        self.timestamp = kwargs.get('timestamp', datetime.utcnow())
+        self.timestamp = kwargs.get('timestamp') or datetime.utcnow()
         self.request_id = kwargs.get('request_id', None)
 
     def message(self):
@@ -69,7 +69,7 @@ class StartRequest:
 
 class FinishRequest:
     def __init__(self, *args, **kwargs):
-        self.timestamp = kwargs.get('timestamp', datetime.utcnow())
+        self.timestamp = kwargs.get('timestamp') or datetime.utcnow()
         self.request_id = kwargs.get('request_id', None)
 
     def message(self):
@@ -81,7 +81,7 @@ class FinishRequest:
 
 class TagSpan:
     def __init__(self, *args, **kwargs):
-        self.timestamp = kwargs.get('timestamp', datetime.utcnow())
+        self.timestamp = kwargs.get('timestamp') or datetime.utcnow()
         self.request_id = kwargs.get('request_id', None)
         self.span_id = kwargs.get('span_id', None)
         self.tag = kwargs.get('tag', None)
@@ -99,7 +99,7 @@ class TagSpan:
 
 class TagRequest:
     def __init__(self, *args, **kwargs):
-        self.timestamp = kwargs.get('timestamp', datetime.utcnow())
+        self.timestamp = kwargs.get('timestamp') or datetime.utcnow()
         self.request_id = kwargs.get('request_id', None)
         self.tag = kwargs.get('tag', None)
         self.value = kwargs.get('value', None)
@@ -117,7 +117,7 @@ class ApplicationEvent:
     def __init__(self, *args, **kwargs):
         self.event_type = kwargs.get('event_type', '')
         self.event_value = kwargs.get('event_value', '')
-        self.timestamp = kwargs.get('timestamp', datetime.utcnow())
+        self.timestamp = kwargs.get('timestamp') or datetime.utcnow()
         self.source = kwargs.get('source', '')
 
     def message(self):

--- a/src/scout_apm/core/commands.py
+++ b/src/scout_apm/core/commands.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 # A constant that represents an "unknown" date. Fallback, and will be rejected
 # by the CoreAgent. But important to avoid exceptions if a None timestamp is
 # passed to a Command.
-INVALID_DATE = datetime.datetime(year=2000, month=1, day=1)
+INVALID_DATE = datetime(year=2000, month=1, day=1)
 
 
 class Register:

--- a/src/scout_apm/core/request_manager.py
+++ b/src/scout_apm/core/request_manager.py
@@ -38,4 +38,5 @@ class RequestBuffer(ThreadLocalSingleton):
 
     def flush_request(self, request):
         batch_command = BatchCommand.from_tracked_request(request)
-        AgentContext.socket().send(batch_command)
+        if batch_command is not None:
+            AgentContext.socket().send(batch_command)

--- a/src/scout_apm/core/tracked_request.py
+++ b/src/scout_apm/core/tracked_request.py
@@ -84,7 +84,12 @@ class TrackedRequest(ThreadLocalSingleton):
         RequestManager.instance().add_request(self)
         if self.is_real_request():
             Samplers.ensure_running()
-        self.release()
+
+        # This can fail if the Tracked Request was created directly, not through instance()
+        try:
+            self.release()
+        except:
+            pass
 
 
 class Span:

--- a/tests/scout_apm_tests/commands_test.py
+++ b/tests/scout_apm_tests/commands_test.py
@@ -1,0 +1,33 @@
+import scout_apm.core.commands
+from scout_apm.core.tracked_request import TrackedRequest
+
+def test_stop_span_defaults_timestamp_to_invalid_date():
+    command = scout_apm.core.commands.StopSpan(request_id="req_id", span_id="span_id")
+    assert(command.timestamp == scout_apm.core.commands.INVALID_DATE)
+
+
+def test_finish_request_defaults_timestamp_to_invalid_date():
+    command = scout_apm.core.commands.FinishRequest(request_id="req_id")
+    assert(command.timestamp == scout_apm.core.commands.INVALID_DATE)
+
+
+def test_from_tracked_request_bails_on_unfinished_span():
+    tr = TrackedRequest()
+    tr.start_span("foo")
+    batch = scout_apm.core.commands.BatchCommand.from_tracked_request(tr)
+    assert(batch is None)
+
+
+def test_from_tracked_request_bails_on_unfinished_request():
+    tr = TrackedRequest()
+    batch = scout_apm.core.commands.BatchCommand.from_tracked_request(tr)
+    assert(batch is None)
+
+
+def test_from_tracked_request_creates_batch_command():
+    tr = TrackedRequest()
+    tr.start_span("foo")
+    tr.stop_span()
+
+    batch = scout_apm.core.commands.BatchCommand.from_tracked_request(tr)
+    assert(len(batch.commands) == 4)


### PR DESCRIPTION
This can come up if for some reason a Span isn't stopped, and its
timestamp is None. The code to create the StopSpan command explicitly
sets the kwarg to None, rather than leaving it off. So the defaulting
in `get` that existed didn't work (it was there as a key, just with a
value of None).

I applied this change to all Commands, since timestamps should always
exist, even if off.