### PR TITLE
Fixes "Registering with app" log message not using configured logger

### DIFF
--- a/src/scout_apm/core/commands.py
+++ b/src/scout_apm/core/commands.py
@@ -18,7 +18,7 @@ class Register(object):
         self.key = kwargs.get("key")
 
     def message(self):
-        logging.info("Registering with app=%s key=%s" % (self.app, self.key))
+        logger.info("Registering with app=%s key=%s" % (self.app, self.key))
         return {
             "Register": {
                 "app": self.app,


### PR DESCRIPTION
The log message was defaulting to use root logger config and not the logger configured for scoutapp