### PR TITLE
Add test coverage for samplers

### DIFF
--- a/src/scout_apm/core/samplers/cpu.py
+++ b/src/scout_apm/core/samplers/cpu.py
@@ -33,7 +33,7 @@ class Cpu(object):
         if wall_clock_elapsed < timedelta(0):
             self.save_times(now, cpu_times)
             logger.debug(
-                "%s: Negative time elapsed. now: %s, last_run: %s, total time: %s.",
+                "%s: Negative time elapsed. now: %s, last_run: %s.",
                 self.human_name(),
                 now,
                 self.last_run,
@@ -65,22 +65,10 @@ class Cpu(object):
         ).total_seconds()
 
         # If somehow we run for 0 seconds between calls, don't try to divide by 0
-        res = None
         if normalized_wall_clock_elapsed == 0:
             res = 0
         else:
             res = (process_elapsed / normalized_wall_clock_elapsed) * 100
-
-        if res < 0:
-            self.save_times(now, cpu_times)
-            logger.debug(
-                "%s: Negative CPU: %s / %s * 100 ==> %s",
-                self.human_name(),
-                process_elapsed,
-                normalized_wall_clock_elapsed,
-                res,
-            )
-            return None
 
         self.save_times(now, cpu_times)
 

--- a/tests/unit/core/samplers/__init__.py
+++ b/tests/unit/core/samplers/__init__.py
@@ -1,0 +1,2 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function, unicode_literals

--- a/tests/unit/core/samplers/test_cpu.py
+++ b/tests/unit/core/samplers/test_cpu.py
@@ -1,0 +1,81 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import datetime as dt
+import logging
+
+from psutil._common import pcputimes
+
+from scout_apm.core.samplers.cpu import Cpu
+
+
+def test_metric_type():
+    assert Cpu().metric_type() == "CPU"
+
+
+def test_metric_name():
+    assert Cpu().metric_name() == "Utilization"
+
+
+def test_human_name():
+    assert Cpu().human_name() == "Process CPU"
+
+
+def test_run_negative_time_elapsed(caplog):
+    caplog.set_level(logging.DEBUG)
+    cpu = Cpu()
+    cpu.last_run = dt.datetime.utcnow() + dt.timedelta(days=100)
+
+    result = cpu.run()
+
+    assert result is None
+    assert len(caplog.record_tuples) == 1
+    logger, level, message = caplog.record_tuples[0]
+    assert logger == "scout_apm.core.samplers.cpu"
+    assert level == logging.DEBUG
+    assert message.startswith("Process CPU: Negative time elapsed. now: ")
+
+
+def test_run_negative_last_cpu_times(caplog):
+    caplog.set_level(logging.DEBUG)
+    cpu = Cpu()
+    cpu.last_cpu_times = pcputimes(
+        user=1e12, system=1e12, children_user=0.0, children_system=0.0
+    )
+
+    result = cpu.run()
+
+    assert result is None
+    assert len(caplog.record_tuples) == 1
+    logger, level, message = caplog.record_tuples[0]
+    assert logger == "scout_apm.core.samplers.cpu"
+    assert level == logging.DEBUG
+    assert message.startswith("Process CPU: Negative process time elapsed. utime: ")
+    assert message.endswith("This is normal to see when starting a forking web server.")
+
+
+def test_run_within_zero_seconds(caplog):
+    caplog.set_level(logging.DEBUG)
+    cpu = Cpu()
+    # Force the calculation of normalized_wall_clock_elapsed to 0
+    cpu.num_processors = 0
+
+    result = cpu.run()
+
+    assert result == 0
+    assert caplog.record_tuples == [
+        ("scout_apm.core.samplers.cpu", logging.DEBUG, "Process CPU: 0 [0 CPU(s)]")
+    ]
+
+
+def test_run(caplog):
+    caplog.set_level(logging.DEBUG)
+    cpu = Cpu()
+
+    result = cpu.run()
+
+    assert isinstance(result, float) and result > 0
+    logger, level, message = caplog.record_tuples[0]
+    assert logger == "scout_apm.core.samplers.cpu"
+    assert level == logging.DEBUG
+    assert message.startswith("Process CPU: {}".format(result))

--- a/tests/unit/core/samplers/test_cpu.py
+++ b/tests/unit/core/samplers/test_cpu.py
@@ -74,7 +74,7 @@ def test_run(caplog):
 
     result = cpu.run()
 
-    assert isinstance(result, float) and result > 0
+    assert isinstance(result, float) and result >= 0.0
     logger, level, message = caplog.record_tuples[0]
     assert logger == "scout_apm.core.samplers.cpu"
     assert level == logging.DEBUG

--- a/tests/unit/core/samplers/test_cpu.py
+++ b/tests/unit/core/samplers/test_cpu.py
@@ -29,9 +29,11 @@ def test_run_negative_time_elapsed(caplog):
     result = cpu.run()
 
     assert result is None
-    assert len(caplog.record_tuples) == 1
-    logger, level, message = caplog.record_tuples[0]
-    assert logger == "scout_apm.core.samplers.cpu"
+    record_tuples = [
+        r for r in caplog.record_tuples if r[0] == "scout_apm.core.samplers.cpu"
+    ]
+    assert len(record_tuples) == 1
+    _, level, message = record_tuples[0]
     assert level == logging.DEBUG
     assert message.startswith("Process CPU: Negative time elapsed. now: ")
 
@@ -46,9 +48,11 @@ def test_run_negative_last_cpu_times(caplog):
     result = cpu.run()
 
     assert result is None
-    assert len(caplog.record_tuples) == 1
-    logger, level, message = caplog.record_tuples[0]
-    assert logger == "scout_apm.core.samplers.cpu"
+    record_tuples = [
+        r for r in caplog.record_tuples if r[0] == "scout_apm.core.samplers.cpu"
+    ]
+    assert len(record_tuples) == 1
+    _, level, message = record_tuples[0]
     assert level == logging.DEBUG
     assert message.startswith("Process CPU: Negative process time elapsed. utime: ")
     assert message.endswith("This is normal to see when starting a forking web server.")
@@ -63,7 +67,10 @@ def test_run_within_zero_seconds(caplog):
     result = cpu.run()
 
     assert result == 0
-    assert caplog.record_tuples == [
+    record_tuples = [
+        r for r in caplog.record_tuples if r[0] == "scout_apm.core.samplers.cpu"
+    ]
+    assert record_tuples == [
         ("scout_apm.core.samplers.cpu", logging.DEBUG, "Process CPU: 0 [0 CPU(s)]")
     ]
 
@@ -75,7 +82,10 @@ def test_run(caplog):
     result = cpu.run()
 
     assert isinstance(result, float) and result >= 0.0
-    logger, level, message = caplog.record_tuples[0]
-    assert logger == "scout_apm.core.samplers.cpu"
+    record_tuples = [
+        r for r in caplog.record_tuples if r[0] == "scout_apm.core.samplers.cpu"
+    ]
+    assert len(record_tuples) == 1
+    _, level, message = record_tuples[0]
     assert level == logging.DEBUG
     assert message.startswith("Process CPU: {}".format(result))

--- a/tests/unit/core/samplers/test_memory.py
+++ b/tests/unit/core/samplers/test_memory.py
@@ -58,8 +58,10 @@ def test_run(caplog):
 
     result = Memory().run()
     assert isinstance(result, float) and result > 0.0
-    assert len(caplog.record_tuples) == 1
-    logger, level, message = caplog.record_tuples[0]
-    assert logger == "scout_apm.core.samplers.memory"
+    record_tuples = [
+        r for r in caplog.record_tuples if r[0] == "scout_apm.core.samplers.memory"
+    ]
+    assert len(record_tuples) == 1
+    _, level, message = record_tuples[0]
     assert level == logging.DEBUG
     assert message.startswith("Process Memory: #")

--- a/tests/unit/core/samplers/test_memory.py
+++ b/tests/unit/core/samplers/test_memory.py
@@ -1,0 +1,65 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import logging
+
+import pytest
+
+from scout_apm.core.samplers.memory import Memory
+
+
+@pytest.mark.parametrize(
+    "given, expected",
+    [
+        (0, 0.0),
+        (1024 * 1024, 1.0),
+        (2 * 1024 * 1024, 2.0),
+        (2 * 1024 * 1024 + 1, 2.0000009536743164),
+    ],
+)
+def test_rss_to_mb(given, expected):
+    assert Memory.rss_to_mb(given) == expected
+
+
+def test_rss():
+    result = Memory.rss()
+    assert isinstance(result, int) and result > 0
+
+
+def test_rss_in_mb():
+    result = Memory.rss_in_mb()
+    assert isinstance(result, float) and result > 0.0
+
+
+def test_get_delta():
+    result = Memory.get_delta(1.0)
+    assert isinstance(result, float) and result > 0.0
+
+
+def test_get_delta_big():
+    result = Memory.get_delta(1e12)
+    assert result == 0.0
+
+
+def test_metric_type():
+    assert Memory().metric_type() == "Memory"
+
+
+def test_metric_name():
+    assert Memory().metric_name() == "Physical"
+
+
+def test_human_name():
+    assert Memory().human_name() == "Process Memory"
+
+
+def test_run(caplog):
+    caplog.set_level(logging.DEBUG)
+
+    result = Memory().run()
+    assert isinstance(result, float) and result > 0.0
+    assert len(caplog.record_tuples) == 1
+    logger, level, message = caplog.record_tuples[0]
+    assert logger == "scout_apm.core.samplers.memory"
+    assert level == logging.DEBUG
+    assert message.startswith("Process Memory: #")


### PR DESCRIPTION
This revealed a few bugs in `Cpu`:

* The first defensive log message was broken in terms of expected format parameters. I dropped the last one.
* The last branch defending against `res < 0` was unreacahable since the two divisors had already been verified as not being negative, so the division could not end up negative.