### PR TITLE
Configure isort to always require all __future__ imports

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,12 +20,16 @@ max-line-length = 88
 # flake8-coding
 accept-encodings = utf-8
 
-[isort]
+[isort]\
+add_imports =
+    from __future__ import absolute_import
+    from __future__ import division
+    from __future__ import print_function
+    from __future__ import unicode_literals
 default_section = THIRDPARTY
 force_grid_wrap = 0
 include_trailing_comma = True
 known_first_party = scout_apm,tests
 line_length = 88
 multi_line_output = 3
-not_skip = __init__.py
 use_parentheses = True

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup_args = {
     "zip_safe": False,
     "python_requires": ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4",
     "packages": find_packages("src"),
-    "package_dir": {"": "src"},
+    "package_dir": {str(""): str("src")},
     "py_modules": [os.splitext(os.basename(path))[0] for path in glob("src/*.py")],
     "ext_modules": [
         Extension(

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,6 @@
 # coding=utf-8
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import os
 import sys
 from glob import glob
@@ -32,7 +34,9 @@ setup_args = {
     "package_dir": {"": "src"},
     "py_modules": [os.splitext(os.basename(path))[0] for path in glob("src/*.py")],
     "ext_modules": [
-        Extension("scout_apm.core.objtrace", ["src/scout_apm/core/ext/objtrace.c"])
+        Extension(
+            str("scout_apm.core.objtrace"), [str("src/scout_apm/core/ext/objtrace.c")]
+        )
     ],
     "entry_points": {
         "console_scripts": [

--- a/src/scout_apm/core/monkey.py
+++ b/src/scout_apm/core/monkey.py
@@ -1,4 +1,5 @@
 # flake8: noqa
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 # Originally taken from https://pypi.python.org/pypi/ProxyTypes
 # Inlined due to python3 issues with setup.py

--- a/src/scout_apm/core/web_requests.py
+++ b/src/scout_apm/core/web_requests.py
@@ -1,4 +1,6 @@
 # coding=utf-8
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import time
 
 from scout_apm.compat import datetime_to_timestamp, urlencode

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
 # coding=utf-8
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import logging
 import os
 

--- a/tests/integration/app.py
+++ b/tests/integration/app.py
@@ -14,6 +14,8 @@ Configure it with the SCOUT_MONITOR, SCOUT_KEY, and SCOUT_NAME env variables.
 
 """
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import scout_apm.api
 from tests.integration import test_bottle, test_django, test_flask, test_pyramid
 

--- a/tests/integration/core/__init__.py
+++ b/tests/integration/core/__init__.py
@@ -1,1 +1,2 @@
 # coding=utf-8
+from __future__ import absolute_import, division, print_function, unicode_literals


### PR DESCRIPTION
Most files already have them, but missing them in some files could lead to bugs, especially with `unicode_literals`.