### PR TITLE
Refactor Django configuration

### DIFF
--- a/src/scout_apm/core/config.py
+++ b/src/scout_apm/core/config.py
@@ -96,6 +96,15 @@ class ScoutConfig(object):
             SCOUT_PYTHON_VALUES[key] = value
 
     @classmethod
+    def unset(cls, *keys):
+        """
+        Removes a configuration value for the Scout agent.
+        """
+        global SCOUT_PYTHON_VALUES
+        for key in keys:
+            SCOUT_PYTHON_VALUES.pop(key, None)
+
+    @classmethod
     def reset_all(cls):
         """
         Remove all configuration settings set via `ScoutConfig.set(...)`.

--- a/tests/integration/django_app.py
+++ b/tests/integration/django_app.py
@@ -2,23 +2,36 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import django
 from django.conf import settings
-from django.core.wsgi import get_wsgi_application
 from django.db import connection
 from django.http import HttpResponse
 from django.template import engines
 
-settings.configure(
-    ALLOWED_HOSTS=["*"],
-    DATABASES={"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"}},
-    DEBUG=True,
+config = {
+    "ALLOWED_HOSTS": ["*"],
+    "DATABASES": {
+        "default": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"}
+    },
+    "DEBUG": True,
     # Enable the following for debugging exceptions:
-    # DEBUG_PROPAGATE_EXCEPTIONS=True,
-    ROOT_URLCONF=__name__,
-    SECRET_KEY="********",
-    TEMPLATES=[{"BACKEND": "django.template.backends.django.DjangoTemplates"}],
-    TIME_ZONE="America/Chicago",
-)
+    # "DEBUG_PROPAGATE_EXCEPTIONS": True,
+    "ROOT_URLCONF": __name__,
+    "SECRET_KEY": "********",
+    "TEMPLATES": [{"BACKEND": "django.template.backends.django.DjangoTemplates"}],
+    "TIME_ZONE": "America/Chicago",
+    # Setup as per https://docs.scoutapm.com/#django but *without* the settings
+    # - these are temporarily set by app_with_scout() to avoid state leak
+    "INSTALLED_APPS": ["scout_apm.django"],
+}
+
+if django.VERSION > (1, 10):
+    config["MIDDLEWARE"] = []
+else:
+    config["MIDDLEWARE_CLASSES"] = []
+
+
+settings.configure(**config)
 
 
 def home(request):
@@ -72,6 +85,3 @@ except ImportError:  # Django < 2.0
         url(r"^sql/$", sql),
         url(r"^template/$", template),
     ]
-
-
-app = get_wsgi_application()


### PR DESCRIPTION
The existing tests did not reset Django to a clean state each time, since the scout_apm app was being repeatedly re-installed and uninstalled, but it didn't do anything to reset settings on uninstall. This is what lead to me implementing idempotent middleware addition in #168.

This PR refactors the way configuration is done. The test Django app is initialized only once, with Scout already installed. Scout then synchronizes the Django settings into ScoutConfig, and listens to Django's `setting_changed` signal to keep them in sync. Rather than rely on reset_all at the end of each test, I added an assertion that no settings have been left in place by any test - if they all use `override_settings` to change the settings, this will be the case.

This has let me write tests that cover all the cases with the middleware idempotency.