### PR TITLE
Update default socket path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Pending
+
+### Fixed
+
+- Use the same default socket name that the core agent uses when launched alone
+  (`core-agent.sock` -> `scout-agent.sock`)
+  ([PR #240](https://github.com/scoutapp/scout_apm_python/pull/240)).
+
 ## [2.4.1] 2019-08-26
 
 ### Added

--- a/src/scout_apm/core/config.py
+++ b/src/scout_apm/core/config.py
@@ -186,7 +186,7 @@ class ScoutConfigDerived(object):
         return getattr(self, func_name, None)
 
     def derive_socket_path(self):
-        return "{}/{}/core-agent.sock".format(
+        return "{}/{}/scout-agent.sock".format(
             self.config.value("core_agent_dir"),
             self.config.value("core_agent_full_name"),
         )

--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -44,7 +44,7 @@ def test_get_derived_config_value():
             r"-v1\.1\.8"
             r"-(x86_64|i686|unknown)"
             r"-(unknown-linux-gnu|apple-darwin|unknown)"
-            r"/core-agent\.sock",
+            r"/scout-agent\.sock",
             config.value("socket_path"),
         )
     finally:


### PR DESCRIPTION
The core agent has used the default socket name `scout-agent.sock` when started solo since version 1.0.0. Python has been starting it with a different socket name, which could lead to multiple agents running on different sockets if multiple languages are used.