### PR TITLE
Use UTC for timing measurements.

### DIFF
--- a/src/scout_apm/core/samplers/cpu.py
+++ b/src/scout_apm/core/samplers/cpu.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 class Cpu(object):
     def __init__(self):
-        self.last_run = datetime.now()
+        self.last_run = datetime.utcnow()
         self.last_cpu_times = psutil.Process().cpu_times()
         self.num_processors = psutil.cpu_count()
 
@@ -24,7 +24,7 @@ class Cpu(object):
         return "Process CPU"
 
     def run(self):
-        now = datetime.now()
+        now = datetime.utcnow()
         process = psutil.Process()  # get a handle on the current process
         cpu_times = process.cpu_times()
 

--- a/tests/scout_apm_tests/tracked_request_test.py
+++ b/tests/scout_apm_tests/tracked_request_test.py
@@ -88,7 +88,7 @@ def test_start_span_ignores_children():
 def test_span_captures_backtrace():
     tr = TrackedRequest()
     span = tr.start_span(
-        operation="Sql/Work", start_time=datetime.now() - timedelta(seconds=1)
+        operation="Sql/Work", start_time=datetime.utcnow() - timedelta(seconds=1)
     )
     tr.stop_span()
     assert span.tags["stack"]
@@ -97,10 +97,12 @@ def test_span_captures_backtrace():
 def test_span_does_not_capture_backtrace():
     tr = TrackedRequest()
     controller = tr.start_span(
-        operation="Controller/Work", start_time=datetime.now() - timedelta(seconds=10)
+        operation="Controller/Work",
+        start_time=datetime.utcnow() - timedelta(seconds=10),
     )
     middleware = tr.start_span(
-        operation="Middleware/Work", start_time=datetime.now() - timedelta(seconds=10)
+        operation="Middleware/Work",
+        start_time=datetime.utcnow() - timedelta(seconds=10),
     )
     tr.stop_span()
     tr.stop_span()


### PR DESCRIPTION
Fix test_span_captures_backtrace, which passed in UTC-XX
and failed in UTC+XX.

Update CPU timing measurements for consistency.