### PR TITLE
Add Falcon integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add support to Django integration for tracking request queue timing from the
   value of the `X-Queue-Start` or `X-Request-Start` header
+- Add Falcon integration.
 
 ## [2.0.5] 2019-06-21
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,22 @@ __A Scout account is required. [Signup for Scout](https://scoutapm.com/users/sig
 pip install scout-apm
 ```
 
+### Bottle
+
+```python
+from scout_apm.bottle import ScoutPlugin
+
+app = bottle.default_app()
+app.config.update({
+    "scout.name": "YOUR_APP_NAME",
+    "scout.key": "YOUR_KEY",
+    "scout.monitor": "true",
+})
+
+scout = ScoutPlugin()
+bottle.install(scout)
+```
+
 ### Django
 
 ```python
@@ -43,6 +59,22 @@ INSTALLED_APPS = [
 SCOUT_MONITOR = True
 SCOUT_KEY = "[AVAILABLE IN THE SCOUT UI]"
 SCOUT_NAME = "A FRIENDLY NAME FOR YOUR APP"
+```
+
+### Falcon
+
+```python
+import falcon
+from scout_apm.falcon import ScoutMiddleware
+
+scout_middleware = ScoutMiddleware(config={
+    "key": "[AVAILABLE IN THE SCOUT UI]",
+    "monitor": True,
+    "name": "A FRIENDLY NAME FOR YOUR APP",
+})
+api = falcon.API(middleware=[ScoutMiddleware()])
+# Required for accessing API internals, Falcon doesn't provide it default
+scout_middleware.set_api(api)
 ```
 
 ### Flask
@@ -85,22 +117,6 @@ if __name__ == "__main__":
         config.include("scout_apm.pyramid")
 
         # Rest of your config...
-```
-
-### Bottle
-
-```python
-from scout_apm.bottle import ScoutPlugin
-
-app = bottle.default_app()
-app.config.update({
-    "scout.name": "YOUR_APP_NAME",
-    "scout.key": "YOUR_KEY",
-    "scout.monitor": "true",
-})
-
-scout = ScoutPlugin()
-bottle.install(scout)
 ```
 
 For full installation instructions, including information on configuring Scout via environment variables, see our [Python docs](https://docs.scoutapm.com/#python-agent).

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ scout_middleware = ScoutMiddleware(config={
     "name": "A FRIENDLY NAME FOR YOUR APP",
 })
 api = falcon.API(middleware=[ScoutMiddleware()])
-# Required for accessing API internals, Falcon doesn't provide it default
+# Required for accessing extra per-request information
 scout_middleware.set_api(api)
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Python Versions:
 Scout APM works with the following frameworks:
 
 * Django 1.8+
+* Falcon 2.0+
 * Flask 0.10+
 * Celery 3.1+
 * Pyramid 1.8+

--- a/src/scout_apm/falcon.py
+++ b/src/scout_apm/falcon.py
@@ -1,0 +1,87 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import inspect
+
+from scout_apm.api import install
+from scout_apm.core.ignore import ignore_path
+from scout_apm.core.tracked_request import TrackedRequest
+
+# Falcon Middleware docs:
+# https://falcon.readthedocs.io/en/stable/api/middleware.html
+
+
+class ScoutMiddleware(object):
+    """
+    Falcon Middleware for integration with Scout APMi.
+    """
+
+    def __init__(self, config):
+        install(config=config)
+
+    def process_request(self, req, resp):
+        tracked_request = TrackedRequest.instance()
+        tracked_request.mark_real_request()
+        req.context.scout_tracked_request = tracked_request
+
+        tracked_request.tag("path", req.path)
+
+        if ignore_path(req.path):
+            tracked_request.tag("ignore_transaction", True)
+
+    def process_resource(self, req, resp, resource, params):
+        tracked_request = getattr(req.context, "scout_tracked_request", None)
+        if tracked_request is None:
+            # Somehow we didn't start a request - this might occur in
+            # combination with a pretty adversarial application, so guard
+            # against it, although if a request was started and the context was
+            # lost, other problems might occur.
+            return  # pragma: no cover
+
+        # Find the current responder's name. Falcon passes middleware the
+        # current resource but unfortunately not the method being called. Also
+        # middleware doesn't have a reference to the current API object so we
+        # can't check the router there. Use some hopefully pretty harmless
+        # stack inspection to look up the current responder method.
+        responder_name = None
+        current_frame = inspect.currentframe()
+        # current_frame can return None if stack inspection is not available
+        if current_frame is not None:
+            try:
+                if current_frame.f_back is not None:
+                    responder = current_frame.f_back.f_locals.get("responder", None)
+                    if responder is not None:
+                        responder_name = getattr(responder, "__name__", None)
+            finally:
+                # As per inspect docs, one should always be careful to release
+                # references to frames
+                del current_frame
+
+        if responder_name is not None:
+            operation = "Controller/{}.{}.{}".format(
+                resource.__module__, resource.__class__.__name__, responder_name
+            )
+        else:
+            # Since we couldn't find the current responder method, instead use
+            # a slash and the HTTP method name
+            operation = "Controller/{}.{}/{}".format(
+                resource.__module__, resource.__class__.__name__, req.method
+            )
+
+        span = tracked_request.start_span(operation=operation)
+        req.context.scout_resource_span = span
+
+    def process_response(self, req, resp, resource, req_succeeded):
+        tracked_request = getattr(req.context, "scout_tracked_request", None)
+        if tracked_request is None:
+            # Somehow we didn't start a request
+            return
+
+        if not req_succeeded:
+            tracked_request.tag("error", "true")
+
+        span = getattr(req.context, "scout_resource_span", None)
+        if span is not None:
+            tracked_request.stop_span()
+        else:
+            tracked_request.finish()

--- a/src/scout_apm/falcon.py
+++ b/src/scout_apm/falcon.py
@@ -1,11 +1,14 @@
 # coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import inspect
-
 from scout_apm.api import install
 from scout_apm.core.ignore import ignore_path
 from scout_apm.core.tracked_request import TrackedRequest
+
+try:
+    import falcon
+except ImportError:  # pragma: no cover
+    falcon = None
 
 # Falcon Middleware docs:
 # https://falcon.readthedocs.io/en/stable/api/middleware.html
@@ -18,16 +21,38 @@ class ScoutMiddleware(object):
 
     def __init__(self, config):
         install(config=config)
+        self.api = None
+
+    def set_api(self, api):
+        if not isinstance(api, falcon.API):
+            raise ValueError("api should be an instance of falcon.API")
+        self.api = api
 
     def process_request(self, req, resp):
+        if self.api is None:
+            raise RuntimeError(
+                "Call {}.set_api() before requests begin".format(
+                    self.__class__.__name__
+                )
+            )
+
         tracked_request = TrackedRequest.instance()
         tracked_request.mark_real_request()
         req.context.scout_tracked_request = tracked_request
 
         tracked_request.tag("path", req.path)
-
         if ignore_path(req.path):
             tracked_request.tag("ignore_transaction", True)
+
+        # Determine a remote IP to associate with the request. The value is
+        # spoofable by the requester so this is not suitable to use in any
+        # security sensitive context.
+        user_ip = (
+            req.get_header("x-forwarded-for", default="").split(",")[0]
+            or req.get_header("client-ip", default="").split(",")[0]
+            or req.remote_addr
+        )
+        tracked_request.tag("user_ip", user_ip)
 
     def process_resource(self, req, resp, resource, params):
         tracked_request = getattr(req.context, "scout_tracked_request", None)
@@ -36,37 +61,15 @@ class ScoutMiddleware(object):
             # combination with a pretty adversarial application, so guard
             # against it, although if a request was started and the context was
             # lost, other problems might occur.
-            return  # pragma: no cover
+            return
 
         # Find the current responder's name. Falcon passes middleware the
-        # current resource but unfortunately not the method being called. Also
-        # middleware doesn't have a reference to the current API object so we
-        # can't check the router there. Use some hopefully pretty harmless
-        # stack inspection to look up the current responder method.
-        responder_name = None
-        current_frame = inspect.currentframe()
-        # current_frame can return None if stack inspection is not available
-        if current_frame is not None:
-            try:
-                if current_frame.f_back is not None:
-                    responder = current_frame.f_back.f_locals.get("responder", None)
-                    if responder is not None:
-                        responder_name = getattr(responder, "__name__", None)
-            finally:
-                # As per inspect docs, one should always be careful to release
-                # references to frames
-                del current_frame
-
-        if responder_name is not None:
-            operation = "Controller/{}.{}.{}".format(
-                resource.__module__, resource.__class__.__name__, responder_name
-            )
-        else:
-            # Since we couldn't find the current responder method, instead use
-            # a slash and the HTTP method name
-            operation = "Controller/{}.{}/{}".format(
-                resource.__module__, resource.__class__.__name__, req.method
-            )
+        # current resource but unfortunately not the method being called, hence
+        # we have to go through routing again.
+        responder, _params, _resource, _uri_template = self.api._get_responder(req)
+        operation = "Controller/{}.{}.{}".format(
+            resource.__module__, resource.__class__.__name__, responder.__name__
+        )
 
         span = tracked_request.start_span(operation=operation)
         req.context.scout_resource_span = span

--- a/src/scout_apm/falcon.py
+++ b/src/scout_apm/falcon.py
@@ -1,14 +1,11 @@
 # coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import falcon
+
 from scout_apm.api import install
 from scout_apm.core.ignore import ignore_path
 from scout_apm.core.tracked_request import TrackedRequest
-
-try:
-    import falcon
-except ImportError:  # pragma: no cover
-    falcon = None
 
 # Falcon Middleware docs:
 # https://falcon.readthedocs.io/en/stable/api/middleware.html

--- a/src/scout_apm/falcon.py
+++ b/src/scout_apm/falcon.py
@@ -13,7 +13,7 @@ from scout_apm.core.tracked_request import TrackedRequest
 
 class ScoutMiddleware(object):
     """
-    Falcon Middleware for integration with Scout APMi.
+    Falcon Middleware for integration with Scout APM.
     """
 
     def __init__(self, config):

--- a/tests/integration/test_falcon.py
+++ b/tests/integration/test_falcon.py
@@ -1,0 +1,217 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from contextlib import contextmanager
+
+import falcon
+import pytest
+from webtest import TestApp
+
+from scout_apm.api import Config
+from scout_apm.falcon import ScoutMiddleware
+from tests.compat import mock
+
+
+@contextmanager
+def app_with_scout(config=None, middleware=None):
+    """
+    Context manager that yields a fresh Falcon app with Scout configured.
+    """
+    # Enable Scout by default in tests.
+    if config is None:
+        config = {"monitor": True}
+
+    # Disable running the agent.
+    config["core_agent_launch"] = False
+
+    # Basic Falcon app
+    if middleware is None:
+        middleware = []
+    middleware.append(ScoutMiddleware(config=config))
+    app = falcon.API(middleware=middleware)
+
+    class HomeResource(object):
+        def on_get(self, req, resp):
+            resp.status = falcon.HTTP_200
+            resp.content_type = falcon.MEDIA_TEXT
+            resp.body = "Welcome home."
+
+        def on_get_suffixed(self, req, resp):
+            self.on_get(req, resp)
+            resp.body = "Welcome home, suffixed."
+
+    app.add_route("/", HomeResource())
+    app.add_route("/suffixed", HomeResource(), suffix="suffixed")
+
+    class CrashResource(object):
+        def on_get(self, req, resp):
+            raise falcon.HTTPStatus("748 Confounded by ponies")
+
+    app.add_route("/crash", CrashResource())
+
+    try:
+        yield app
+    finally:
+        Config.reset_all()
+
+
+def test_home(tracked_requests):
+    with app_with_scout() as app:
+        response = TestApp(app).get("/")
+
+    assert response.status_int == 200
+    assert response.text == "Welcome home."
+    assert len(tracked_requests) == 1
+    tracked_request = tracked_requests[0]
+    assert tracked_request.tags["path"] == "/"
+    assert tracked_request.active_spans == []
+    assert len(tracked_request.complete_spans) == 1
+    span = tracked_request.complete_spans[0]
+    assert (
+        span.operation == "Controller/tests.integration.test_falcon.HomeResource.on_get"
+    )
+
+
+@pytest.mark.parametrize(
+    "frame_mocker",
+    [
+        # This checks the branch where stack inspection isn't possible, which
+        # according to the inspect.currentframe() docs, is "some
+        # implementations" of Python. For the record, it does work in
+        # PyPy3.5-7.0.0:
+        mock.patch("scout_apm.falcon.inspect.currentframe", return_value=None),
+        # This checks the unlikely branch that somehow we can inspect the
+        # current frame but not see the frame above it to find the "responder"
+        # variable:
+        mock.patch(
+            "scout_apm.falcon.inspect.currentframe", return_value=mock.Mock(f_back=None)
+        ),
+        # This tests the future where Falcon is refactored so that 'responder'
+        # is no longer the name for the responder method or it's not
+        # visible in the frame above the middleware's process_response. Basically
+        # if this line, or similar, are changed:
+        # https://github.com/falconry/falcon/blob/7372895e0132fa7c626d9afde0d9e07e37655486/falcon/api.py#L247
+        mock.patch(
+            "scout_apm.falcon.inspect.currentframe",
+            return_value=mock.Mock(f_back=mock.Mock(f_locals={})),
+        ),
+    ],
+)
+def test_home_stack_inspection_failures(frame_mocker, tracked_requests):
+    with app_with_scout() as app, frame_mocker:
+        response = TestApp(app).get("/")
+
+    assert response.status_int == 200
+    assert response.text == "Welcome home."
+    assert len(tracked_requests) == 1
+    tracked_request = tracked_requests[0]
+    assert tracked_request.tags["path"] == "/"
+    assert tracked_request.active_spans == []
+    assert len(tracked_request.complete_spans) == 1
+    span = tracked_request.complete_spans[0]
+    assert span.operation == "Controller/tests.integration.test_falcon.HomeResource/GET"
+
+
+def test_home_suffixed(tracked_requests):
+    with app_with_scout() as app:
+        response = TestApp(app).get("/suffixed")
+
+    assert response.status_int == 200
+    assert response.text == "Welcome home, suffixed."
+    assert len(tracked_requests) == 1
+    tracked_request = tracked_requests[0]
+    assert tracked_request.tags["path"] == "/suffixed"
+    assert tracked_request.active_spans == []
+    assert len(tracked_request.complete_spans) == 1
+    span = tracked_request.complete_spans[0]
+    assert (
+        span.operation
+        == "Controller/tests.integration.test_falcon.HomeResource.on_get_suffixed"
+    )
+
+
+def test_home_ignored(tracked_requests):
+    with app_with_scout({"monitor": True, "ignore": ["/"]}) as app:
+        response = TestApp(app).get("/")
+
+    assert response.status_int == 200
+    assert response.text == "Welcome home."
+    assert tracked_requests == []
+
+
+def test_middleware_returning_early_from_process_request(tracked_requests):
+    class ShortcutMiddleware(object):
+        def process_request(self, req, resp):
+            resp.status = falcon.HTTP_200
+            resp.body = "Shortcut!"
+            resp.complete = True
+
+        def process_resource(self, req, resp, resource, params):
+            pass
+
+        def process_response(self, req, resp, resource, req_succeeded):
+            pass
+
+    with app_with_scout(middleware=[ShortcutMiddleware()]) as app:
+        response = TestApp(app).get("/")
+
+    assert response.status_int == 200
+    assert response.text == "Shortcut!"
+    assert tracked_requests == []
+
+
+def test_middleware_returning_early_from_process_resource(tracked_requests):
+    class ShortcutMiddleware(object):
+        def process_request(self, req, resp):
+            pass
+
+        def process_resource(self, req, resp, resource, params):
+            resp.status = falcon.HTTP_200
+            resp.body = "Shortcut!"
+            resp.complete = True
+
+        def process_response(self, req, resp, resource, req_succeeded):
+            pass
+
+    with app_with_scout(middleware=[ShortcutMiddleware()]) as app:
+        response = TestApp(app).get("/")
+
+    assert response.status_int == 200
+    assert response.text == "Shortcut!"
+    assert len(tracked_requests) == 1
+    tracked_request = tracked_requests[0]
+    assert tracked_request.tags["path"] == "/"
+    assert tracked_request.active_spans == []
+    assert tracked_request.complete_spans == []
+
+
+def test_not_found(tracked_requests):
+    with app_with_scout() as app:
+        response = TestApp(app).get("/not-found", expect_errors=True)
+
+    assert response.status_int == 404
+    assert len(tracked_requests) == 1
+    tracked_request = tracked_requests[0]
+    assert tracked_request.tags["path"] == "/not-found"
+    assert tracked_request.tags["error"] == "true"
+    assert tracked_request.active_spans == []
+    assert tracked_request.complete_spans == []
+
+
+def test_crash(tracked_requests):
+    with app_with_scout() as app:
+        response = TestApp(app).get("/crash", expect_errors=True)
+
+    assert response.status_int == 748
+    assert response.text == ""
+    assert len(tracked_requests) == 1
+    tracked_request = tracked_requests[0]
+    assert tracked_request.tags["path"] == "/crash"
+    assert tracked_request.tags["error"] == "true"
+    assert tracked_request.active_spans == []
+    assert len(tracked_request.complete_spans) == 1
+    span = tracked_request.complete_spans[0]
+    assert (
+        span.operation
+        == "Controller/tests.integration.test_falcon.CrashResource.on_get"
+    )

--- a/tests/integration/test_falcon.py
+++ b/tests/integration/test_falcon.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import sys
 from contextlib import contextmanager
 
 import falcon
@@ -111,6 +112,11 @@ def test_home(tracked_requests):
     ],
 )
 def test_user_ip(headers, extra_environ, expected, tracked_requests):
+    if sys.version_info[0] == 2:
+        # Required for WebTest lint
+        headers = {str(k): str(v) for k, v in headers.items()}
+        extra_environ = {str(k): str(v) for k, v in extra_environ.items()}
+
     with app_with_scout() as app:
         TestApp(app).get("/", headers=headers, extra_environ=extra_environ)
 

--- a/tests/integration/test_falcon.py
+++ b/tests/integration/test_falcon.py
@@ -106,7 +106,10 @@ def test_home_without_set_api(caplog, tracked_requests):
         (
             "scout_apm.falcon",
             logging.WARNING,
-            "ScoutMiddleware.set_api() should be called before requests begin for more detail",
+            (
+                "ScoutMiddleware.set_api() should be called before requests "
+                "begin for more detail"
+            ),
         )
     ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,7 @@ deps =
     django21: Django>=2.1,<2.2
     django22: Django>=2.2,<2.3
     elasticsearch
+    falcon
     flask
     flask-sqlalchemy
     jinja2


### PR DESCRIPTION
Fixes #179. Add a middleware that implements basic tracking of Falcon resources, with operations named after the current resource name plus the method called on it. The method name is retrieved through stack inspection, which can fail and in that case we use the raw HTTP method name instead.