### PR TITLE
Enable web frameworks' exception propagation flags in tests

### DIFF
--- a/tests/integration/django_app.py
+++ b/tests/integration/django_app.py
@@ -12,9 +12,7 @@ config = {
     "DATABASES": {
         "default": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"}
     },
-    # Enable the following for debugging exceptions:
-    # "DEBUG": True,
-    # "DEBUG_PROPAGATE_EXCEPTIONS": True,
+    "DEBUG_PROPAGATE_EXCEPTIONS": True,
     "ROOT_URLCONF": __name__,
     "SECRET_KEY": "********",
     "TEMPLATES": [

--- a/tests/integration/test_django.py
+++ b/tests/integration/test_django.py
@@ -608,7 +608,7 @@ def test_old_style_on_exception_response_middleware(middleware_index, tracked_re
 
 class OldStyleExceptionOnRequestMiddleware:
     def process_request(self, request):
-        return ValueError("Woops!")
+        raise ValueError("Woops!")
 
 
 @skip_unless_old_style_middleware
@@ -623,7 +623,9 @@ def test_old_style_exception_on_request_middleware(middleware_index, tracked_req
         + [__name__ + "." + OldStyleExceptionOnRequestMiddleware.__name__]
         + settings.MIDDLEWARE_CLASSES[middleware_index:]
     )
-    with app_with_scout(MIDDLEWARE_CLASSES=new_middleware) as app:
+    with app_with_scout(
+        MIDDLEWARE_CLASSES=new_middleware, DEBUG_PROPAGATE_EXCEPTIONS=False
+    ) as app:
         response = TestApp(app).get("/", expect_errors=True)
 
     assert response.status_int == 500
@@ -640,7 +642,9 @@ def test_old_style_timing_middleware_deleted(url, expected_status, tracked_reque
     but OldStyleViewMiddleware defends against this.
     """
     new_middleware = settings.MIDDLEWARE_CLASSES[1:]
-    with app_with_scout(MIDDLEWARE_CLASSES=new_middleware) as app:
+    with app_with_scout(
+        MIDDLEWARE_CLASSES=new_middleware, DEBUG_PROPAGATE_EXCEPTIONS=False
+    ) as app:
         response = TestApp(app).get(url, expect_errors=True)
 
     assert response.status_int == expected_status

--- a/tests/integration/test_django.py
+++ b/tests/integration/test_django.py
@@ -150,7 +150,7 @@ def test_not_found(tracked_requests):
 
 
 def test_server_error(tracked_requests):
-    with app_with_scout() as app:
+    with app_with_scout(DEBUG_PROPAGATE_EXCEPTIONS=False) as app:
         response = TestApp(app).get("/crash/", expect_errors=True)
 
     assert response.status_int == 500
@@ -310,7 +310,7 @@ def test_no_monitor(tracked_requests):
 
 
 def test_no_monitor_server_error(tracked_requests):
-    with app_with_scout(SCOUT_MONITOR=False) as app:
+    with app_with_scout(SCOUT_MONITOR=False, DEBUG_PROPAGATE_EXCEPTIONS=False) as app:
         response = TestApp(app).get("/crash/", expect_errors=True)
 
     assert response.status_int == 500


### PR DESCRIPTION
I've been uncommenting these enough during different test workflows that I think it's better to have them permanently on and disable them in the few tests that need to.