### PR TITLE
Add a lock around ThreadLocalSingleton tasks

### DIFF
--- a/src/scout_apm/core/thread_local.py
+++ b/src/scout_apm/core/thread_local.py
@@ -4,23 +4,37 @@ import threading
 
 
 class ThreadLocalSingleton(object):
+    _instance_lock = threading.Lock()
+
     @classmethod
     def instance(cls, *args, **kwargs):
-        if not hasattr(cls, '_thread_lookup'):
-            cls.__new_instance(args, kwargs)
-        elif not hasattr(cls._thread_lookup, 'instance'):
-            cls.__new_instance(args, kwargs)
-        elif cls._thread_lookup.instance is None:
-            cls.__new_instance(args, kwargs)
-        return cls._thread_lookup.instance
+        with cls._instance_lock:
+            # The thread local dict doesn't exist at all. Need to create both it and the instance
+            if not hasattr(cls, '_thread_lookup'):
+                cls.__new_instance(args, kwargs)
+                return cls._thread_lookup.instance
+
+            # Somehow we have the thread local dict, but failed to make the instance. Just reinit both
+            if not hasattr(cls._thread_lookup, 'instance'):
+                cls.__new_instance(args, kwargs)
+                return cls._thread_lookup.instance
+
+            # The instance is none, so we'll need to recreate it (and the thread local dict too)
+            if cls._thread_lookup.instance is None:
+                cls.__new_instance(args, kwargs)
+                cls._thread_lookup.instance
+
+            return cls._thread_lookup.instance
+
+    # Releasing is under the same lock as creating, so it shouldn't step on each other.
+    def release(self):
+        with self.__class__._instance_lock:
+            if getattr(self.__class__._thread_lookup, 'instance', None) is self:
+                self.__class__._thread_lookup.instance = None
+
 
     @classmethod
     def __new_instance(cls, *args, **kwargs):
         cls._thread_lookup = threading.local()
         cls._thread_lookup.instance = cls(args, kwargs)
 
-    def release(self):
-            if getattr(self.__class__._thread_lookup,
-                       'instance',
-                       None) is self:
-                self.__class__._thread_lookup.instance = None

--- a/src/scout_apm/core/thread_local.py
+++ b/src/scout_apm/core/thread_local.py
@@ -22,8 +22,9 @@ class ThreadLocalSingleton(object):
             # The instance is none, so we'll need to recreate it (and the thread local dict too)
             if cls._thread_lookup.instance is None:
                 cls.__new_instance(args, kwargs)
-                cls._thread_lookup.instance
+                return cls._thread_lookup.instance
 
+            # We made it through the checks, return the instance that we know exists
             return cls._thread_lookup.instance
 
     # Releasing is under the same lock as creating, so it shouldn't step on each other.


### PR DESCRIPTION
We've had customer reports of races in this class when run with python
async code, which uses finer-grained multithreading than actual threads.

Adding the lock here should fix this. It worked in socket.py.