### PR TITLE
Deduplicate Werkzeug request data tracking

### DIFF
--- a/src/scout_apm/flask/__init__.py
+++ b/src/scout_apm/flask/__init__.py
@@ -8,12 +8,7 @@ import scout_apm.core
 from scout_apm.core.config import ScoutConfig
 from scout_apm.core.monkey import CallableProxy
 from scout_apm.core.tracked_request import TrackedRequest
-from scout_apm.core.web_requests import (
-    create_filtered_path,
-    ignore_path,
-    track_amazon_request_queue_time,
-    track_request_queue_time,
-)
+from scout_apm.core.web_requests import werkzeug_track_request_data
 
 
 class ScoutApm(object):
@@ -72,30 +67,7 @@ class ScoutApm(object):
         span = tracked_request.start_span(operation=operation)
         span.tag("name", name)
 
-        path = request.path
-        tracked_request.tag(
-            "path", create_filtered_path(path, request.args.items(multi=True))
-        )
-        if ignore_path(path):
-            tracked_request.tag("ignore_transaction", True)
-
-        # Determine a remote IP to associate with the request. The value is
-        # spoofable by the requester so this is not suitable to use in any
-        # security sensitive context.
-        user_ip = (
-            request.headers.get("x-forwarded-for", default="").split(",")[0]
-            or request.headers.get("client-ip", default="").split(",")[0]
-            or request.remote_addr
-        )
-        tracked_request.tag("user_ip", user_ip)
-
-        queue_time = request.headers.get(
-            "x-queue-start", default=""
-        ) or request.headers.get("x-request-start", default="")
-        tracked = track_request_queue_time(queue_time, tracked_request)
-        if not tracked:
-            amazon_queue_time = request.headers.get("x-amzn-trace-id", default="")
-            track_amazon_request_queue_time(amazon_queue_time, tracked_request)
+        werkzeug_track_request_data(request, tracked_request)
 
         try:
             return wrapped(*args, **kwargs)

--- a/src/scout_apm/nameko.py
+++ b/src/scout_apm/nameko.py
@@ -7,12 +7,7 @@ from werkzeug.wrappers import Request
 
 import scout_apm.core
 from scout_apm.core.tracked_request import TrackedRequest
-from scout_apm.core.web_requests import (
-    create_filtered_path,
-    ignore_path,
-    track_amazon_request_queue_time,
-    track_request_queue_time,
-)
+from scout_apm.core.web_requests import werkzeug_track_request_data
 
 
 class ScoutReporter(DependencyProvider):
@@ -47,30 +42,7 @@ class ScoutReporter(DependencyProvider):
         if not isinstance(request, Request):
             return
 
-        path = request.path
-        tracked_request.tag(
-            "path", create_filtered_path(path, request.args.items(multi=True))
-        )
-        if ignore_path(path):
-            tracked_request.tag("ignore_transaction", True)
-
-        # Determine a remote IP to associate with the request. The value is
-        # spoofable by the requester so this is not suitable to use in any
-        # security sensitive context.
-        user_ip = (
-            request.headers.get("x-forwarded-for", default="").split(",")[0]
-            or request.headers.get("client-ip", default="").split(",")[0]
-            or request.remote_addr
-        )
-        tracked_request.tag("user_ip", user_ip)
-
-        queue_time = request.headers.get(
-            "x-queue-start", default=""
-        ) or request.headers.get("x-request-start", default="")
-        tracked_queue_time = track_request_queue_time(queue_time, tracked_request)
-        if not tracked_queue_time:
-            amazon_queue_time = request.headers.get("x-amzn-trace-id", default="")
-            track_amazon_request_queue_time(amazon_queue_time, tracked_request)
+        werkzeug_track_request_data(request, tracked_request)
 
     def worker_result(self, worker_ctx, result=None, exc_info=None):
         if self._do_nothing:


### PR DESCRIPTION
Flask and Nameko both use Werkzeug requests, and had basically copy-pasted blocks of code to call the underlying pieces. DRY that out with a single function.