### PR TITLE
Fix RemoteIp class looking for the wrong keys in the header array

### DIFF
--- a/src/scout_apm/core/remote_ip.py
+++ b/src/scout_apm/core/remote_ip.py
@@ -21,8 +21,8 @@ class RemoteIp:
         remote_addr = cls.ips_from(headers.get("REMOTE_ADDR"))
 
         # Could be a CSV list and/or repeated headers that were concatenated.
-        forwarded_ips = cls.ips_from(headers.get("X-FORWARDED-FOR"))
-        client_ips = cls.ips_from(headers.get("CLIENT_IP"))
+        forwarded_ips = cls.ips_from(headers.get("HTTP_X_FORWARDED_FOR"))
+        client_ips = cls.ips_from(headers.get("HTTP_CLIENT_IP"))
 
         # We assume these things about the IP headers:
         #
@@ -31,7 +31,8 @@ class RemoteIp:
         #   - Client-Ip is propagated from the outermost proxy, or is blank
         #   - REMOTE_ADDR will be the IP that made the request to this server
         #
-        # X-Forwarded-For and Client-Ip shouldn't be set at the same time
+        # X-Forwarded-For and Client-Ip shouldn't be set at the same time, but
+        # if they are, use the one in Forwarded
         ips = forwarded_ips + client_ips + remote_addr
 
         try:

--- a/tests/scout_apm_tests/remote_ip_test.py
+++ b/tests/scout_apm_tests/remote_ip_test.py
@@ -1,0 +1,30 @@
+from scout_apm.core.remote_ip import RemoteIp
+
+def test_no_forwarded_for():
+    ip = RemoteIp.lookup_from_headers({'REMOTE_ADDR': '1.1.1.1'})
+    assert(ip == '1.1.1.1')
+
+
+def test_forwarded_for():
+    ip = RemoteIp.lookup_from_headers({
+        'REMOTE_ADDR': '1.1.1.1',
+        'HTTP_X_FORWARDED_FOR': '2.2.2.2,3.3.3.3',
+        })
+    assert(ip == '2.2.2.2')
+
+
+def test_client_ip():
+    ip = RemoteIp.lookup_from_headers({
+        'REMOTE_ADDR': '1.1.1.1',
+        'HTTP_CLIENT_IP': '2.2.2.2',
+        })
+    assert(ip == '2.2.2.2')
+
+
+def test_forwarded_over_client_ip():
+    ip = RemoteIp.lookup_from_headers({
+        'REMOTE_ADDR': '1.1.1.1',
+        'HTTP_X_FORWARDED_FOR': '2.2.2.2,3.3.3.3',
+        'HTTP_CLIENT_IP': '4.4.4.4',
+        })
+    assert(ip == '2.2.2.2')


### PR DESCRIPTION
The header dictionary created by WSGI has keys with a prefix of `HTTP_`

But not for REMOTE_ADDR. Since that's not a user-provided value, and
instead generated by the server - it's not a header, but an extra bit of
data that lives with the headers