### PR TITLE
Core agent permissions

### DIFF
--- a/src/scout_apm/core/config.py
+++ b/src/scout_apm/core/config.py
@@ -6,6 +6,7 @@ import sys
 
 from scout_apm.core.git_revision import GitRevision
 from scout_apm.core.platform_detection import PlatformDetection
+from scout_apm.core.util import octal
 
 logger = logging.getLogger(__name__)
 
@@ -58,6 +59,7 @@ class ScoutConfig(object):
             "core_agent_dir",
             "core_agent_download",
             "core_agent_launch",
+            "core_agent_permissions",
             "core_agent_version",
             "disabled_instruments",
             "download_url",
@@ -72,6 +74,16 @@ class ScoutConfig(object):
             "revision_sha",
             "socket_path",
         ]
+
+    def core_agent_permissions(self):
+        try:
+            return octal(self.value("core_agent_permissions"))
+        except ValueError as e:
+            logger.error("Invalid core_agent_permissions value: %s."
+                         " Using default: %s",
+                         repr(e),
+                         0o700)
+            return 0o700
 
     @classmethod
     def set(cls, **kwargs):
@@ -195,6 +207,7 @@ class ScoutConfigDefaults(object):
             "core_agent_dir": "/tmp/scout_apm_core",
             "core_agent_download": True,
             "core_agent_launch": True,
+            "core_agent_permissions": 700
             "core_agent_version": "v1.1.8",  # can be an exact tag name, or 'latest'
             "disabled_instruments": [],
             "download_url": "https://s3-us-west-1.amazonaws.com/scout-public-downloads/apm_core_agent/release",  # noqa: E501

--- a/src/scout_apm/core/config.py
+++ b/src/scout_apm/core/config.py
@@ -207,7 +207,7 @@ class ScoutConfigDefaults(object):
             "core_agent_dir": "/tmp/scout_apm_core",
             "core_agent_download": True,
             "core_agent_launch": True,
-            "core_agent_permissions": 700
+            "core_agent_permissions": 700,
             "core_agent_version": "v1.1.8",  # can be an exact tag name, or 'latest'
             "disabled_instruments": [],
             "download_url": "https://s3-us-west-1.amazonaws.com/scout-public-downloads/apm_core_agent/release",  # noqa: E501

--- a/src/scout_apm/core/config.py
+++ b/src/scout_apm/core/config.py
@@ -79,10 +79,11 @@ class ScoutConfig(object):
         try:
             return octal(self.value("core_agent_permissions"))
         except ValueError as e:
-            logger.error("Invalid core_agent_permissions value: %s."
-                         " Using default: %s",
-                         repr(e),
-                         0o700)
+            logger.error(
+                "Invalid core_agent_permissions value: %s." " Using default: %s",
+                repr(e),
+                0o700,
+            )
             return 0o700
 
     @classmethod

--- a/src/scout_apm/core/core_agent_manager.py
+++ b/src/scout_apm/core/core_agent_manager.py
@@ -146,7 +146,8 @@ class CoreAgentDownloader(object):
 
     def create_core_agent_dir(self):
         try:
-            os.makedirs(self.destination, 0o700)
+            os.makedirs(self.destination,
+                        AgentContext.instance.config.core_agent_permissions)
         except OSError:
             pass
 

--- a/src/scout_apm/core/core_agent_manager.py
+++ b/src/scout_apm/core/core_agent_manager.py
@@ -147,7 +147,7 @@ class CoreAgentDownloader(object):
     def create_core_agent_dir(self):
         try:
             os.makedirs(self.destination,
-                        AgentContext.instance.config.core_agent_permissions)
+                        AgentContext.instance.config.core_agent_permissions())
         except OSError:
             pass
 

--- a/src/scout_apm/core/core_agent_manager.py
+++ b/src/scout_apm/core/core_agent_manager.py
@@ -146,8 +146,9 @@ class CoreAgentDownloader(object):
 
     def create_core_agent_dir(self):
         try:
-            os.makedirs(self.destination,
-                        AgentContext.instance.config.core_agent_permissions())
+            os.makedirs(
+                self.destination, AgentContext.instance.config.core_agent_permissions()
+            )
         except OSError:
             pass
 

--- a/src/scout_apm/core/util.py
+++ b/src/scout_apm/core/util.py
@@ -1,0 +1,8 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+
+# Takes an integer or a string containing an integer and returns
+# the octal value.
+# Raises a ValueError if the value cannot be converted to octal.
+def octal(value):
+    return int('{}'.format(value), 8)

--- a/src/scout_apm/core/util.py
+++ b/src/scout_apm/core/util.py
@@ -5,4 +5,4 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 # the octal value.
 # Raises a ValueError if the value cannot be converted to octal.
 def octal(value):
-    return int('{}'.format(value), 8)
+    return int("{}".format(value), 8)

--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -76,6 +76,23 @@ def test_log_config():
         ScoutConfig.reset_all()
 
 
+def test_core_agent_permissions_default():
+    config = ScoutConfig()
+    assert 0o700 == config.core_agent_permissions
+
+
+def test_core_agent_permissions_custom():
+    ScoutConfig.set(core_agent_permissions=770)
+    config = ScoutConfig()
+    assert 0o770 == config.core_agent_permissions
+
+
+def test_core_agent_permissions_invalid_uses_default():
+    ScoutConfig.set(core_agent_permissions="THIS IS INVALID")
+    config = ScoutConfig()
+    assert 0o700 == config.core_agent_permissions
+
+
 def test_null_config_name():
     # For coverage... this is never called elsewhere.
     ScoutConfigNull().name()

--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -78,19 +78,19 @@ def test_log_config():
 
 def test_core_agent_permissions_default():
     config = ScoutConfig()
-    assert 0o700 == config.core_agent_permissions
+    assert 0o700 == config.core_agent_permissions()
 
 
 def test_core_agent_permissions_custom():
     ScoutConfig.set(core_agent_permissions=770)
     config = ScoutConfig()
-    assert 0o770 == config.core_agent_permissions
+    assert 0o770 == config.core_agent_permissions()
 
 
 def test_core_agent_permissions_invalid_uses_default():
     ScoutConfig.set(core_agent_permissions="THIS IS INVALID")
     config = ScoutConfig()
-    assert 0o700 == config.core_agent_permissions
+    assert 0o700 == config.core_agent_permissions()
 
 
 def test_null_config_name():

--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -84,13 +84,19 @@ def test_core_agent_permissions_default():
 def test_core_agent_permissions_custom():
     ScoutConfig.set(core_agent_permissions=770)
     config = ScoutConfig()
-    assert 0o770 == config.core_agent_permissions()
+    try:
+        assert 0o770 == config.core_agent_permissions()
+    finally:
+        ScoutConfig.reset_all()
 
 
 def test_core_agent_permissions_invalid_uses_default():
     ScoutConfig.set(core_agent_permissions="THIS IS INVALID")
     config = ScoutConfig()
-    assert 0o700 == config.core_agent_permissions()
+    try:
+        assert 0o700 == config.core_agent_permissions()
+    finally:
+        ScoutConfig.reset_all()
 
 
 def test_null_config_name():

--- a/tests/unit/core/test_util.py
+++ b/tests/unit/core/test_util.py
@@ -1,0 +1,18 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from scout_apm.core.util import octal
+
+
+def test_octal_with_valid_integer():
+    assert 448 == octal(700)
+
+
+def test_octal_with_valid_string():
+    assert 448 == octal("700")
+
+
+def test_octal_raises_valueerror_on_invalid_value():
+    try:
+        octal("THIS IS INVALID")
+    except ValueError:
+        pass

--- a/tests/unit/core/test_util.py
+++ b/tests/unit/core/test_util.py
@@ -4,11 +4,11 @@ from scout_apm.core.util import octal
 
 
 def test_octal_with_valid_integer():
-    assert 448 == octal(700)
+    assert 0o700 == octal(700)
 
 
 def test_octal_with_valid_string():
-    assert 448 == octal("700")
+    assert 0o700 == octal("700")
 
 
 def test_octal_raises_valueerror_on_invalid_value():


### PR DESCRIPTION
Provides a new config option `core_agent_permissions` which allows users to choose the mode for creating the core agent directories.

Resolves #72