### PR TITLE
Drop CoreAgentVersion and CoreAgentVersionResponse

### DIFF
--- a/src/scout_apm/core/commands.py
+++ b/src/scout_apm/core/commands.py
@@ -1,7 +1,6 @@
 # coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import json
 import logging
 from datetime import datetime
 
@@ -148,17 +147,6 @@ class ApplicationEvent(object):
                 "source": self.source,
             }
         }
-
-
-class CoreAgentVersion(object):
-    def message(self):
-        return {"CoreAgentVersion": {}}
-
-
-class CoreAgentVersionResponse(object):
-    def __init__(self, message):
-        self.loaded = json.loads(message)
-        self.version = self.loaded["CoreAgentVersion"]["version"]
 
 
 class BatchCommand(object):

--- a/tests/unit/core/test_commands.py
+++ b/tests/unit/core/test_commands.py
@@ -189,11 +189,9 @@ END_TIME_STR = "2018-12-01T17:04:34.641403Z"
                 }
             },
         ),
-        (commands.CoreAgentVersion(), {"CoreAgentVersion": {}}),
         (
             commands.BatchCommand(
                 [
-                    commands.CoreAgentVersion(),
                     commands.StartRequest(timestamp=TIMESTAMP, request_id=REQUEST_ID),
                     commands.FinishRequest(timestamp=TIMESTAMP, request_id=REQUEST_ID),
                 ]
@@ -201,7 +199,6 @@ END_TIME_STR = "2018-12-01T17:04:34.641403Z"
             {
                 "BatchCommand": {
                     "commands": [
-                        {"CoreAgentVersion": {}},
                         {
                             "StartRequest": {
                                 "timestamp": TIMESTAMP_STR,
@@ -222,13 +219,6 @@ END_TIME_STR = "2018-12-01T17:04:34.641403Z"
 )
 def test_command_message(command, message):
     assert command.message() == message
-
-
-def test_core_agent_version_response():
-    command = commands.CoreAgentVersionResponse(
-        '{"CoreAgentVersion": {"version": "x.y"}}'
-    )
-    assert command.version == "x.y"
 
 
 def make_tracked_request_instance_deterministic(tr):


### PR DESCRIPTION
These classes are unused except in tests, so drop them according to the YAGNI principle.