### PR TITLE
Improve logging in CoreAgentSocket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Pending
+
+### Added
+
+- Improved logging for debugging customer problems.
+
 ## [2.4.0] 2019-08-20
 
 ### Added


### PR DESCRIPTION
* Add exception in the "thread exception" message
* Pass `exc_info=exc` so if the messages are picked up by a formatter that works with exceptions, it uses them.