### PR TITLE
Fix Flask to track missed automatic OPTIONS requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Tested on Django 2.2
 - Added PyPI Trove classifiers for supported Django versions
 - Track usernames on Django < 1.10
+- Fix Flask integration to track some missed requests such as automatic
+  `OPTONS` responses.
 
 ### Fixed
 

--- a/tests/integration/test_flask.py
+++ b/tests/integration/test_flask.py
@@ -3,13 +3,12 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from contextlib import contextmanager
 
+import flask
 import pytest
-from flask import Flask
 from webtest import TestApp
 
 from scout_apm.api import Config
 from scout_apm.flask import ScoutApm
-from tests.compat import mock
 
 
 @contextmanager
@@ -26,14 +25,18 @@ def app_with_scout(config=None):
     config["SCOUT_CORE_AGENT_LAUNCH"] = False
 
     # Basic Flask app
-    app = Flask("test_app")
+    app = flask.Flask("test_app")
+    # Enable the following for debugging exceptions:
+    # app.config["PROPAGATE_EXCEPTIONS"] = True
 
     @app.route("/")
     def home():
         return "Welcome home."
 
-    @app.route("/hello/")
+    @app.route("/hello/", methods=["GET", "OPTIONS"], provide_automatic_options=False)
     def hello():
+        if flask.request.method == "OPTIONS":
+            return "Hello Options!"
         return "Hello World!"
 
     @app.route("/crash/")
@@ -56,10 +59,11 @@ def test_home(tracked_requests):
         assert response.status_int == 200
 
     assert len(tracked_requests) == 1
-    spans = tracked_requests[0].complete_spans
-    assert [s.operation for s in spans] == [
-        "Controller/tests.integration.test_flask.home"
-    ]
+    assert len(tracked_requests[0].complete_spans) == 1
+    span = tracked_requests[0].complete_spans[0]
+    assert span.operation == "Controller/tests.integration.test_flask.home"
+    assert span.tags["path"] == "/"
+    assert span.tags["name"] == "tests.integration.test_flask.home"
 
 
 def test_hello(tracked_requests):
@@ -68,10 +72,25 @@ def test_hello(tracked_requests):
         assert response.status_int == 200
 
     assert len(tracked_requests) == 1
-    spans = tracked_requests[0].complete_spans
-    assert [s.operation for s in spans] == [
-        "Controller/tests.integration.test_flask.hello"
-    ]
+    assert len(tracked_requests[0].complete_spans) == 1
+    span = tracked_requests[0].complete_spans[0]
+    assert span.operation == "Controller/tests.integration.test_flask.hello"
+    assert span.tags["path"] == "/hello/"
+    assert span.tags["name"] == "tests.integration.test_flask.hello"
+
+
+def test_hello_options(tracked_requests):
+    with app_with_scout() as app:
+        response = TestApp(app).options("/hello/")
+
+    assert response.status_int == 200
+    assert response.text == "Hello Options!"
+    assert len(tracked_requests) == 1
+    assert len(tracked_requests[0].complete_spans) == 1
+    span = tracked_requests[0].complete_spans[0]
+    assert span.operation == "Controller/tests.integration.test_flask.hello"
+    assert span.tags["path"] == "/hello/"
+    assert span.tags["name"] == "tests.integration.test_flask.hello"
 
 
 def test_not_found(tracked_requests):
@@ -88,42 +107,32 @@ def test_server_error(tracked_requests):
         assert response.status_int == 500
 
     assert len(tracked_requests) == 1
-    spans = tracked_requests[0].complete_spans
-    assert [s.operation for s in spans] == [
-        "Controller/tests.integration.test_flask.crash"
-    ]
+    tracked_request = tracked_requests[0]
+    assert tracked_request.tags["error"] == "true"
+    assert len(tracked_request.complete_spans) == 1
+    span = tracked_request.complete_spans[0]
+    assert span.operation == "Controller/tests.integration.test_flask.crash"
+    assert span.tags["path"] == "/crash/"
+    assert span.tags["name"] == "tests.integration.test_flask.crash"
 
 
 def test_automatic_options(tracked_requests):
-    """
-    We don't want to capture automatic options
-    """
     with app_with_scout() as app:
-        response = TestApp(app).options("/hello/")
-        assert response.status_int == 200
+        response = TestApp(app).options("/")
 
-    assert tracked_requests == []
+    assert response.status_int == 200
+    assert response.text == ""
+    assert len(tracked_requests) == 1
+    spans = tracked_requests[0].complete_spans
+    assert [s.operation for s in spans] == [
+        "Controller/tests.integration.test_flask.home"
+    ]
 
 
 @pytest.mark.xfail(reason="Integration still captures requests with monitor=False")
 def test_no_monitor(tracked_requests):
     # With an empty config, "SCOUT_MONITOR" defaults to False.
     with app_with_scout({}) as app:
-        response = TestApp(app).get("/hello/")
-        assert response.status_int == 200
-
-    assert tracked_requests == []
-
-
-@mock.patch("scout_apm.core.monkey.CallableProxy", side_effect=ValueError)
-def test_wrapping_exception(CallableProxy, tracked_requests):
-    """
-    Scout doesn't crash if scout_apm.core.monkey.CallableProxy raises an exception.
-
-    This cannot be tested without mocking because it should never happen.
-
-    """
-    with app_with_scout() as app:
         response = TestApp(app).get("/hello/")
         assert response.status_int == 200
 


### PR DESCRIPTION
* Add failing test `test_hello_options` that shows how Monkey-patched `dispatch_request` missed Flask's `provide_automatic_options` behaviour
* Remove `process_request` and `process_response` hooks which have been empty since #99
* Stop entirely monkey patching `dispatch_request` ([Flask source](https://github.com/pallets/flask/blob/d4b688bd035b9704b3168b28fed39c8fcfe3b997/src/flask/app.py#L1872c)) and instead wrap it with a `CallableProxy` around `wrapped_dispatch_request`. This fixes the current divergence around `provide_automatic_options` and guards against potential future divergence.
* Remove the `try/except Exception` around putting in place `CallableProxy`, since we're no longer wrapping each view function but only the one method. This will fail at startup if it's not possible, and that doesn't seem likely anyway.