### PR TITLE
Minimize TrackedRequest and Span classes

### DIFF
--- a/src/scout_apm/core/commands.py
+++ b/src/scout_apm/core/commands.py
@@ -182,13 +182,13 @@ class BatchCommand(object):
         # The TrackedRequest must be finished
         commands = []
         commands.append(
-            StartRequest(timestamp=request.start_time, request_id=request.req_id)
+            StartRequest(timestamp=request.start_time, request_id=request.request_id)
         )
         for key in request.tags:
             commands.append(
                 TagRequest(
                     timestamp=request.start_time,
-                    request_id=request.req_id,
+                    request_id=request.request_id,
                     tag=key,
                     value=request.tags[key],
                 )
@@ -209,7 +209,7 @@ class BatchCommand(object):
                 commands.append(
                     TagSpan(
                         timestamp=span.start_time,
-                        request_id=request.req_id,
+                        request_id=request.request_id,
                         span_id=span.span_id,
                         tag=key,
                         value=span.tags[key],
@@ -225,7 +225,7 @@ class BatchCommand(object):
             )
 
         commands.append(
-            FinishRequest(timestamp=request.end_time, request_id=request.req_id)
+            FinishRequest(timestamp=request.end_time, request_id=request.request_id)
         )
 
         return cls(commands)

--- a/src/scout_apm/core/thread_local.py
+++ b/src/scout_apm/core/thread_local.py
@@ -40,6 +40,6 @@ class ThreadLocalSingleton(object):
                 self.__class__._thread_lookup.instance = None
 
     @classmethod
-    def __new_instance(cls, *args, **kwargs):
+    def __new_instance(cls, args, kwargs):
         cls._thread_lookup = threading.local()
-        cls._thread_lookup.instance = cls(args, kwargs)
+        cls._thread_lookup.instance = cls(*args, **kwargs)

--- a/tests/unit/core/test_commands.py
+++ b/tests/unit/core/test_commands.py
@@ -167,8 +167,8 @@ def make_tracked_request_instance_deterministic(tr):
     Override values in a TrackedRequest instance to make tests determistic.
 
     """
-    assert type(tr.req_id) == type(REQUEST_ID)
-    tr.req_id = REQUEST_ID
+    assert type(tr.request_id) == type(REQUEST_ID)
+    tr.request_id = REQUEST_ID
 
     assert type(tr.start_time) == type(START_TIME)
     tr.start_time = START_TIME

--- a/tests/unit/core/test_tracked_request.py
+++ b/tests/unit/core/test_tracked_request.py
@@ -129,22 +129,16 @@ def test_start_span_ignores_children(tr):
 
 
 def test_span_captures_backtrace(tr):
-    span = tr.start_span(
-        operation="Sql/Work", start_time=dt.datetime.utcnow() - dt.timedelta(seconds=1)
-    )
+    span = tr.start_span(operation="Sql/Work")
+    # Pretend it was started 1 second ago
+    span.start_time = dt.datetime.utcnow() - dt.timedelta(seconds=1)
     tr.stop_span()
-    assert span.tags["stack"]
+    assert "stack" in span.tags
 
 
 def test_span_does_not_capture_backtrace(tr):
-    controller = tr.start_span(
-        operation="Controller/Work",
-        start_time=dt.datetime.utcnow() - dt.timedelta(seconds=10),
-    )
-    middleware = tr.start_span(
-        operation="Middleware/Work",
-        start_time=dt.datetime.utcnow() - dt.timedelta(seconds=10),
-    )
+    controller = tr.start_span(operation="Controller/Work")
+    middleware = tr.start_span(operation="Middleware/Work")
     tr.stop_span()
     tr.stop_span()
     assert "stack" not in controller.tags


### PR DESCRIPTION
Replicate the changes from #255 into these key classes. Also remove unused constructor arguments and rename `req_id` to `request_id`.