### PR TITLE
Reverse Django middleware insertion logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.3.3] 2018-08-27
+
+### Fixed
+
+- Fix issue when `MIDDLEWARE` and `MIDDLEWARE_CLASSES`
+  are both defined in Django 1.x apps (PR #122)
+
 ## [1.3.2] 2018-08-24
 
 ### Fixed

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ compile_extensions = True
 
 setup_args = {
       'name': 'scout_apm',
-      'version': '1.3.2',
+      'version': '1.3.3',
       'description': 'Scout Application Performance Monitoring Agent',
       'long_description': long_description,
       'long_description_content_type': 'text/markdown',

--- a/src/scout_apm/django/apps.py
+++ b/src/scout_apm/django/apps.py
@@ -40,20 +40,8 @@ class ScoutApmDjangoConfig(AppConfig):
         """
         from django.conf import settings
 
-        # If MIDDLEWARE_CLASSES is set, update that, with handling of tuple vs array forms
-        if getattr(settings, "MIDDLEWARE_CLASSES", None) is not None:
-            if isinstance(settings.MIDDLEWARE_CLASSES, tuple):
-                settings.MIDDLEWARE_CLASSES = (
-                    ('scout_apm.django.middleware.OldStyleMiddlewareTimingMiddleware', ) +
-                    settings.MIDDLEWARE_CLASSES +
-                    ('scout_apm.django.middleware.OldStyleViewMiddleware', ))
-            else:
-                settings.MIDDLEWARE_CLASSES.insert(0, 'scout_apm.django.middleware.OldStyleMiddlewareTimingMiddleware')
-                settings.MIDDLEWARE_CLASSES.append('scout_apm.django.middleware.OldStyleViewMiddleware')
-
-        # Otherwise, we're doing new style middleware, do the same thing with
-        # the same handling of tuple vs array forms
-        else:
+        # If MIDDLEWARE is set, update that, with handling of tuple vs array forms
+        if getattr(settings, "MIDDLEWARE", None) is not None:
             if isinstance(settings.MIDDLEWARE, tuple):
                 settings.MIDDLEWARE = (
                     ('scout_apm.django.middleware.MiddlewareTimingMiddleware', ) +
@@ -63,3 +51,14 @@ class ScoutApmDjangoConfig(AppConfig):
                 settings.MIDDLEWARE.insert(0, 'scout_apm.django.middleware.MiddlewareTimingMiddleware')
                 settings.MIDDLEWARE.append('scout_apm.django.middleware.ViewTimingMiddleware')
 
+        # Otherwise, we're doing old style middleware, do the same thing with
+        # the same handling of tuple vs array forms
+        else:
+            if isinstance(settings.MIDDLEWARE_CLASSES, tuple):
+                settings.MIDDLEWARE_CLASSES = (
+                    ('scout_apm.django.middleware.OldStyleMiddlewareTimingMiddleware', ) +
+                    settings.MIDDLEWARE_CLASSES +
+                    ('scout_apm.django.middleware.OldStyleViewMiddleware', ))
+            else:
+                settings.MIDDLEWARE_CLASSES.insert(0, 'scout_apm.django.middleware.OldStyleMiddlewareTimingMiddleware')
+                settings.MIDDLEWARE_CLASSES.append('scout_apm.django.middleware.OldStyleViewMiddleware')


### PR DESCRIPTION
Fixes a bug in Django <= 2 when both `MIDDLEWARE` and `MIDDLEWARE_CLASSES` are defined.