### PR TITLE
Pin to major versions of requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
             "core-agent-manager = scout_apm.core.cli.core_agent_manager:main"
         ]
     },
-    install_requires=["psutil", "requests"],
+    install_requires=["psutil>=5,<6", "requests>=2,<3"],
     keywords="apm performance monitoring development",
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
This will prevent new releases from breaking us unexpectedly.