### PR TITLE
Fix logging warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Pending
+
+### Fixed
+
+- Fix warning emitted from using deprecated 'warn' method
+  ([PR #283](https://github.com/scoutapp/scout_apm_python/pull/283)).
+
 ## [2.6.0] 2019-10-22
 
 ### Deprecated

--- a/src/scout_apm/core/core_agent_manager.py
+++ b/src/scout_apm/core/core_agent_manager.py
@@ -89,7 +89,7 @@ class CoreAgentManager(object):
         # Old deprecated name "log_level"
         log_level = AgentContext.instance.config.value("log_level")
         if log_level is not None:
-            logger.warn(
+            logger.warning(
                 "The config name 'log_level' is deprecated - "
                 + "please use the new name 'core_agent_log_level' instead."
             )


### PR DESCRIPTION
Fix this warning from emittig this warning:

> DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead