### PR TITLE
Don't omit monkey.py from coverage

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,6 @@ ignore =
 
 [coverage:run]
 branch = True
-omit = src/scout_apm/core/monkey.py
 
 [flake8]
 # core


### PR DESCRIPTION
I simplified it in #175 to only the parts we use. Ideally they should have coverage in our code base, or we should finish moving to `wrapt`.