### PR TITLE
Guard against undetermined CPU count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Use the same default socket name that the core agent uses when launched alone
   (`core-agent.sock` -> `scout-agent.sock`)
   ([PR #240](https://github.com/scoutapp/scout_apm_python/pull/240)).
+- Fix CPU statistics to work when the CPU count cannot be determined
+  ([PR #245](https://github.com/scoutapp/scout_apm_python/pull/245)).
 
 ## [2.4.1] 2019-08-26
 


### PR DESCRIPTION
Spotted whilst adding test coverage in #242.

The [`psutil.cpu_count` docs](https://psutil.readthedocs.io/en/latest/#psutil.cpu_count) say it can return `None` in the case that the CPU count cannot be determined. This would lead to a `TypeError` in the multiplication, so fix that by assuming 'undetermined' means one CPU - incorrect statistics, but better than nothing.