### PR TITLE
Add platform triple to config

### DIFF
--- a/src/scout_apm/core/config.py
+++ b/src/scout_apm/core/config.py
@@ -189,8 +189,11 @@ class ScoutConfigDerived(object):
         return "{name}-{version}-{triple}".format(
             name="scout_apm_core",
             version=self.config.value("core_agent_version"),
-            triple=PlatformDetection.get_triple(),
+            triple=self.config.value("core_agent_triple"),
         )
+
+    def derive_core_agent_triple(self):
+        return PlatformDetection.get_triple()
 
 
 class ScoutConfigDefaults(object):

--- a/tests/integration/core/test_socket.py
+++ b/tests/integration/core/test_socket.py
@@ -6,7 +6,7 @@ import pytest
 
 from scout_apm.core.socket import CoreAgentSocket
 
-from .test_core_agent_manager import (  # noqa: F401
+from .test_core_agent_manager import (  # noqa: F401,F811
     core_agent_manager,
     is_running,
     shutdown,
@@ -19,7 +19,7 @@ except ImportError:  # Python 2.7
 
 
 @pytest.fixture  # noqa: F811
-def running_agent(core_agent_manager):
+def running_agent(core_agent_manager):  # noqa: F811
     assert not is_running(core_agent_manager)
     assert core_agent_manager.launch()
     time.sleep(0.01)  # wait for agent to start running

--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -42,6 +42,18 @@ def test_get_derived_config_value():
         ScoutConfig.reset_all()
 
 
+def test_override_triple():
+    ScoutConfig.set(core_agent_triple="unknown-linux-musl")
+    config = ScoutConfig()
+    try:
+        assert re.match(
+            r"v([^-]*)-(x86_64|i686|unknown)-unknown-linux-musl",
+            config.value("core_agent_fullname"),
+        )
+    finally:
+        ScoutConfig.reset_all()
+
+
 def test_get_default_config_value():
     config = ScoutConfig()
     assert config.value("core_agent_dir") == "/tmp/scout_apm_core"

--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -48,7 +48,7 @@ def test_override_triple():
     try:
         assert re.match(
             r"v([^-]*)-(x86_64|i686|unknown)-unknown-linux-musl",
-            config.value("core_agent_fullname"),
+            config.value("core_agent_full_name"),
         )
     finally:
         ScoutConfig.reset_all()

--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -47,7 +47,7 @@ def test_override_triple():
     config = ScoutConfig()
     try:
         assert re.match(
-            r"v([^-]*)-(x86_64|i686|unknown)-unknown-linux-musl",
+            r"scout_apm_core-v.*-unknown-linux-musl",
             config.value("core_agent_full_name"),
         )
     finally:


### PR DESCRIPTION
In some edge cases, we're not able to automatically detect the host details of python, but we need that information to correctly download the binary component. This allows manual override. So far this has only come up in some Docker + Alpine Linux setups (but not all).