### PR TITLE
Implement __repr__ on TrackedRequest and Span

### DIFF
--- a/src/scout_apm/core/tracked_request.py
+++ b/src/scout_apm/core/tracked_request.py
@@ -38,6 +38,12 @@ class TrackedRequest(ThreadLocalSingleton):
         self.callset = NPlusOneCallSet()
         logger.debug("Starting request: %s", self.req_id)
 
+    def __repr__(self):
+        # Incomplete to avoid TMI
+        return "<TrackedRequest(req_id={}, tags={})>".format(
+            repr(self.req_id), repr(self.tags)
+        )
+
     def mark_real_request(self):
         self.real_request = True
 
@@ -132,6 +138,12 @@ class Span(object):
                 "start_objtrace_counts", (0, 0, 0, 0)
             )
         self.end_objtrace_counts = kwargs.get("end_objtrace_counts", (0, 0, 0, 0))
+
+    def __repr__(self):
+        # Incomplete to avoid TMI
+        return "<Span(span_id={}, operation={}, ignore={}, tags={})>".format(
+            repr(self.span_id), repr(self.operation), repr(self.ignore), repr(self.tags)
+        )
 
     def stop(self):
         self.end_time = datetime.utcnow()

--- a/tests/unit/core/test_tracked_request.py
+++ b/tests/unit/core/test_tracked_request.py
@@ -22,6 +22,10 @@ def tr():
         request.finish()
 
 
+def test_tracked_request_repr(tr):
+    assert repr(tr).startswith("<TrackedRequest(")
+
+
 def test_tracked_request_instance_is_a_singleton():
     tr1 = TrackedRequest.instance()
     tr2 = TrackedRequest.instance()
@@ -39,7 +43,6 @@ def test_real_request(tr):
 
 
 def test_tag_request(tr):
-
     tr.tag("foo", "bar")
 
     assert len(tr.tags) == 1
@@ -53,6 +56,14 @@ def test_tag_request_overwrite(tr):
 
     assert len(tr.tags) == 1
     assert tr.tags["foo"] == "baz"
+
+
+def test_span_repr(tr):
+    span = tr.start_span()
+    try:
+        assert repr(span).startswith("<Span(")
+    finally:
+        tr.stop_span()
 
 
 def test_tag_span(tr):


### PR DESCRIPTION
Output some partial information on each in order to make test authoring easier.