### PR TITLE
Improve tox + pytest setup

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = --cov=scout_apm
+          --cov-report=term-missing:skip-covered

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,7 @@ ignore =
     CHANGELOG.md
     ci*
     Makefile
+    pytest.ini
     requirements.txt
     tests*
     tox.ini

--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ deps =
     urllib3
     webtest
 commands =
-    {posargs:py.test --cov=scout_apm --cov-report=term-missing tests}
+    pytest {posargs}
 
 [testenv:check]
 deps =


### PR DESCRIPTION
Allow passing arguments through rather than whole commands with {posargs}, always have coverage using pytest `addopts`, and use modern `pytest` name rather than deprecated `py.test`.