### PR TITLE
Fix some warnings in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import os
 
 import pytest
+from webtest import TestApp
 
 from scout_apm.core import socket as scout_apm_core_socket
 from scout_apm.core.config import SCOUT_PYTHON_VALUES
@@ -19,6 +20,14 @@ except ImportError:
 for key in os.environ.keys():
     if key.startswith("SCOUT_"):
         del os.environ[key]
+
+
+# Prevent pytest from trying to collect webtest's TestApp as a test class:
+#     PytestWarning: cannot collect test class 'TestApp'
+#     because it has a __init__ constructor
+# As per https://github.com/pytest-dev/pytest/issues/477
+
+TestApp.__test__ = False
 
 
 class GlobalStateLeak(Exception):

--- a/tests/integration/test_flask_sqlalchemy.py
+++ b/tests/integration/test_flask_sqlalchemy.py
@@ -13,6 +13,7 @@ from .test_flask import app_with_scout
 def conn_with_scout():
     with app_with_scout() as app:
         app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+        app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
         db = SQLAlchemy(app)
         # Setup according to https://docs.scoutapm.com/#flask-sqlalchemy
         instrument_sqlalchemy(db)


### PR DESCRIPTION
Fix these warnings:

```
/private/tmp/tox/py37-django22/lib/python3.7/site-packages/webtest/app.py:89
/private/tmp/tox/py37-django22/lib/python3.7/site-packages/webtest/app.py:89
/private/tmp/tox/py37-django22/lib/python3.7/site-packages/webtest/app.py:89
/private/tmp/tox/py37-django22/lib/python3.7/site-packages/webtest/app.py:89
  /private/tmp/tox/py37-django22/lib/python3.7/site-packages/webtest/app.py:89: PytestWarning: cannot collect test class 'TestApp' because it has a __init__ constructor
    class TestApp(object):

tests/integration/test_flask_sqlalchemy.py::test_hello
  /private/tmp/tox/py37-django22/lib/python3.7/site-packages/flask_sqlalchemy/__init__.py:835: FSADeprecationWarning: SQLALCHEMY_TRACK_MODIFICATIONS adds significant overhead and will be disabled by default in the future.  Set it to True or False to suppress this warning.
    'SQLALCHEMY_TRACK_MODIFICATIONS adds significant overhead and '
```

The remaining warnings are out of our control:

```
/private/tmp/tox/py37-django22/bin/bottle.py:87
  /private/tmp/tox/py37-django22/bin/bottle.py:87: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    from collections import MutableMapping as DictMixin

/private/tmp/tox/py37-django22/lib/python3.7/site-packages/jinja2/runtime.py:318
  /private/tmp/tox/py37-django22/lib/python3.7/site-packages/jinja2/runtime.py:318: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    from collections import Mapping
```