### PR TITLE
Save App variable in Flask instruments `init_app(app)`

### DIFF
--- a/src/scout_apm/flask/__init__.py
+++ b/src/scout_apm/flask/__init__.py
@@ -14,6 +14,8 @@ class ScoutApm(object):
             self.init_app(app)
 
     def init_app(self, app):
+        self.app = app
+
         app.before_first_request(self.before_first_request)
         app.before_request(self.process_request)
         app.after_request(self.process_response)


### PR DESCRIPTION
A customer had a workflow where the ScoutApm() object was created before
the Flask app, and then the app was passed to `init_app`. Because we
didn't save it off at that point, it caused an exception when accessing
`self.app`.

```
scoutapm = ScoutApm()

def create_app():
  app = Flask(__name__)
  scoutapm.init_app(app)
```