### PR TITLE
Add extra Celery tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Add Dramatiq integration
   ([PR #223](https://github.com/scoutapp/scout_apm_python/pull/223)).
+- Track Celery task `is_eager`, `exchange`, `routing_key` and `queue` tags
+  ([PR #205](https://github.com/scoutapp/scout_apm_python/pull/205)).
 
 ## [2.3.0] 2019-08-04
 

--- a/src/scout_apm/celery.py
+++ b/src/scout_apm/celery.py
@@ -7,20 +7,22 @@ import scout_apm.core
 from scout_apm.core.tracked_request import TrackedRequest
 
 
-# TODO: Capture queue.
-# https://stackoverflow.com/questions/22385297/how-to-get-the-queue-in-which-a-task-was-run-celery?utm_medium=organic&utm_source=google_rich_qa&utm_campaign=google_rich_qa
-def prerun_callback(sender=None, headers=None, body=None, **kwargs):
-    name = kwargs["task"].name
+def prerun_callback(task=None, **kwargs):
+    tracked_request = TrackedRequest.instance()
+    tracked_request.mark_real_request()
 
-    tr = TrackedRequest.instance()
-    tr.mark_real_request()
-    span = tr.start_span(operation=("Job/" + name))
-    span.tag("queue", "default")
+    delivery_info = task.request.delivery_info
+    tracked_request.tag("is_eager", delivery_info.get("is_eager", False))
+    tracked_request.tag("exchange", delivery_info.get("exchange", "unknown"))
+    tracked_request.tag("routing_key", delivery_info.get("routing_key", "unknown"))
+    tracked_request.tag("queue", delivery_info.get("queue", "unknown"))
+
+    tracked_request.start_span(operation=("Job/" + task.name))
 
 
-def postrun_callback(sender=None, headers=None, body=None, **kwargs):
-    tr = TrackedRequest.instance()
-    tr.stop_span()
+def postrun_callback(task=None, **kwargs):
+    tracked_request = TrackedRequest.instance()
+    tracked_request.stop_span()
 
 
 def install():

--- a/tests/integration/test_celery.py
+++ b/tests/integration/test_celery.py
@@ -3,25 +3,41 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from contextlib import contextmanager
 
-from celery import Celery
+import celery
+import pytest
+from celery.signals import setup_logging
 
 import scout_apm.celery
 from scout_apm.api import Config
 
+# http://docs.celeryproject.org/en/latest/userguide/testing.html#py-test
+skip_unless_celery_4_plus = pytest.mark.skipif(
+    celery.VERSION < (4, 0), reason="pytest fixtures added in Celery 4.0"
+)
+
+
+@setup_logging.connect
+def do_nothing(**kwargs):
+    # Just by connecting to this signal, we prevent Celery from setting up
+    # logging - and stop it from interfering with global state
+    # http://docs.celeryproject.org/en/v4.3.0/userguide/signals.html#setup-logging
+    pass
+
 
 @contextmanager
-def app_with_scout(config=None):
+def app_with_scout(app=None, config=None):
     """
     Context manager that configures a Celery app with Scout installed.
     """
+    if app is None:
+        app = celery.Celery("tasks", broker="memory://")
+
     # Enable Scout by default in tests.
     if config is None:
         config = {"monitor": True}
 
     # Disable running the agent.
     config["core_agent_launch"] = False
-
-    app = Celery("tasks", broker="memory://")
 
     @app.task
     def hello():
@@ -39,23 +55,44 @@ def app_with_scout(config=None):
         Config.reset_all()
 
 
-def test_hello(tracked_requests):
+def test_hello_eager(tracked_requests):
     with app_with_scout() as app:
         result = app.tasks["tests.integration.test_celery.hello"].apply()
 
     assert result.result == "Hello World!"
     assert len(tracked_requests) == 1
     tracked_request = tracked_requests[0]
+    assert tracked_request.tags["is_eager"] is True
+    assert tracked_request.tags["exchange"] == "unknown"
+    assert tracked_request.tags["routing_key"] == "unknown"
+    assert tracked_request.tags["queue"] == "unknown"
     assert tracked_request.active_spans == []
     assert len(tracked_request.complete_spans) == 1
     span = tracked_request.complete_spans[0]
     assert span.operation == "Job/tests.integration.test_celery.hello"
-    assert span.tags["queue"] == "default"
+
+
+@skip_unless_celery_4_plus
+def test_hello_worker(celery_app, celery_worker, tracked_requests):
+    with app_with_scout(app=celery_app) as app:
+        result = app.tasks["tests.integration.test_celery.hello"].delay().get()
+
+    assert result == "Hello World!"
+    assert len(tracked_requests) == 1
+    tracked_request = tracked_requests[0]
+    assert tracked_request.tags["is_eager"] is False
+    assert tracked_request.tags["exchange"] == ""
+    assert tracked_request.tags["routing_key"] == "celery"
+    assert tracked_request.tags["queue"] == "unknown"
+    assert tracked_request.active_spans == []
+    assert len(tracked_request.complete_spans) == 1
+    span = tracked_request.complete_spans[0]
+    assert span.operation == "Job/tests.integration.test_celery.hello"
 
 
 def test_no_monitor(tracked_requests):
     # With an empty config, "monitor" defaults to False.
-    with app_with_scout({}) as app:
+    with app_with_scout(config={}) as app:
         result = app.tasks["tests.integration.test_celery.hello"].apply()
 
     assert result.result == "Hello World!"


### PR DESCRIPTION
Fixes #34. Tagging with the current *queue* is only *sometimes* possible - often the *exchange* and *routing_key* are provided instead. The task may have come from a particular queue, but its delivery information normally onyl tracks where it was sent at the top of the AMQP funnel by exchange + routing_key, since that's what's needed for retry. Also track the `is_eager` flag which may be useful for determining which way the task was run.

More information on these parameters can be gleaned from [the source](https://github.com/celery/celery/blob/8cf8fae70630954cff3448485588bbe2a77ff3ab/celery/app/task.py#L600).

Updating the tests to use the fixture added in Celery 4.0, but since we support 3.1 this is in a conditional test. Our test suite currently installs the latest version of Celery only, so I tested locally temporarily with Celery 3.1 as well by specifying `celery>=3.1,<3.2` in `tox.ini`. For complete automated testing in the future, we should look at a better requirements management system.