### PR TITLE
Track queue time on Celery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   ([PR #223](https://github.com/scoutapp/scout_apm_python/pull/223)).
 - Track Celery task `is_eager`, `exchange`, `routing_key` and `queue` tags
   ([PR #205](https://github.com/scoutapp/scout_apm_python/pull/205)).
+- Track Celery task time in queue with context tag `queue_time`
+  ([PR #206](https://github.com/scoutapp/scout_apm_python/pull/206)).
 
 ## [2.3.0] 2019-08-04
 


### PR DESCRIPTION
Fixes #35. Track the queue time by using an extra haeder to track when the task is added to the queue and comparing when it gets executed. This should work in most setups but if the celery app isn't all set up on the producer side, we are well defended against it.

Like #205, I manually tested on Celery 3.1.x locally by editing `tox.ini` and reinstalling with `tox -r`.