### PR TITLE
Rename a Transaction

### DIFF
--- a/src/scout_apm/core/config.py
+++ b/src/scout_apm/core/config.py
@@ -64,6 +64,7 @@ class ScoutConfig(object):
             "framework",
             "framework_version",
             "hostname",
+            "ignore",
             "key",
             "log_level",
             "monitor",
@@ -265,4 +266,5 @@ CONVERSIONS = {
     "core_agent_launch": BooleanConversion,
     "monitor": BooleanConversion,
     "disabled_instruments": ListConversion,
+    "ignore": ListConversion,
 }

--- a/src/scout_apm/core/ignore.py
+++ b/src/scout_apm/core/ignore.py
@@ -1,0 +1,9 @@
+from scout_apm.core.context import AgentContext
+
+
+def ignore_path(path):
+    ignored_paths = AgentContext.instance.config.value("ignore")
+    for ignored in ignored_paths:
+        if path.startswith(ignored):
+            return True
+    return False

--- a/src/scout_apm/core/tracked_request.py
+++ b/src/scout_apm/core/tracked_request.py
@@ -95,7 +95,8 @@ class TrackedRequest(ThreadLocalSingleton):
             self.end_time = datetime.utcnow()
         if self.is_real_request():
             self.tag("mem_delta", Memory.get_delta(self.memory_start))
-            RequestManager.instance().add_request(self)
+            if not self.is_ignored():
+                RequestManager.instance().add_request(self)
             Samplers.ensure_running()
 
         # This can fail if the Tracked Request was created directly,
@@ -104,6 +105,10 @@ class TrackedRequest(ThreadLocalSingleton):
             self.release()
         except Exception:
             pass
+
+    # A request is ignored if the tag "ignore_transaction" is set to True
+    def is_ignored(self):
+        return self.tags.get("ignore_transaction", False)
 
 
 class Span(object):

--- a/src/scout_apm/django/middleware.py
+++ b/src/scout_apm/django/middleware.py
@@ -5,6 +5,7 @@ import logging
 from scout_apm.api.context import Context
 from scout_apm.core.remote_ip import RemoteIp
 from scout_apm.core.tracked_request import TrackedRequest
+from scout_apm.core.ignore import ignore_path
 
 logger = logging.getLogger(__name__)
 
@@ -68,6 +69,9 @@ class ViewTimingMiddleware(object):
         Capture details about the view_func that is about to execute
         """
         try:
+            if ignore_path(request.path):
+                TrackedRequest.instance().tag("ignore_transaction", True)
+
             view_name = request.resolver_match._func_path
             span = TrackedRequest.instance().current_span()
             if span is not None:

--- a/tests/unit/core/test_ignore.py
+++ b/tests/unit/core/test_ignore.py
@@ -1,0 +1,14 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from scout_apm.core.config import ScoutConfig
+from scout_apm.core.ignore import ignore_path
+
+
+def test_loads_class_instrument():
+    ScoutConfig.set(ignore=["/health"])
+
+    assert ignore_path("/health")
+    assert ignore_path("/health/foo")
+    assert not ignore_path("/users")
+
+    ScoutConfig.reset_all()

--- a/tests/unit/core/test_tracked_request.py
+++ b/tests/unit/core/test_tracked_request.py
@@ -153,3 +153,9 @@ def test_finish_does_captures_memory_on_real_requests(tr):
     tr.finish()
 
     assert "mem_delta" in tr.tags
+
+
+def test_is_ignored(tr):
+    assert tr.is_ignored() == False
+    tr.tag("ignore_transaction", True)
+    assert tr.is_ignored()


### PR DESCRIPTION
This matches the Ruby agent's ScoutApm::Transaction.rename call.

This is most useful when an app has a single entry point, then makes business
logic decisions with easily nameable branches. GraphQL for instance has a
single POST endpoint, but immediately branches into different queries and
mutations with clear names.

**NOTE** - This requires a yet-unreleased change to the binary agent, and will
not yet work. A note will be added to this PR when it is fully released