### PR TITLE
Add old style Django middleware instrumentation

### DIFF
--- a/src/scout_apm/django/apps.py
+++ b/src/scout_apm/django/apps.py
@@ -40,12 +40,26 @@ class ScoutApmDjangoConfig(AppConfig):
         """
         from django.conf import settings
 
-        if isinstance(settings.MIDDLEWARE, tuple):
-            settings.MIDDLEWARE = (
-                ('scout_apm.django.middleware.MiddlewareTimingMiddleware', ) +
-                settings.MIDDLEWARE +
-                ('scout_apm.django.middleware.ViewTimingMiddleware', ))
+        # If MIDDLEWARE_CLASSES is set, update that, with handling of tuple vs array forms
+        if settings.MIDDLEWARE_CLASSES is not None:
+            if isinstance(settings.MIDDLEWARE_CLASSES, tuple):
+                settings.MIDDLEWARE_CLASSES = (
+                    ('scout_apm.django.middleware.OldStyleMiddlewareTimingMiddleware', ) +
+                    settings.MIDDLEWARE_CLASSES +
+                    ('scout_apm.django.middleware.OldStyleViewMiddleware', ))
+            else:
+                settings.MIDDLEWARE_CLASSES.insert(0, 'scout_apm.django.middleware.OldStyleMiddlewareTimingMiddleware')
+                settings.MIDDLEWARE_CLASSES.append('scout_apm.django.middleware.OldStyleViewMiddleware')
+
+        # Otherwise, we're doing new style middleware, do the same thing with
+        # the same handling of tuple vs array forms
         else:
-            settings.MIDDLEWARE.insert(0, 'scout_apm.django.middleware.MiddlewareTimingMiddleware')
-            settings.MIDDLEWARE.append('scout_apm.django.middleware.ViewTimingMiddleware')
+            if isinstance(settings.MIDDLEWARE, tuple):
+                settings.MIDDLEWARE = (
+                    ('scout_apm.django.middleware.MiddlewareTimingMiddleware', ) +
+                    settings.MIDDLEWARE +
+                    ('scout_apm.django.middleware.ViewTimingMiddleware', ))
+            else:
+                settings.MIDDLEWARE.insert(0, 'scout_apm.django.middleware.MiddlewareTimingMiddleware')
+                settings.MIDDLEWARE.append('scout_apm.django.middleware.ViewTimingMiddleware')
 


### PR DESCRIPTION
For now, this is to support apps on Django 1.10+ that have updated from older
versions and stuck with MIDDLEWARE_CLASSES. These are not yet tested on older
Django versions.

I ran into this scenario when testing the open source project Spirit
(https://github.com/nitely/Spirit).