### PR TITLE
Test tracked requests and fix username tracking on Django < 1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Tested on Django 2.2
 - Added PyPI Trove classifiers for supported Django versions
+- Track usernames on Django < 1.10
 
 ### Fixed
 

--- a/src/scout_apm/django/instruments/sql.py
+++ b/src/scout_apm/django/instruments/sql.py
@@ -49,6 +49,8 @@ class _DetailedTracingCursorWrapper(CursorWrapper):
 
 
 class SQLInstrument(object):
+    installed = False
+
     @staticmethod
     def install():
         """
@@ -56,6 +58,9 @@ class SQLInstrument(object):
         method of BaseDatabaseWrapper, to return a wrapper that instruments any
         calls going through it.
         """
+        if SQLInstrument.installed:
+            return
+        SQLInstrument.installed = True
 
         @monkeypatch_method(BaseDatabaseWrapper)
         def cursor(original, self, *args, **kwargs):

--- a/src/scout_apm/django/instruments/template.py
+++ b/src/scout_apm/django/instruments/template.py
@@ -47,6 +47,8 @@ def load(parser, token):  # pragma: no cover
 
 
 class TemplateInstrument(object):
+    installed = False
+
     @staticmethod
     def install():
         # Our eventual aim is to patch the render() method on the Node objects
@@ -70,6 +72,9 @@ class TemplateInstrument(object):
 
         # XXX: Stopped working in Django 1.9
         #  add_to_builtins('apm.instruments.view')
+        if TemplateInstrument.installed:
+            return
+        TemplateInstrument.installed = True
 
         @trace_method(Template)
         def __init__(self, *args, **kwargs):

--- a/src/scout_apm/django/middleware.py
+++ b/src/scout_apm/django/middleware.py
@@ -133,6 +133,12 @@ class OldStyleViewMiddleware(object):
         # if we're matched up when stopping
         request.scout_view_span = span
 
+        try:
+            if getattr(request, "user", None) is not None:
+                Context.add("username", request.user.get_username())
+        except Exception:
+            pass
+
         return None
 
     # Process Response could be called without ever having called process_view.


### PR DESCRIPTION
Split from #167.

The `tracked_requests` fixture intercepts all the requests that would go into `RequestBuffer` so assertions can be made on them.

Adding these assertions has revealed a number of bugs, only some of which I'm fixing here:
* Repeated spans - the middleware seems is re-installed repeatedly in tests, but it doesn't uninstall itself, so the instruments were installed on top of each other a lot. I've fixed this for now by making the installs idempotent, like the middleware, but long term will be making the django app only get installed once during tests.
* Username tracking wasn't implemented in the old Django middleware
* The test to disable monitoring doesn't really disable it because Scout is fully installed by the time the test runs. Some refactoring is needed here.