### PR TITLE
Fix 'ignore' functionality on Django < 1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 
+## Pending Release
+
+- Fix 'ignore' functionality on Django < 1.10
+
 ## [2.0.3] 2019-04-10
 
 ### Added
 
-- Add 'scm_subdirecoty' config option (PR #155)
+- Add 'scm_subdirectory' config option (PR #155)
 
 ### Fixed
 

--- a/src/scout_apm/django/middleware.py
+++ b/src/scout_apm/django/middleware.py
@@ -91,11 +91,6 @@ class ViewTimingMiddleware(object):
         """
         TrackedRequest.instance().tag("error", "true")
 
-    #  def process_template_response(self, request, response):
-    #      """
-    #      """
-    #      pass
-
 
 class OldStyleMiddlewareTimingMiddleware(object):
     """
@@ -124,6 +119,9 @@ class OldStyleViewMiddleware(object):
 
     def process_view(self, request, view_func, view_func_args, view_func_kwargs):
         tr = TrackedRequest.instance()
+
+        if ignore_path(request.path):
+            tr.tag("ignore_transaction", True)
 
         view_name = request.resolver_match._func_path
         operation = "Controller/" + view_name

--- a/tests/integration/django_app.py
+++ b/tests/integration/django_app.py
@@ -64,11 +64,11 @@ except ImportError:  # Django < 2.0
     from django.conf.urls import url
 
     urlpatterns = [
-        url("^$", home),
-        url("^hello/$", hello),
-        url("^crash/$", crash),
-        url("^sql/$", sql),
-        url("^template/$", template),
+        url(r"^$", home),
+        url(r"^hello/$", hello),
+        url(r"^crash/$", crash),
+        url(r"^sql/$", sql),
+        url(r"^template/$", template),
     ]
 
 


### PR DESCRIPTION
This second middleware class for old versions of Django was missed when adding the functionality in #144.

Tested with local Django app on Django 1.9 and Python 2.7. I looked into adding tests but there's not any machinery atm for determining if requests would be tracked.