### PR TITLE
Improve exception logging

### DIFF
--- a/src/scout_apm/core/config.py
+++ b/src/scout_apm/core/config.py
@@ -79,11 +79,9 @@ class ScoutConfig(object):
     def core_agent_permissions(self):
         try:
             return octal(self.value("core_agent_permissions"))
-        except ValueError as e:
-            logger.error(
-                "Invalid core_agent_permissions value: %s." " Using default: %s",
-                repr(e),
-                0o700,
+        except ValueError:
+            logger.exception(
+                "Invalid core_agent_permissions value, using default of 0o700"
             )
             return 0o700
 

--- a/src/scout_apm/core/core_agent_manager.py
+++ b/src/scout_apm/core/core_agent_manager.py
@@ -66,9 +66,9 @@ class CoreAgentManager(object):
                 + self.config_file()
                 + self.socket_path()
             )
-        except Exception as exc:
+        except Exception:
             # TODO detect failure of launch properly
-            logger.error("Error running Core Agent: %r", exc)
+            logger.exception("Error running Core Agent")
             return False
         return True
 
@@ -140,8 +140,8 @@ class CoreAgentDownloader(object):
             try:
                 self.download_package()
                 self.untar()
-            except OSError as e:
-                logger.error("Exception raised while downloading Core Agent: %r", e)
+            except OSError:
+                logger.exception("Exception raised while downloading Core Agent")
             finally:
                 self.release_download_lock()
 

--- a/src/scout_apm/instruments/urllib3.py
+++ b/src/scout_apm/instruments/urllib3.py
@@ -43,9 +43,9 @@ class Instrument(object):
                     except KeyError:
                         method = args[0]
                     url = "{}".format(self._absolute_url("/"))
-                except Exception as e:
-                    logger.error(
-                        "Could not get instrument data for HTTPConnectionPool: %r", e
+                except Exception:
+                    logger.exception(
+                        "Could not get instrument data for HTTPConnectionPool"
                     )
 
                 tr = TrackedRequest.instance()

--- a/tests/integration/core/test_core_agent_manager.py
+++ b/tests/integration/core/test_core_agent_manager.py
@@ -127,23 +127,16 @@ def test_verify_error(caplog, core_agent_manager):
 
 
 def test_launch_error(caplog, core_agent_manager):
-    class CustomException(ValueError):
-        # Consistent repr() across Python versions
-        def __repr__(self):
-            return "fail"
-
+    exception = ValueError("Hello Fail")
     with mock.patch(
         "scout_apm.core.core_agent_manager.CoreAgentManager.agent_binary",
-        side_effect=CustomException(),
+        side_effect=exception,
     ):
         result = core_agent_manager.launch()
 
     assert not result
     assert not is_running(core_agent_manager)
     assert caplog.record_tuples == [
-        (
-            "scout_apm.core.core_agent_manager",
-            logging.ERROR,
-            "Error running Core Agent: fail",
-        )
+        ("scout_apm.core.core_agent_manager", logging.ERROR, "Error running Core Agent")
     ]
+    assert caplog.records[0].exc_info[1] is exception


### PR DESCRIPTION
Use `logger.exception` instead of `logger.error` so the full traceback is displayed, as suggested by Aymeric.