### PR TITLE
Span flag should capture backtrace

### DIFF
--- a/src/scout_apm/api/__init__.py
+++ b/src/scout_apm/api/__init__.py
@@ -80,7 +80,9 @@ class Transaction(ContextDecorator):
 
         tracked_request = TrackedRequest.instance()
         tracked_request.mark_real_request()
-        span = tracked_request.start_span(operation=operation)
+        span = tracked_request.start_span(
+            operation=operation, should_capture_backtrace=False
+        )
         for key, value in tags.items():
             tracked_request.tag(key, value)
         return span

--- a/src/scout_apm/bottle.py
+++ b/src/scout_apm/bottle.py
@@ -58,7 +58,10 @@ class ScoutPlugin(object):
                 controller_name = "/home"
             if not controller_name.startswith("/"):
                 controller_name = "/" + controller_name
-            tracked_request.start_span(operation="Controller{}".format(controller_name))
+            tracked_request.start_span(
+                operation="Controller{}".format(controller_name),
+                should_capture_backtrace=False,
+            )
 
             # Determine a remote IP to associate with the request. The
             # value is spoofable by the requester so this is not suitable

--- a/src/scout_apm/django/middleware.py
+++ b/src/scout_apm/django/middleware.py
@@ -86,7 +86,9 @@ class MiddlewareTimingMiddleware(object):
 
         tracked_request = TrackedRequest.instance()
 
-        tracked_request.start_span(operation="Middleware")
+        tracked_request.start_span(
+            operation="Middleware", should_capture_backtrace=False
+        )
         queue_time = request.META.get("HTTP_X_QUEUE_START") or request.META.get(
             "HTTP_X_REQUEST_START", ""
         )
@@ -129,7 +131,7 @@ class ViewTimingMiddleware(object):
 
         # This operation name won't be recorded unless changed later in
         # process_view
-        tracked_request.start_span(operation="Unknown")
+        tracked_request.start_span(operation="Unknown", should_capture_backtrace=False)
         try:
             return self.get_response(request)
         finally:
@@ -182,7 +184,9 @@ class OldStyleMiddlewareTimingMiddleware(object):
                 request.META.get("HTTP_X_AMZN_TRACE_ID", ""), tracked_request
             )
 
-        tracked_request.start_span(operation="Middleware")
+        tracked_request.start_span(
+            operation="Middleware", should_capture_backtrace=False
+        )
 
     def process_response(self, request, response):
         # Only stop span if there's a request, but presume we are balanced,
@@ -206,7 +210,9 @@ class OldStyleViewMiddleware(object):
 
         track_request_view_data(request, tracked_request)
 
-        span = tracked_request.start_span(operation=get_operation_name(request))
+        span = tracked_request.start_span(
+            operation=get_operation_name(request), should_capture_backtrace=False
+        )
         # Save the span into the request, so we can check
         # if we're matched up when stopping
         request._scout_view_span = span

--- a/src/scout_apm/falcon.py
+++ b/src/scout_apm/falcon.py
@@ -96,7 +96,9 @@ class ScoutMiddleware(object):
                 resource.__module__, resource.__class__.__name__, responder.__name__
             )
 
-        span = tracked_request.start_span(operation=operation)
+        span = tracked_request.start_span(
+            operation=operation, should_capture_backtrace=False
+        )
         req.context.scout_resource_span = span
 
     def process_response(self, req, resp, resource, req_succeeded):

--- a/src/scout_apm/flask/__init__.py
+++ b/src/scout_apm/flask/__init__.py
@@ -64,7 +64,9 @@ class ScoutApm(object):
 
         tracked_request = TrackedRequest.instance()
         tracked_request.mark_real_request()
-        span = tracked_request.start_span(operation=operation)
+        span = tracked_request.start_span(
+            operation=operation, should_capture_backtrace=False
+        )
         span.tag("name", name)
 
         werkzeug_track_request_data(request, tracked_request)

--- a/src/scout_apm/nameko.py
+++ b/src/scout_apm/nameko.py
@@ -36,7 +36,7 @@ class ScoutReporter(DependencyProvider):
             + "."
             + worker_ctx.entrypoint.method_name
         )
-        tracked_request.start_span(operation=operation)
+        tracked_request.start_span(operation=operation, should_capture_backtrace=False)
 
     def _track_request_data(self, request, tracked_request):
         if not isinstance(request, Request):

--- a/src/scout_apm/pyramid.py
+++ b/src/scout_apm/pyramid.py
@@ -29,7 +29,9 @@ def includeme(config):
 def instruments(handler, registry):
     def scout_tween(request):
         tracked_request = TrackedRequest.instance()
-        span = tracked_request.start_span(operation="Controller/Pyramid")
+        span = tracked_request.start_span(
+            operation="Controller/Pyramid", should_capture_backtrace=False
+        )
 
         try:
             path = request.path


### PR DESCRIPTION
Use a flag rather than magic string matching. This also:

* Removes the accidentally committed check for the magic string `QueueTime/Request` (from #167, before going in a different direction than using a span) 
* Makes custom instrumented transactions ignore their top level spans, no matter the name, which was skipped before.