### PR TITLE
Enforce UTF-8 coding in all Python files

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,8 +16,11 @@ omit =
     src/scout_apm/core/monkey.py
 
 [flake8]
+# core
 ignore = E203,W503
 max-line-length = 88
+# flake8-coding
+accept-encodings = utf-8
 
 [isort]
 default_section = THIRDPARTY

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 import os
 import sys
 from glob import glob

--- a/src/scout_apm/api/__init__.py
+++ b/src/scout_apm/api/__init__.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging

--- a/src/scout_apm/api/context.py
+++ b/src/scout_apm/api/context.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from scout_apm.core.tracked_request import TrackedRequest

--- a/src/scout_apm/bottle/__init__.py
+++ b/src/scout_apm/bottle/__init__.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from bottle import request

--- a/src/scout_apm/celery/__init__.py
+++ b/src/scout_apm/celery/__init__.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from celery.signals import task_postrun, task_prerun

--- a/src/scout_apm/core/__init__.py
+++ b/src/scout_apm/core/__init__.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging

--- a/src/scout_apm/core/backtrace.py
+++ b/src/scout_apm/core/backtrace.py
@@ -1,5 +1,7 @@
-# Module for helper functions to capture tracebacks
-
+# coding=utf-8
+"""
+Module for helper functions to capture tracebacks
+"""
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import traceback

--- a/src/scout_apm/core/cli/core_agent_manager.py
+++ b/src/scout_apm/core/cli/core_agent_manager.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import argparse

--- a/src/scout_apm/core/commands.py
+++ b/src/scout_apm/core/commands.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import json

--- a/src/scout_apm/core/config.py
+++ b/src/scout_apm/core/config.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging

--- a/src/scout_apm/core/context.py
+++ b/src/scout_apm/core/context.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from scout_apm.core.config import ScoutConfig

--- a/src/scout_apm/core/core_agent_manager.py
+++ b/src/scout_apm/core/core_agent_manager.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import hashlib

--- a/src/scout_apm/core/git_revision.py
+++ b/src/scout_apm/core/git_revision.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os

--- a/src/scout_apm/core/ignore.py
+++ b/src/scout_apm/core/ignore.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from scout_apm.core.context import AgentContext
 
 

--- a/src/scout_apm/core/instrument_manager.py
+++ b/src/scout_apm/core/instrument_manager.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import importlib

--- a/src/scout_apm/core/metadata.py
+++ b/src/scout_apm/core/metadata.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging

--- a/src/scout_apm/core/n_plus_one_call_set.py
+++ b/src/scout_apm/core/n_plus_one_call_set.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging

--- a/src/scout_apm/core/platform_detection.py
+++ b/src/scout_apm/core/platform_detection.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import platform

--- a/src/scout_apm/core/remote_ip.py
+++ b/src/scout_apm/core/remote_ip.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 

--- a/src/scout_apm/core/request_manager.py
+++ b/src/scout_apm/core/request_manager.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging

--- a/src/scout_apm/core/samplers/__init__.py
+++ b/src/scout_apm/core/samplers/__init__.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging

--- a/src/scout_apm/core/samplers/cpu.py
+++ b/src/scout_apm/core/samplers/cpu.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging

--- a/src/scout_apm/core/samplers/memory.py
+++ b/src/scout_apm/core/samplers/memory.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging

--- a/src/scout_apm/core/socket.py
+++ b/src/scout_apm/core/socket.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import json

--- a/src/scout_apm/core/stacktracer.py
+++ b/src/scout_apm/core/stacktracer.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging

--- a/src/scout_apm/core/thread_local.py
+++ b/src/scout_apm/core/thread_local.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import threading

--- a/src/scout_apm/core/tracked_request.py
+++ b/src/scout_apm/core/tracked_request.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging

--- a/src/scout_apm/core/util.py
+++ b/src/scout_apm/core/util.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 

--- a/src/scout_apm/django/__init__.py
+++ b/src/scout_apm/django/__init__.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 default_app_config = "scout_apm.django.apps.ScoutApmDjangoConfig"

--- a/src/scout_apm/django/apps.py
+++ b/src/scout_apm/django/apps.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging

--- a/src/scout_apm/django/config.py
+++ b/src/scout_apm/django/config.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging

--- a/src/scout_apm/django/instruments/sql.py
+++ b/src/scout_apm/django/instruments/sql.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging

--- a/src/scout_apm/django/instruments/template.py
+++ b/src/scout_apm/django/instruments/template.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging

--- a/src/scout_apm/django/middleware.py
+++ b/src/scout_apm/django/middleware.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging

--- a/src/scout_apm/flask/__init__.py
+++ b/src/scout_apm/flask/__init__.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from flask import current_app

--- a/src/scout_apm/flask/sqlalchemy.py
+++ b/src/scout_apm/flask/sqlalchemy.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from flask_sqlalchemy import SQLAlchemy

--- a/src/scout_apm/instruments/elasticsearch.py
+++ b/src/scout_apm/instruments/elasticsearch.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging

--- a/src/scout_apm/instruments/jinja2.py
+++ b/src/scout_apm/instruments/jinja2.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging

--- a/src/scout_apm/instruments/pymongo.py
+++ b/src/scout_apm/instruments/pymongo.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging

--- a/src/scout_apm/instruments/redis.py
+++ b/src/scout_apm/instruments/redis.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging

--- a/src/scout_apm/instruments/urllib3.py
+++ b/src/scout_apm/instruments/urllib3.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging

--- a/src/scout_apm/pyramid/__init__.py
+++ b/src/scout_apm/pyramid/__init__.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import scout_apm.core

--- a/src/scout_apm/sqlalchemy/__init__.py
+++ b/src/scout_apm/sqlalchemy/__init__.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from sqlalchemy import event

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 import os
 
 import pytest

--- a/tests/integration/app.py
+++ b/tests/integration/app.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# coding=utf-8
 
 """
 Test application that proxies requests to various frameworks.

--- a/tests/integration/celery_app.py
+++ b/tests/integration/celery_app.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from celery import Celery

--- a/tests/integration/core/__init__.py
+++ b/tests/integration/core/__init__.py
@@ -1,0 +1,1 @@
+# coding=utf-8

--- a/tests/integration/core/test_core_agent_manager.py
+++ b/tests/integration/core/test_core_agent_manager.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import subprocess

--- a/tests/integration/core/test_socket.py
+++ b/tests/integration/core/test_socket.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import time

--- a/tests/integration/instruments/test_elasticsearch.py
+++ b/tests/integration/instruments/test_elasticsearch.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os

--- a/tests/integration/instruments/test_jinja2.py
+++ b/tests/integration/instruments/test_jinja2.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import sys

--- a/tests/integration/instruments/test_pymongo.py
+++ b/tests/integration/instruments/test_pymongo.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os

--- a/tests/integration/instruments/test_redis.py
+++ b/tests/integration/instruments/test_redis.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os

--- a/tests/integration/instruments/test_urllib3.py
+++ b/tests/integration/instruments/test_urllib3.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os

--- a/tests/integration/test_bottle.py
+++ b/tests/integration/test_bottle.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from contextlib import contextmanager

--- a/tests/integration/test_celery.py
+++ b/tests/integration/test_celery.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from contextlib import contextmanager

--- a/tests/integration/test_django.py
+++ b/tests/integration/test_django.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os.path

--- a/tests/integration/test_flask.py
+++ b/tests/integration/test_flask.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from contextlib import contextmanager

--- a/tests/integration/test_flask_sqlalchemy.py
+++ b/tests/integration/test_flask_sqlalchemy.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from contextlib import contextmanager

--- a/tests/integration/test_pyramid.py
+++ b/tests/integration/test_pyramid.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from contextlib import contextmanager

--- a/tests/integration/test_sqlalchemy.py
+++ b/tests/integration/test_sqlalchemy.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from contextlib import contextmanager

--- a/tests/unit/core/test_backtrace.py
+++ b/tests/unit/core/test_backtrace.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from scout_apm.core import backtrace

--- a/tests/unit/core/test_commands.py
+++ b/tests/unit/core/test_commands.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import datetime

--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os

--- a/tests/unit/core/test_context.py
+++ b/tests/unit/core/test_context.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from scout_apm.core.config import ScoutConfig

--- a/tests/unit/core/test_git_revision.py
+++ b/tests/unit/core/test_git_revision.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os

--- a/tests/unit/core/test_ignore.py
+++ b/tests/unit/core/test_ignore.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from scout_apm.core.config import ScoutConfig

--- a/tests/unit/core/test_instrument_manager.py
+++ b/tests/unit/core/test_instrument_manager.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from scout_apm.core.config import ScoutConfig

--- a/tests/unit/core/test_metadata.py
+++ b/tests/unit/core/test_metadata.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import sys

--- a/tests/unit/core/test_n_plus_one_call_set.py
+++ b/tests/unit/core/test_n_plus_one_call_set.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from scout_apm.core.n_plus_one_call_set import NPlusOneCallSet, NPlusOneCallSetItem

--- a/tests/unit/core/test_objtrace.py
+++ b/tests/unit/core/test_objtrace.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import pytest

--- a/tests/unit/core/test_platform_detection.py
+++ b/tests/unit/core/test_platform_detection.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import sys

--- a/tests/unit/core/test_remote_ip.py
+++ b/tests/unit/core/test_remote_ip.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import pytest

--- a/tests/unit/core/test_request_manager.py
+++ b/tests/unit/core/test_request_manager.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import pytest

--- a/tests/unit/core/test_stacktracer.py
+++ b/tests/unit/core/test_stacktracer.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import pytest

--- a/tests/unit/core/test_tracked_request.py
+++ b/tests/unit/core/test_tracked_request.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from datetime import datetime, timedelta

--- a/tests/unit/core/test_util.py
+++ b/tests/unit/core/test_util.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from scout_apm.core.util import octal

--- a/tox.ini
+++ b/tox.ini
@@ -55,6 +55,7 @@ deps =
     check-manifest
     black
     flake8
+    flake8-coding
     isort
 skip_install = true
 commands =


### PR DESCRIPTION
This is needed for Python 2.7, which without a coding comment, defaults to the system encoding. This can cause problems in rare situations - and I already managed to write a test that broke on Python 2.7 (emoji).