### PR TITLE
Fix core-agent-manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Fixed
 
 - Track path and user IP on Django < 1.10
+- The undocumented `core-agent-manager` CLI command works again
 
 ## [2.1.0] 2019-06-25
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,9 +11,7 @@ ignore =
 
 [coverage:run]
 branch = True
-omit =
-    src/scout_apm/core/cli/core_agent_manager.py
-    src/scout_apm/core/monkey.py
+omit = src/scout_apm/core/monkey.py
 
 [flake8]
 # core

--- a/src/scout_apm/core/cli/core_agent_manager.py
+++ b/src/scout_apm/core/cli/core_agent_manager.py
@@ -4,38 +4,31 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import argparse
 import logging
 
+from scout_apm.core import AgentContext, CoreAgentManager
 
-def download(**kwargs):
-    from scout_apm.core import CoreAgentManager
-
-    core_agent_manager = CoreAgentManager()
-    core_agent_manager.download()
+logger = logging.getLogger(__name__)
 
 
-def launch(**kwargs):
-    from scout_apm.core import CoreAgentManager
-
-    core_agent_manager = CoreAgentManager()
-    core_agent_manager.launch()
-
-
-def main(**kwargs):
+def main(argv=None):
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "-v", "--verbose", help="increase output verbosity", action="count"
     )
 
-    subparsers = parser.add_subparsers(dest="subparser")
+    subparsers = parser.add_subparsers(
+        title="subcommands", description="valid subcommands", dest="subparser"
+    )
     subparsers.add_parser("download")
     subparsers.add_parser("launch")
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     if args.verbose is not None:
         if args.verbose >= 2:
-            logging.basicConfig(level=getattr(logging, "DEBUG", None))
-        elif args.verbose == 1:
-            logging.basicConfig(level=getattr(logging, "INFO", None))
+            logging.basicConfig(level=logging.DEBUG)
+        else:
+            logging.basicConfig(level=logging.INFO)
 
-    kwargs = vars(args)
-    globals()[kwargs.pop("subparser")](**kwargs)
+    AgentContext.build()
+    core_agent_manager = CoreAgentManager()
+    getattr(core_agent_manager, args.subparser)()

--- a/tests/unit/core/cli/test_core_agent_manager.py
+++ b/tests/unit/core/cli/test_core_agent_manager.py
@@ -1,0 +1,39 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import logging
+
+import pytest
+
+from scout_apm.core.cli.core_agent_manager import main
+from tests.compat import mock
+
+
+@pytest.fixture(autouse=True)
+def mock_CoreAgentManager():
+    # Always mock out the actual CoreAgentManager class for these tests, to
+    # keep them quick
+    path = "scout_apm.core.cli.core_agent_manager.CoreAgentManager"
+    with mock.patch(path) as mock_obj:
+        yield mock_obj
+
+
+@mock.patch("scout_apm.core.cli.core_agent_manager.logging.basicConfig")
+@pytest.mark.parametrize(
+    "args, expected_level", [(["-v"], logging.INFO), (["-v", "-v"], logging.DEBUG)]
+)
+def test_logging_verbose(mock_basicConfig, args, expected_level):
+    # Have to use a mock for basicConfig since logging is already configured
+    # during tests
+    main(args + ["download"])
+
+    mock_basicConfig.assert_called_with(level=expected_level)
+
+
+@pytest.mark.parametrize("command", ["download", "launch"])
+def test_command(mock_CoreAgentManager, command):
+    main([command])
+
+    instance = mock_CoreAgentManager.return_value
+    method = getattr(instance, command)
+    method.assert_called_with()


### PR DESCRIPTION
Fixes #120. Steps:

* Added a call to `AgentContext.build()` to restore functionality. This is the
  only thing that broke. I used `git bisect` to discover that it was broken in
  6ab579e22ab903bb6b72108bc485550bb151f353, which is when `AgentContext` was
  refactored.
* Refactored to remove the unnecessary extra functions for the subparsers
* Removed unnecessary subparser name validity check, as this is done by
  argparse already
* Restored test coverage checking for the file
* Added some basic tests to get to 100% coverage