### PR TITLE
Fix Elasticsearch integration for 'index' being passed as a list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Pending Release
+
+### Fixed
+
+- Fixed Elasticsearch integration for queries passing 'index' to `elasticsearch-py` as a list (PR #156)
+
 ## [2.0.1] 2019-01-07
 
 ### Added

--- a/src/scout_apm/instruments/elasticsearch.py
+++ b/src/scout_apm/instruments/elasticsearch.py
@@ -84,11 +84,14 @@ class Instrument(object):
 
         for method_str in self.__class__.CLIENT_METHODS:
             try:
-                code_str = """
+                code_str = """\
 @monkeypatch_method(Elasticsearch)
 def {method_str}(original, self, *args, **kwargs):
     tr = TrackedRequest.instance()
-    index = kwargs.get('index', 'Unknown').title()
+    index = kwargs.get('index', 'Unknown')
+    if isinstance(index, (list, tuple)):
+        index = ','.join(index)
+    index = index.title()
     name = '/'.join(['Elasticsearch', index, '{camel_name}'])
     tr.start_span(operation=name, ignore_children=True)
 

--- a/tests/integration/instruments/test_elasticsearch.py
+++ b/tests/integration/instruments/test_elasticsearch.py
@@ -52,6 +52,30 @@ def test_search():
         es.search()
 
 
+def test_search_no_indexes_string():
+    with es_with_scout() as es:
+        es.search(
+            index='',
+            body={
+                "query": {
+                    "term": {"user" : "kimchy"},
+                },
+            }
+        )
+
+
+def test_search_no_indexes_list():
+    with es_with_scout() as es:
+        es.search(
+            index=[],
+            body={
+                "query": {
+                    "term": {"user" : "kimchy"},
+                },
+            }
+        )
+
+
 def test_perform_request_missing_url():
     with es_with_scout() as es:
         with pytest.raises(TypeError):


### PR DESCRIPTION
`elasticsearch-py` documented each method as taking the `index` parameter as a string (either a single index name or a comma separated list). The higher level library `elasticsearch-dsl-py` [forces using a list of strings](https://github.com/elastic/elasticsearch-dsl-py/blob/master/elasticsearch_dsl/search.py#L100) for the `index` parameter that it passes down to `elasticsearch-py`, which is supported but not documented as it is later serialized to a comma-separated list (in [`_make_path`](https://github.com/elastic/elasticsearch-py/blob/master/elasticsearch/client/utils.py#L44)).

Our monkey patch on all the methods in `elasticsearch-py` only expected strings, this updates it to work with lists of strings as well. I added a test that failed before and passes after.

I've also made [a PR to `elasticsearch-py` to fix their documentation](https://github.com/elastic/elasticsearch-py/pull/921).