### PR TITLE
Initial Pyramid Support

### DIFF
--- a/src/scout_apm/core/__init__.py
+++ b/src/scout_apm/core/__init__.py
@@ -20,3 +20,4 @@ def install():
     CoreAgentManager().launch()
     AppMetadata.report()
     AgentContext.socket().stop()
+    return True

--- a/src/scout_apm/pyramid/__init__.py
+++ b/src/scout_apm/pyramid/__init__.py
@@ -1,0 +1,51 @@
+import scout_apm.core
+from scout_apm.core.tracked_request import TrackedRequest
+from scout_apm.core.config.config import ScoutConfig
+from scout_apm.api.context import Context
+
+
+def includeme(config):
+    configs = {}
+    pyramid_config = config.get_settings()
+    for name in filter(lambda x: x.startswith('SCOUT_'), pyramid_config):
+        value = pyramid_config[name]
+        clean_name = name.replace('SCOUT_', '').lower()
+        configs[clean_name] = value
+    ScoutConfig.set(**configs)
+
+    if scout_apm.core.install():
+        config.add_tween('scout_apm.pyramid.instruments')
+
+
+def instruments(handler, registry):
+    def scout_tween(request):
+        try:
+            tr = TrackedRequest.instance()
+            span = tr.start_span(operation='Controller/Pyramid')
+
+            # Capture what we can from the request, but never fail
+            try:
+                Context.add('path', request.path)
+                Context.add('user_ip', request.remote_addr)
+            except:
+                pass
+
+            try:
+                response = handler(request)
+            except:
+                TrackedRequest.instance().tag('error', 'true')
+                raise
+
+            # This happens further down the call chain. So time it starting
+            # above, but only name it if it gets to here.
+            if request.matched_route is not None:
+                tr.mark_real_request()
+                span.operation = 'Controller/' + request.matched_route.name
+
+        finally:
+            TrackedRequest.instance().stop_span()
+
+        return response
+
+    return scout_tween
+

--- a/src/scout_apm/pyramid/__init__.py
+++ b/src/scout_apm/pyramid/__init__.py
@@ -33,7 +33,7 @@ def instruments(handler, registry):
             try:
                 response = handler(request)
             except:
-                TrackedRequest.instance().tag('error', 'true')
+                tr.tag('error', 'true')
                 raise
 
             # This happens further down the call chain. So time it starting
@@ -43,7 +43,7 @@ def instruments(handler, registry):
                 span.operation = 'Controller/' + request.matched_route.name
 
         finally:
-            TrackedRequest.instance().stop_span()
+            tr.stop_span()
 
         return response
 


### PR DESCRIPTION
To use, add the SCOUT_* settings to the Pyramid config, and then `config.include('scout_apm.pyramid')`


```python
import scout_apm.pyramid

if __name__ == '__main__':
    with Configurator() as config:
        config.add_settings(
            SCOUT_KEY = '...',
            SCOUT_MONITOR = True,
            SCOUT_NAME = 'My Pyramid App'
        )
        config.include('scout_apm.pyramid')

        # Rest of your config...
```