### PR TITLE
Move convert_ambiguous_timestamp_to_ns

### DIFF
--- a/src/scout_apm/core/queue_time.py
+++ b/src/scout_apm/core/queue_time.py
@@ -1,8 +1,9 @@
 # coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import time
+
 from scout_apm.compat import datetime_to_timestamp
-from scout_apm.core.util import convert_ambiguous_timestamp_to_ns
 
 
 def track_request_queue_time(header_value, tracked_request):
@@ -34,3 +35,30 @@ def track_request_queue_time(header_value, tracked_request):
 
     queue_time_ns = int(tr_start_timestamp_ns - start_timestamp_ns)
     tracked_request.tag("scout.queue_time_ns", queue_time_ns)
+
+
+# Cutoff epoch is used for determining ambiguous timestamp boundaries, and is
+# just over 10 years ago at time of writing
+CUTOFF_EPOCH_S = time.mktime((2009, 6, 1, 0, 0, 0, 0, 0, 0))
+CUTOFF_EPOCH_MS = CUTOFF_EPOCH_S * 1000.0
+CUTOFF_EPOCH_US = CUTOFF_EPOCH_S * 1000000.0
+CUTOFF_EPOCH_NS = CUTOFF_EPOCH_S * 1000000000.0
+
+
+def convert_ambiguous_timestamp_to_ns(timestamp):
+    """
+    Convert an ambiguous float timestamp that could be in nanoseconds,
+    microseconds, milliseconds, or seconds to nanoseconds. Return 0.0 for
+    values in the more than 10 years ago.
+    """
+    if timestamp > CUTOFF_EPOCH_NS:
+        converted_timestamp = timestamp
+    elif timestamp > CUTOFF_EPOCH_US:
+        converted_timestamp = timestamp * 1000.0
+    elif timestamp > CUTOFF_EPOCH_MS:
+        converted_timestamp = timestamp * 1000000.0
+    elif timestamp > CUTOFF_EPOCH_S:
+        converted_timestamp = timestamp * 1000000000.0
+    else:
+        return 0.0
+    return converted_timestamp

--- a/src/scout_apm/core/util.py
+++ b/src/scout_apm/core/util.py
@@ -1,34 +1,6 @@
 # coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import time
-
-# Cutoff epoch is used for determining ambiguous timestamp boundaries, and is
-# just over 10 years ago at time of writing
-CUTOFF_EPOCH_S = time.mktime((2009, 6, 1, 0, 0, 0, 0, 0, 0))
-CUTOFF_EPOCH_MS = CUTOFF_EPOCH_S * 1000.0
-CUTOFF_EPOCH_US = CUTOFF_EPOCH_S * 1000000.0
-CUTOFF_EPOCH_NS = CUTOFF_EPOCH_S * 1000000000.0
-
-
-def convert_ambiguous_timestamp_to_ns(timestamp):
-    """
-    Convert an ambiguous float timestamp that could be in nanoseconds,
-    microseconds, milliseconds, or seconds to nanoseconds. Return 0.0 for
-    values in the more than 10 years ago.
-    """
-    if timestamp > CUTOFF_EPOCH_NS:
-        converted_timestamp = timestamp
-    elif timestamp > CUTOFF_EPOCH_US:
-        converted_timestamp = timestamp * 1000.0
-    elif timestamp > CUTOFF_EPOCH_MS:
-        converted_timestamp = timestamp * 1000000.0
-    elif timestamp > CUTOFF_EPOCH_S:
-        converted_timestamp = timestamp * 1000000000.0
-    else:
-        return 0.0
-    return converted_timestamp
-
 
 def octal(value):
     """

--- a/tests/unit/core/test_util.py
+++ b/tests/unit/core/test_util.py
@@ -1,31 +1,7 @@
 # coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import time
-
-import pytest
-
-from scout_apm.core.util import CUTOFF_EPOCH_S, convert_ambiguous_timestamp_to_ns, octal
-
-ref_time_s = time.mktime((2019, 6, 1, 0, 0, 0, 0, 0, 0))
-
-
-@pytest.mark.parametrize(
-    "given,expected",
-    [
-        (ref_time_s, ref_time_s * 1e9),
-        (ref_time_s * 1e3, ref_time_s * 1e9),
-        (ref_time_s * 1e6, ref_time_s * 1e9),
-        (CUTOFF_EPOCH_S + 10, (CUTOFF_EPOCH_S + 10) * 1e9),
-        (0.0, 0.0),
-        (1000.0, 0.0),
-        (float("inf"), float("inf")),
-        (float("-inf"), 0.0),
-        (float("nan"), 0.0),
-    ],
-)
-def test_convert_ambiguous_timestamp_to_ns(given, expected):
-    assert convert_ambiguous_timestamp_to_ns(given) == expected
+from scout_apm.core.util import octal
 
 
 def test_octal_with_valid_integer():


### PR DESCRIPTION
Put it next to the queue time tools and out of the ambiguously named 'util' module.