### PR TITLE
Remove socket stopping during installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
   ([PR #240](https://github.com/scoutapp/scout_apm_python/pull/240)).
 - Fix CPU statistics to work when the CPU count cannot be determined
   ([PR #245](https://github.com/scoutapp/scout_apm_python/pull/245)).
+- Don't stop the socket thread during startup
+  ([PR #246](https://github.com/scoutapp/scout_apm_python/pull/246)).
 
 ## [2.4.1] 2019-08-26
 

--- a/src/scout_apm/core/__init__.py
+++ b/src/scout_apm/core/__init__.py
@@ -36,10 +36,8 @@ def install(*args, **kwargs):
         objtrace.enable()
 
     logger.debug("APM Launching on PID: %s", getpid())
-    launched = CoreAgentManager().launch()
+    CoreAgentManager().launch()
 
     AppMetadata.report()
-    if launched:
-        AgentContext.socket().stop()
 
     return True


### PR DESCRIPTION
This was added in 3a3216c9efb8b055afa1527b7c9b37138c29ac8c but it's not clear why. It also needed fixing a bit in fb07442d2baa6f731d3980c685a6aa1b530dc266 for test speed.

The socket thread can be seen stopping on every application load and then getting restarted during the next send, for example on my Django test app I was seeing:

```
2019-08-28T08:27:36+0000 DEBUG CoreAgentSocket thread stopping.
2019-08-28T08:27:36+0000 DEBUG CoreAgentSocket thread stopped.
2019-08-28T08:27:36+0000 DEBUG Installed DB connection created signal handler
2019-08-28T08:27:36+0000 DEBUG Monkey patched Templates
2019-08-28T08:33:02+0000 DEBUG Starting request: req-d3d8860e-a229-4c0e-bbd9-a4a42a7e02f1
2019-08-28T08:33:02+0000 DEBUG Stopping request: req-d3d8860e-a229-4c0e-bbd9-a4a42a7e02f1
2019-08-28T08:33:02+0000 DEBUG Flushing RequestBuffer
2019-08-28T08:33:02+0000 DEBUG Flushing Request Id: req-d3d8860e-a229-4c0e-bbd9-a4a42a7e02f1
2019-08-28T08:33:02+0000 DEBUG CoreAgentSocket attempt 1, connecting to /tmp/scout_apm_core/scout_apm_core-v1.1.11-x86_64-apple-darwin/core-agent.sock, PID: 19363, Thread: <CoreAgentSocket(Thread-2, started daemon 123145574707200)>
2019-08-28T08:33:02+0000 DEBUG Starting Samplers. Acquiring samplers lock.
2019-08-28T08:33:02+0000 DEBUG CoreAgentSocket is connected
```

This is a background thread that gets used frequently, so I think it's best to keep it running rather than spend resources restarting it.