### PR TITLE
Do not expect a request.user attribute.

### DIFF
--- a/src/scout_apm/django/middleware.py
+++ b/src/scout_apm/django/middleware.py
@@ -70,7 +70,7 @@ class ViewTimingMiddleware(object):
                 span.operation = "Controller/" + view_name
                 Context.add("path", request.path)
                 Context.add("user_ip", RemoteIp.lookup_from_headers(request.META))
-                if request.user is not None:
+                if getattr(request, "user", None) is not None:
                     Context.add("username", request.user.get_username())
         except Exception:
             pass


### PR DESCRIPTION
The attribute isn't there when the authentication middleware isn't
enabled. This situation was handled by the catchall try / except.
However a proper check is better to prevent a premature exit,,
in case new statements are added before the `except` clause.