### PR TITLE
Move to standard toxworkdir

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-toxworkdir=/tmp/tox
 envlist =
     clean,
     check,


### PR DESCRIPTION
This was done in 986d17cddeecf73a457ac2766b3e5686ac005cbe but I'm not sure why. It's better for my workflow to keep it in the standard directory so that virtualenvs don't need rebuildingn so frequently when `/tmp` gets cleared.