### PR TITLE
Fix warnings for deprecated method logger.warn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Pending
+
+### Fixed
+
+- Stop warnings from using deprecated method `logger.warn`
+
 ## [2.0.4] 2019-04-18
 
 ### Fixed

--- a/src/scout_apm/instruments/elasticsearch.py
+++ b/src/scout_apm/instruments/elasticsearch.py
@@ -48,7 +48,7 @@ class Instrument(object):
             logger.info("Unable to import for Elasticsearch instruments")
             return False
         if self.installed:
-            logger.warn("Elasticsearch Instruments are already installed.")
+            logger.warning("Elasticsearch Instruments are already installed.")
             return False
         return True
 
@@ -109,7 +109,7 @@ def {method_str}(original, self, *args, **kwargs):
                 logger.info("Instrumented Elasticsearch Elasticsearch.%s", method_str)
 
             except Exception as e:
-                logger.warn(
+                logger.warning(
                     "Unable to instrument for Elasticsearch Elasticsearch.%s: %r",
                     method_str,
                     e,
@@ -182,7 +182,7 @@ def {method_str}(original, self, *args, **kwargs):
             logger.info("Instrumented Elasticsearch Transport")
 
         except Exception as e:
-            logger.warn(
+            logger.warning(
                 "Unable to instrument for Elasticsearch Transport.perform_request: %r",
                 e,
             )

--- a/src/scout_apm/instruments/jinja2.py
+++ b/src/scout_apm/instruments/jinja2.py
@@ -19,7 +19,7 @@ class Instrument(object):
             logger.info("Unable to import for Jinja2 instruments")
             return False
         if self.installed:
-            logger.warn("Jinja2 Instruments are already installed.")
+            logger.warning("Jinja2 Instruments are already installed.")
             return False
         return True
 
@@ -47,7 +47,7 @@ class Instrument(object):
             logger.info("Instrumented Jinja2")
 
         except Exception as e:
-            logger.warn("Unable to instrument for Jinja2 Template.render: %r", e)
+            logger.warning("Unable to instrument for Jinja2 Template.render: %r", e)
             return False
         return True
 

--- a/src/scout_apm/instruments/pymongo.py
+++ b/src/scout_apm/instruments/pymongo.py
@@ -54,7 +54,7 @@ class Instrument(object):
             logger.info("Unable to import for PyMongo instruments")
             return False
         if self.installed:
-            logger.warn("PyMongo Instruments are already installed.")
+            logger.warning("PyMongo Instruments are already installed.")
             return False
         return True
 
@@ -97,7 +97,7 @@ def {method_str}(original, self, *args, **kwargs):
                 logger.info("Instrumented PyMongo Collection.%s", method_str)
 
             except Exception as e:
-                logger.warn(
+                logger.warning(
                     "Unable to instrument for PyMongo Collection.%s: %r", method_str, e
                 )
                 return False

--- a/src/scout_apm/instruments/redis.py
+++ b/src/scout_apm/instruments/redis.py
@@ -32,7 +32,7 @@ class Instrument(object):
             logger.info("Unable to import for Redis instruments")
             return False
         if self.installed:
-            logger.warn("Redis Instruments are already installed.")
+            logger.warning("Redis Instruments are already installed.")
             return False
         return True
 
@@ -79,7 +79,7 @@ class Instrument(object):
                     tr.stop_span()
 
         except Exception as e:
-            logger.warn(
+            logger.warning(
                 "Unable to instrument for Redis StrictRedis.execute_command: %r", e
             )
 
@@ -103,7 +103,7 @@ class Instrument(object):
                     tr.stop_span()
 
         except Exception as e:
-            logger.warn("Unable to instrument for Redis BasePipeline.execute: %r", e)
+            logger.warning("Unable to instrument for Redis BasePipeline.execute: %r", e)
 
     def unpatch_pipeline(self):
         _Redis, Pipeline = import_Redis_and_Pipeline()

--- a/src/scout_apm/instruments/urllib3.py
+++ b/src/scout_apm/instruments/urllib3.py
@@ -19,7 +19,7 @@ class Instrument(object):
             logger.info("Unable to import for Urllib3 instruments")
             return False
         if self.installed:
-            logger.warn("Urllib3 Instruments are already installed.")
+            logger.warning("Urllib3 Instruments are already installed.")
             return False
         return True
 
@@ -60,7 +60,7 @@ class Instrument(object):
             logger.info("Instrumented Urllib3")
 
         except Exception as e:
-            logger.warn(
+            logger.warning(
                 "Unable to instrument for Urllib3 HTTPConnectionPool.urlopen: %r", e
             )
             return False


### PR DESCRIPTION
Fix warnings seen in tests such as:

```
tests/integration/instruments/test_jinja2.py::test_installable
tests/integration/instruments/test_jinja2.py::test_install_is_idempotent
  /private/tmp/tox/py37-django22/lib/python3.7/site-packages/scout_apm/instruments/jinja2.py:22: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
    logger.warn("Jinja2 Instruments are already installed.")

tests/integration/instruments/test_jinja2.py::test_install_failure
  /private/tmp/tox/py37-django22/lib/python3.7/site-packages/scout_apm/instruments/jinja2.py:50: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
    logger.warn("Unable to instrument for Jinja2 Template.render: %r", e)
```