### PR TITLE
Run 'twine check' in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,11 +43,11 @@ jobs:
         - secure: "ohvspT59/b71SdnIFf/HA5552tGaYWLYTUV2IQ/ZNxrTiJd/hcm5eBbfAkOUiC6l2cxdHt+cAyRh27us32z7F29qzlSzrWkTD18pvFKjSGtaa2X0aBTiollfiGgiXpdT5wiDoyjyGWti3q4CpwOZjrpB/rZx0DUxdRejf0cQfs/6W8xqei/PeSTAY+58eRxKUo9JOsEObDgpjJFSWTHVip6Rm0C8zG5fEal6OEMozP+LncSzxIPZiaA0x82nYSMSBQiJXqgX6x1iNDUVl9W1wwghPjCxhz1n6kUtoKOnLcz2VhtmzR+rFDXcdgIr3l9HsSaj8t/jRIPwyUuB1DDamKWuEC0dFrqeTraOKz/t7eZkSpKa+jRaNUC4RLPSSNJVC3hEH8WlNIAyCGyvYv0RAGEYzrWcl0QZQgn1s205uIVKF8v3bepAV4oPUOEjhAk3+kVhBDLrUHWnDtLzQxPJOcC/PpMIkXx5+ZCADJrkmppEAtv+gAbHIE5gcodvyGgUc1ynp/Ul2LQxUX7KUopZBkBtFomRJWOXli5rV9tc8It+m91Xua6+jRB8UePyHw2KLGoABulNNoGSvr+uRdH8Ph/4des33iikTEnEDBk740NAsMW1pExMMlXAdaYScpBjCu7z3MrSCs4oraCVJ1g9nqbc7ugxVqMPC97fu7XKpe8="
       script:
         - python setup.py sdist
-        - pip install --upgrade cibuildwheel
+        - pip install --upgrade cibuildwheel twine
         - cibuildwheel
+        - twine check dist/* wheelhouse/*
         - ls -al dist wheelhouse
         - if [ "${TRAVIS_TAG:-}" != "" ]; then
-            pip install --upgrade twine;
             python -m twine upload --skip-existing dist/* wheelhouse/*;
           fi
 

--- a/tox.ini
+++ b/tox.ini
@@ -57,13 +57,14 @@ deps =
     flake8
     flake8-coding
     isort
-skip_install = true
+    twine
 commands =
     python setup.py check --strict --metadata
     check-manifest {toxinidir}
     black --check src tests setup.py
     isort --check-only --recursive src tests setup.py
     flake8 src tests setup.py
+    twine check {distdir}/*
 
 [testenv:coveralls]
 deps =


### PR DESCRIPTION
This ensures that the package is built in a valid format for PyPI, including the README syntax. Run it on both tox and travis wheel building steps - tox to fail early, and travis to be exhaustive on all the built wheels.