### PR TITLE
Change Windows check

### DIFF
--- a/src/scout_apm/core/__init__.py
+++ b/src/scout_apm/core/__init__.py
@@ -2,8 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
-import sys
-from os import getpid
+import os
 
 from kwargs_only import kwargs_only
 
@@ -24,14 +23,16 @@ def install(config=None):
         scout_config.set(**config)
     context = AgentContext.build(config=scout_config)
 
-    if sys.platform == "win32":
-        logger.info("APM Not Launching on PID: %s - Windows is not supported", getpid())
+    if os.name == "nt":
+        logger.info(
+            "APM Not Launching on PID: %s - Windows is not supported", os.getpid()
+        )
         return False
 
     if not context.config.value("monitor"):
         logger.info(
             "APM Not Launching on PID: %s - Configuration 'monitor' is not true",
-            getpid(),
+            os.getpid(),
         )
         return False
 
@@ -39,7 +40,7 @@ def install(config=None):
 
     objtrace.enable()
 
-    logger.debug("APM Launching on PID: %s", getpid())
+    logger.debug("APM Launching on PID: %s", os.getpid())
     launched = CoreAgentManager().launch()
 
     AppMetadata.report()

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import logging
 import os
-import sys
 
 from scout_apm.api import Config
 from scout_apm.core import install
@@ -12,7 +11,7 @@ from tests.compat import mock
 
 
 def test_install_fail_windows(caplog):
-    with mock.patch.object(sys, "platform", new="win32"):
+    with mock.patch.object(os, "name", new="nt"):
         installed = install()
 
     assert installed is False


### PR DESCRIPTION
I saw that flake8's `is_windows()` check prefers `os.name`, and it seems simpler.