### PR TITLE
Remove overly cautious header fetching behaviour

### DIFF
--- a/src/scout_apm/pyramid.py
+++ b/src/scout_apm/pyramid.py
@@ -41,40 +41,24 @@ def instruments(handler, registry):
             if ignore_path(path):
                 tracked_request.tag("ignore_transaction", True)
 
-            try:
-                # Determine a remote IP to associate with the request. The value is
-                # spoofable by the requester so this is not suitable to use in any
-                # security sensitive context.
-                user_ip = (
-                    request.headers.get("x-forwarded-for", default="").split(",")[0]
-                    or request.headers.get("client-ip", default="").split(",")[0]
-                    or request.remote_addr
-                )
-            except Exception:
-                pass
-            else:
-                tracked_request.tag("user_ip", user_ip)
+            # Determine a remote IP to associate with the request. The value is
+            # spoofable by the requester so this is not suitable to use in any
+            # security sensitive context.
+            user_ip = (
+                request.headers.get("x-forwarded-for", default="").split(",")[0]
+                or request.headers.get("client-ip", default="").split(",")[0]
+                or request.remote_addr
+            )
+            tracked_request.tag("user_ip", user_ip)
 
             tracked_queue_time = False
-            try:
-                queue_time = request.headers.get(
-                    "x-queue-start", default=""
-                ) or request.headers.get("x-request-start", default="")
-            except Exception:
-                pass
-            else:
-                tracked_queue_time = track_request_queue_time(
-                    queue_time, tracked_request
-                )
+            queue_time = request.headers.get(
+                "x-queue-start", default=""
+            ) or request.headers.get("x-request-start", default="")
+            tracked_queue_time = track_request_queue_time(queue_time, tracked_request)
             if not tracked_queue_time:
-                try:
-                    amazon_queue_time = request.headers.get(
-                        "x-amzn-trace-id", default=""
-                    )
-                except Exception:
-                    pass
-                else:
-                    track_amazon_request_queue_time(amazon_queue_time, tracked_request)
+                amazon_queue_time = request.headers.get("x-amzn-trace-id", default="")
+                track_amazon_request_queue_time(amazon_queue_time, tracked_request)
 
             try:
                 response = handler(request)

--- a/tests/integration/test_bottle.py
+++ b/tests/integration/test_bottle.py
@@ -5,13 +5,12 @@ import datetime as dt
 import sys
 from contextlib import contextmanager
 
-from bottle import Bottle, WSGIHeaderDict
+from bottle import Bottle
 from webtest import TestApp
 
 from scout_apm.api import Config
 from scout_apm.bottle import ScoutPlugin
 from scout_apm.compat import datetime_to_timestamp
-from tests.compat import mock
 from tests.integration.util import (
     parametrize_filtered_params,
     parametrize_queue_time_header_name,

--- a/tests/integration/test_bottle.py
+++ b/tests/integration/test_bottle.py
@@ -100,23 +100,6 @@ def test_user_ip(headers, extra_environ, expected, tracked_requests):
     assert tracked_request.tags["user_ip"] == expected
 
 
-def test_user_ip_error(tracked_requests):
-    orig_headers_get = WSGIHeaderDict.get
-
-    def crashy_get(self, key, *args, **kwargs):
-        if key == "x-forwarded-for":
-            raise ValueError("Don't try get *that* header!")
-        return orig_headers_get(key, *args, **kwargs)
-
-    with mock.patch.object(
-        WSGIHeaderDict, "get", new=crashy_get
-    ), app_with_scout() as app:
-        TestApp(app).get("/")
-
-    tracked_request = tracked_requests[0]
-    assert "user_ip" not in tracked_request.tags
-
-
 @parametrize_queue_time_header_name
 def test_queue_time(header_name, tracked_requests):
     # Not testing floats due to Python 2/3 rounding differences
@@ -131,28 +114,6 @@ def test_queue_time(header_name, tracked_requests):
     queue_time_ns = tracked_requests[0].tags["scout.queue_time_ns"]
     # Upper bound assumes we didn't take more than 2s to run this test...
     assert queue_time_ns >= 2000000000 and queue_time_ns < 4000000000
-
-
-def test_queue_time_error(tracked_requests):
-    """
-    Scout doesn't crash if bottle's Request.headers.get raises an exception.
-
-    This cannot be tested without mocking because it should never happen.
-    """
-    orig_headers_get = WSGIHeaderDict.get
-
-    def crashy_get(self, key, *args, **kwargs):
-        if key == "x-queue-start":
-            raise ValueError("Don't try get *that* header!")
-        return orig_headers_get(key, *args, **kwargs)
-
-    with mock.patch.object(
-        WSGIHeaderDict, "get", new=crashy_get
-    ), app_with_scout() as app:
-        TestApp(app).get("/")
-
-    tracked_request = tracked_requests[0]
-    assert "scout.queue_time_ns" not in tracked_request.tags
 
 
 def test_amazon_queue_time(tracked_requests):

--- a/tests/integration/test_pyramid.py
+++ b/tests/integration/test_pyramid.py
@@ -8,12 +8,10 @@ from contextlib import contextmanager
 import pytest
 from pyramid.config import Configurator
 from pyramid.response import Response
-from webob.headers import EnvironHeaders
 from webtest import TestApp
 
 from scout_apm.api import Config
 from scout_apm.compat import datetime_to_timestamp
-from tests.compat import mock
 from tests.integration.util import (
     parametrize_filtered_params,
     parametrize_queue_time_header_name,


### PR DESCRIPTION
Both the Bottle and Pyramid integrations have this overly cautious behaviour around reading headers from the upstream framework. They both assume that basic framework operations such as fetching a header can fail, and guard around it.

Some of this came from my refactoring for Bottle in #192 and Pyramid in #195, where I narrowed large `try/except` blocks down, but didn't rethink this paranoia.

I think this is too cautious and can be removed. It required a lot of extra lines for the two frameworks when adding Amazon request queue timing in #279, to really no extra effect. If fetching headers (with safe defaults) is broken, users' applications are pretty much guaranteed to be broken too.