### PR TITLE
Fix race condition in CoreAgentSocket.stop()

### DIFF
--- a/src/scout_apm/core/socket.py
+++ b/src/scout_apm/core/socket.py
@@ -77,8 +77,8 @@ class CoreAgentSocket(threading.Thread):
         if self._started_event.is_set():
             self._stop_event.set()
             self.command_queue.put(None, False)  # unblock self.command_queue.get
-            self._stopped_event.wait(2 * SECOND)
-            if self._stopped_event.is_set():
+            stopped = self._stopped_event.wait(2 * SECOND)
+            if stopped:
                 return True
             else:
                 logger.debug("CoreAgentSocket Failed to stop thread within timeout!")


### PR DESCRIPTION
I realized that this method has a read-after-write concurrency bug here - if the thread stops successfully but another restarts the thread between the call to `wait()` and `is_set()`, it could incorrectly report failure to stop. `wait()` already returns the value of the event so there's no need to reread here.