### PR TITLE
Remove assertion in config

### DIFF
--- a/src/scout_apm/core/config.py
+++ b/src/scout_apm/core/config.py
@@ -42,9 +42,10 @@ class ScoutConfig(object):
         for layer in self.layers:
             if layer.has_config(key):
                 return layer
-        else:  # pragma: no cover
-            # Not reachable because ScoutConfigNull returns None for all keys.
-            assert False, "key not found in any layer"
+
+        # Should be unreachable because ScoutConfigNull returns None for all
+        # keys.
+        raise ValueError("key {!r} not found in any layer".format(key))
 
     def log(self):
         logger.debug("Configuration Loaded:")


### PR DESCRIPTION
`assert` shouldn't be used in production code since Python's (rarely used) optimize flag (`python -O`) strips them out. Also get the code coverage of this module to 100%.