### PR TITLE
Remove all references to PyYAML

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -89,7 +89,7 @@ for example 2.7 and 3.7. In that case, do the whole setup for each virtualenv.
 
 Install all test dependencies:
 
-    $ pip install bottle celery Django elasticsearch flask flask-sqlalchemy jinja2 mock psutil pymongo pyramid pytest pytest-travis-fold pytest-cov PyYAML redis requests sqlalchemy urllib3 webtest
+    $ pip install bottle celery Django elasticsearch flask flask-sqlalchemy jinja2 mock psutil pymongo pyramid pytest pytest-travis-fold pytest-cov redis requests sqlalchemy urllib3 webtest
 
 Run tests with:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 psutil
-PyYAML
 requests

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup_args = {
             "core-agent-manager = scout_apm.core.cli.core_agent_manager:main"
         ]
     },
-    "install_requires": ["psutil", "PyYAML", "requests"],
+    "install_requires": ["psutil", "requests"],
     "keywords": "apm performance monitoring development",
     "classifiers": [
         "Development Status :: 5 - Production/Stable",

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,6 @@ deps =
     pytest
     pytest-travis-fold
     pytest-cov
-    PyYAML
     redis
     requests
     sqlalchemy


### PR DESCRIPTION
A user reported that an automated GitHub security scan reported PyYAML
as being vulnerable [1].  The user also said that it doesn't appear that
we even use PyYAML. After some checking, it looks that he's right, we
don't use it.

My memory of how this dependency was ever added is that we pulled it in
as a dependency very early in development to implement configuration in
a similar way to how the Ruby agent does. But then, we implemented a
more Pythonic system for configuration.

The underlying security issue isn't relevant to or exploitable in our
agent. We never even import the PyYAML into our code, much less use the
potentially vulnerable `load` function. But of course, the most secure
code is code that doesn't exist. So this commit removes all mentions of
'pyyaml'.

[Closes #145]

[1]: https://github.com/scoutapp/scout_apm_python/issues/145