### PR TITLE
Remove FileNotFoundError

### DIFF
--- a/src/scout_apm/core/socket.py
+++ b/src/scout_apm/core/socket.py
@@ -164,7 +164,7 @@ class CoreAgentSocket(threading.Thread):
                 self.socket.settimeout(0.5)
                 logger.debug('CoreAgentSocket is connected')
                 return True
-            except (FileNotFoundError, OSError) as e:
+            except (OSError) as e:
                 logger.debug('CoreAgentSocket connection error: %s', repr(e))
                 if attempt >= connect_attempts:
                     return False


### PR DESCRIPTION
Does not exist in 2.7 and FileNotFoundError inherits from OSError anyway.
https://docs.python.org/3/library/exceptions.html#exception-hierarchy