### PR TITLE
Fix randomly failing test test_tags_allocations_for_spans

### DIFF
--- a/tests/unit/core/test_tracked_request.py
+++ b/tests/unit/core/test_tracked_request.py
@@ -81,6 +81,7 @@ def test_start_span_wires_parents(tr):
 
 @pytest.mark.skipif(objtrace is None, reason="objtrace extension isn't available")
 def test_tags_allocations_for_spans(tr):
+    objtrace.enable()
     span = tr.start_span()
     tr.stop_span()
     assert span.tags["allocations"] > 0


### PR DESCRIPTION
This test would fail when running just its containing file on Python 3 with:

```
>       assert span.tags["allocations"] > 0
E       assert 0 > 0
```

Turns out `objtrace.enable()` needs calling to ensure it does track.

There's no easy way of making a test fixture that resets the enabled/disabled state at the end of it, but there probably isn't a need anyway as `install()` does `objtrace.enable()` anyway.