### PR TITLE
Fix OldStyleViewMiddleware.process_exception args.

### DIFF
--- a/src/scout_apm/django/middleware.py
+++ b/src/scout_apm/django/middleware.py
@@ -140,7 +140,7 @@ class OldStyleViewMiddleware(object):
             tr.stop_span()
         return response
 
-    def process_exception(request, exception):
+    def process_exception(self, request, exception):
         tr = TrackedRequest.instance()
 
         if (


### PR DESCRIPTION
The signature was clearly wrong. I'm not sure what the effect was.