### PR TITLE
Improve Django middleware tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 - Track path and user IP on Django < 1.10
 - The undocumented `core-agent-manager` CLI command works again
+- Consistently track view responses on Django between different versions
+- Avoid unbalanced request tracking in certain cases on Django < 1.10
 
 ## [2.1.0] 2019-06-25
 


### PR DESCRIPTION
* In both old and new style middleware, mark requests as real only when we hit `process_view`. This means we don't track responses generated by other middleware *before* a view, which may not be desirable, but at least we're consistent between the two implementations for now.
* Be more cautious in the old style middleware, to keep track of the TrackedRequest we have assigned to the current Django request. Unbalanced spans should be less likely.
* Remove `finish_tracked_request_if_old_style_middlware` test fixture, which was really papering over the bugs to do with unbalanced spans.
* Test a lot more cases with old style middleware with other middleware in the stack generating early responses or exceptions, to cover many more scenarios.