### PR TITLE
Use `struct.pack` instead of int.to_bytes() for 2.7 support

### DIFF
--- a/src/scout_apm/core/socket.py
+++ b/src/scout_apm/core/socket.py
@@ -140,12 +140,12 @@ class CoreAgentSocket(threading.Thread):
 
     def _message_length(self, body):
         length = len(body)
-        return length.to_bytes(4, 'big')
+        return struct.pack('>I', length)
 
     def _read_response(self):
         try:
             raw_size = self.socket.recv(4)
-            size = struct.unpack('<I', raw_size)[0]
+            size = struct.unpack('>I', raw_size)[0]
             message = self.socket.recv(size)
             return message
         except (OSError) as e:


### PR DESCRIPTION
Same outcome (a 4 byte big-endian number), but cross compatible with
python 2.7

Also fixes a typo in the unpack of received messages. All bytes over the
wire are big endian.