### PR TITLE
Close file descriptors when launching core agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Pending
+
+### Fixed
+
+- Close file descriptors when launching the core agent process. This fixes a
+  bug where uwsgi's HTTP ports would be held by the it on Python 2.7.
+  ([PR #219](https://github.com/scoutapp/scout_apm_python/pull/219)).
+
 ## [2.2.0] 2019-07-27
 
 ### Added

--- a/src/scout_apm/core/core_agent_manager.py
+++ b/src/scout_apm/core/core_agent_manager.py
@@ -59,12 +59,15 @@ class CoreAgentManager(object):
     def run(self):
         try:
             subprocess.check_call(
-                self.agent_binary()
-                + self.daemonize_flag()
-                + self.log_level()
-                + self.log_file()
-                + self.config_file()
-                + self.socket_path()
+                (
+                    self.agent_binary()
+                    + self.daemonize_flag()
+                    + self.log_level()
+                    + self.log_file()
+                    + self.config_file()
+                    + self.socket_path()
+                ),
+                close_fds=True,
             )
         except Exception:
             # TODO detect failure of launch properly


### PR DESCRIPTION
Fixes #216.

This is the default [on Python 3.4+](https://docs.python.org/3/library/os.html#fd-inheritance).

Tested with https://github.com/adamchainz/scout-test-apps/commit/61f0197e5731c3a6709a1520d08a2102d53a0217 before and after, checking `lsof -nP -i :8000` to see if the core agent process was holding onto the port.