### PR TITLE
Implement request queue time tracking in Bottle, Flask, and Pyramid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 - Track user IP on Flask
 - Make user IP tracking on Bottle and Pyramid use the same algorithm as other
   integrations, checking for the `client-ip` header
-- Add support to Falcon integration for tracking request queue timing
+- Add support to Bottle, Falcon, Flask and Pyramid integrations for tracking
+  request queue timing
 
 ### Fixed
 

--- a/src/scout_apm/bottle.py
+++ b/src/scout_apm/bottle.py
@@ -7,6 +7,7 @@ import scout_apm.core
 from scout_apm.core.config import ScoutConfig
 from scout_apm.core.context import AgentContext
 from scout_apm.core.ignore import ignore_path
+from scout_apm.core.queue_time import track_request_queue_time
 from scout_apm.core.tracked_request import TrackedRequest
 
 
@@ -61,9 +62,19 @@ class ScoutPlugin(object):
                     or request.headers.get("client-ip", "").split(",")[0]
                     or request.environ.get("REMOTE_ADDR")
                 )
-                tracked_request.tag("user_ip", user_ip)
             except Exception:
                 pass
+            else:
+                tracked_request.tag("user_ip", user_ip)
+
+            try:
+                queue_time = request.headers.get(
+                    "x-queue-start", ""
+                ) or request.headers.get("x-request-start", "")
+            except Exception:
+                pass
+            else:
+                track_request_queue_time(queue_time, tracked_request)
 
             try:
                 return callback(*args, **kwargs)

--- a/src/scout_apm/flask/__init__.py
+++ b/src/scout_apm/flask/__init__.py
@@ -8,6 +8,7 @@ import scout_apm.core
 from scout_apm.core.config import ScoutConfig
 from scout_apm.core.ignore import ignore_path
 from scout_apm.core.monkey import CallableProxy
+from scout_apm.core.queue_time import track_request_queue_time
 from scout_apm.core.tracked_request import TrackedRequest
 
 
@@ -77,6 +78,11 @@ class ScoutApm(object):
             or request.remote_addr
         )
         tracked_request.tag("user_ip", user_ip)
+
+        queue_time = request.headers.get(
+            "x-queue-start", default=""
+        ) or request.headers.get("x-request-start", default="")
+        track_request_queue_time(queue_time, tracked_request)
 
         try:
             return original(*args, **kwargs)

--- a/tests/integration/test_bottle.py
+++ b/tests/integration/test_bottle.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import datetime as dt
 import sys
 from contextlib import contextmanager
 
@@ -9,8 +10,12 @@ from webtest import TestApp
 
 from scout_apm.api import Config
 from scout_apm.bottle import ScoutPlugin
+from scout_apm.compat import datetime_to_timestamp
 from tests.compat import mock
-from tests.integration.util import parametrize_user_ip_headers
+from tests.integration.util import (
+    parametrize_queue_time_header_name,
+    parametrize_user_ip_headers,
+)
 
 
 @contextmanager
@@ -99,6 +104,44 @@ def test_user_ip_error(tracked_requests):
 
     tracked_request = tracked_requests[0]
     assert "user_ip" not in tracked_request.tags
+
+
+@parametrize_queue_time_header_name
+def test_queue_time(header_name, tracked_requests):
+    # Not testing floats due to Python 2/3 rounding differences
+    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow()) - 2)
+    with app_with_scout() as app:
+        response = TestApp(app).get(
+            "/", headers={header_name: str("t=") + str(queue_start)}
+        )
+
+    assert response.status_int == 200
+    assert len(tracked_requests) == 1
+    queue_time_ns = tracked_requests[0].tags["scout.queue_time_ns"]
+    # Upper bound assumes we didn't take more than 2s to run this test...
+    assert queue_time_ns >= 2000000000 and queue_time_ns < 4000000000
+
+
+def test_queue_time_error(tracked_requests):
+    """
+    Scout doesn't crash if bottle's Request.headers.get raises an exception.
+
+    This cannot be tested without mocking because it should never happen.
+    """
+    orig_headers_get = WSGIHeaderDict.get
+
+    def crashy_get(self, key, *args, **kwargs):
+        if key == "x-queue-start":
+            raise ValueError("Don't try get *that* header!")
+        return orig_headers_get(key, *args, **kwargs)
+
+    with mock.patch.object(
+        WSGIHeaderDict, "get", new=crashy_get
+    ), app_with_scout() as app:
+        TestApp(app).get("/")
+
+    tracked_request = tracked_requests[0]
+    assert "scout.queue_time_ns" not in tracked_request.tags
 
 
 def test_home_ignored(tracked_requests):

--- a/tests/integration/test_django.py
+++ b/tests/integration/test_django.py
@@ -18,7 +18,10 @@ from scout_apm.compat import datetime_to_timestamp
 from scout_apm.core.tracked_request import TrackedRequest
 from tests.compat import mock
 from tests.integration import django_app  # noqa  # force import to configure
-from tests.integration.util import parametrize_user_ip_headers
+from tests.integration.util import (
+    parametrize_queue_time_header_name,
+    parametrize_user_ip_headers,
+)
 
 skip_unless_new_style_middleware = pytest.mark.skipif(
     django.VERSION < (1, 10), reason="new-style middleware was added in Django 1.10"
@@ -341,7 +344,7 @@ def test_old_style_username_exception(tracked_requests):
     assert "username" not in tr.tags
 
 
-@pytest.mark.parametrize("header_name", ["X-Queue-Start", "X-Request-Start"])
+@parametrize_queue_time_header_name
 def test_queue_time(header_name, tracked_requests):
     # Not testing floats due to Python 2/3 rounding differences
     queue_start = int(datetime_to_timestamp(dt.datetime.utcnow()) - 2)

--- a/tests/integration/test_falcon.py
+++ b/tests/integration/test_falcon.py
@@ -13,7 +13,10 @@ from webtest import TestApp
 from scout_apm.api import Config
 from scout_apm.compat import datetime_to_timestamp
 from scout_apm.falcon import ScoutMiddleware
-from tests.integration.util import parametrize_user_ip_headers
+from tests.integration.util import (
+    parametrize_queue_time_header_name,
+    parametrize_user_ip_headers,
+)
 
 
 @contextmanager
@@ -158,7 +161,7 @@ def test_home_ignored(tracked_requests):
     assert tracked_requests == []
 
 
-@pytest.mark.parametrize("header_name", ["X-Queue-Start", "X-Request-Start"])
+@parametrize_queue_time_header_name
 def test_queue_time(header_name, tracked_requests):
     # Not testing floats due to Python 2/3 rounding differences
     queue_start = int(datetime_to_timestamp(dt.datetime.utcnow()) - 2)

--- a/tests/integration/test_pyramid.py
+++ b/tests/integration/test_pyramid.py
@@ -1,17 +1,23 @@
 # coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import datetime as dt
 import sys
 from contextlib import contextmanager
 
 import pytest
 from pyramid.config import Configurator
 from pyramid.response import Response
+from webob.headers import EnvironHeaders
 from webtest import TestApp
 
 from scout_apm.api import Config
+from scout_apm.compat import datetime_to_timestamp
 from tests.compat import mock
-from tests.integration.util import parametrize_user_ip_headers
+from tests.integration.util import (
+    parametrize_queue_time_header_name,
+    parametrize_user_ip_headers,
+)
 
 
 @contextmanager
@@ -85,7 +91,7 @@ def test_user_ip(headers, extra_environ, expected, tracked_requests):
     assert tracked_request.tags["user_ip"] == expected
 
 
-def test_user_ip_exception(tracked_requests):
+def test_user_ip_error(tracked_requests):
     """
     Scout doesn't crash if pyramid.request.Request.remote_addr raises an exception.
 
@@ -100,6 +106,47 @@ def test_user_ip_exception(tracked_requests):
     )
 
     with app_with_scout() as app, remote_addr_patcher:
+        response = TestApp(app).get("/hello/")
+
+    assert response.status_int == 200
+    assert "user_ip" not in tracked_requests[0].tags
+
+
+@parametrize_queue_time_header_name
+def test_queue_time(header_name, tracked_requests):
+    # Not testing floats due to Python 2/3 rounding differences
+    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow()) - 2)
+    with app_with_scout() as app:
+        response = TestApp(app).get(
+            "/", headers={header_name: str("t=") + str(queue_start)}
+        )
+
+    assert response.status_int == 200
+    assert len(tracked_requests) == 1
+    queue_time_ns = tracked_requests[0].tags["scout.queue_time_ns"]
+    # Upper bound assumes we didn't take more than 2s to run this test...
+    assert queue_time_ns >= 2000000000 and queue_time_ns < 4000000000
+
+
+def test_queue_time_error(tracked_requests):
+    """
+    Scout doesn't crash if pyramid.request.Request.headers.get raises an
+    exception.
+
+    This cannot be tested without mocking because it should never happen.
+    It's implemented in webob.headers.EnvironHeaders as a simple lookup in
+    environ: https://github.com/Pylons/webob/blob/master/src/webob/headers.py
+    """
+    orig_headers_get = EnvironHeaders.get
+
+    def crashy_get(self, key, *args, **kwargs):
+        if key == "x-queue-start":
+            raise ValueError("Don't try get *that* header!")
+        return orig_headers_get(key, *args, **kwargs)
+
+    get_patcher = mock.patch.object(EnvironHeaders, "get", new=crashy_get)
+
+    with app_with_scout() as app, get_patcher:
         response = TestApp(app).get("/hello/")
 
     assert response.status_int == 200

--- a/tests/integration/util.py
+++ b/tests/integration/util.py
@@ -3,6 +3,10 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import pytest
 
+parametrize_queue_time_header_name = pytest.mark.parametrize(
+    "header_name", ["X-Queue-Start", "X-Request-Start"]
+)
+
 parametrize_user_ip_headers = pytest.mark.parametrize(
     "headers, extra_environ, expected",
     [


### PR DESCRIPTION
Add #120 for these three integrations, using the shared function extracted from the Django integration for Falcon in #199.