### PR TITLE
Lint with flake8-bugbear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,6 @@
   ([PR #304](https://github.com/scoutapp/scout_apm_python/pull/304)).
 - Rewrite background samplers thread to avoid some rare race conditions
   ([PR #307](https://github.com/scoutapp/scout_apm_python/pull/307)).
-- Removed mutable default tags from `instrument()`, `BackgroundTransaction`,
-  `Transaction`, and `WebTransaction`. If you've been having problems with tags
-  being shared between instruments or transactions, these should have been
-  fixed ([PR #316](https://github.com/scoutapp/scout_apm_python/pull/316)).
-
 
 ## [2.6.1] 2019-10-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
   ([PR #304](https://github.com/scoutapp/scout_apm_python/pull/304)).
 - Rewrite background samplers thread to avoid some rare race conditions
   ([PR #307](https://github.com/scoutapp/scout_apm_python/pull/307)).
+- Removed mutable default tags from `instrument()`, `BackgroundTransaction`,
+  `Transaction`, and `WebTransaction`. If you've been having problems with tags
+  being shared between instruments or transactions, these should have been
+  fixed ([PR #316](https://github.com/scoutapp/scout_apm_python/pull/316)).
+
 
 ## [2.6.1] 2019-10-23
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ branch = True
 # black-recommended setup with flake8-bugbear
 max-line-length = 80
 select = C,E,F,W,B,B950
-ignore = E501,W503
+ignore = E203,E501,W503
 # flake8-coding
 accept-encodings = utf-8
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,8 +14,10 @@ branch = True
 
 [flake8]
 # core
-ignore = E203,W503
-max-line-length = 88
+# black-recommended setup with flake8-bugbear
+max-line-length = 80
+select = C,E,F,W,B,B950
+ignore = E501,W503
 # flake8-coding
 accept-encodings = utf-8
 

--- a/src/scout_apm/core/instrument_manager.py
+++ b/src/scout_apm/core/instrument_manager.py
@@ -19,7 +19,7 @@ class InstrumentManager(object):
             installable = getattr(installable, klass)
             installable = installable(*args, **kwargs)
 
-            result = getattr(installable, "install")()
+            result = installable.install()
             return result
         except Exception as e:
             logger.info("Exception while installing instrument %s: %r", module_name, e)

--- a/src/scout_apm/core/web_requests.py
+++ b/src/scout_apm/core/web_requests.py
@@ -8,7 +8,7 @@ from scout_apm.core.context import AgentContext
 
 # Originally derived from:
 # 1. Rails:
-#   https://github.com/rails/rails/blob/0196551e6039ca864d1eee1e01819fcae12c1dc9/railties/lib/rails/generators/rails/app/templates/config/initializers/filter_parameter_logging.rb.tt
+#   https://github.com/rails/rails/blob/0196551e6039ca864d1eee1e01819fcae12c1dc9/railties/lib/rails/generators/rails/app/templates/config/initializers/filter_parameter_logging.rb.tt  # noqa
 # 2. Sentry server side scrubbing:
 #   https://docs.sentry.io/data-management/sensitive-data/#server-side-scrubbing
 FILTER_PARAMETERS = frozenset(

--- a/tests/integration/core/test_core_agent_manager.py
+++ b/tests/integration/core/test_core_agent_manager.py
@@ -39,7 +39,7 @@ def is_running(core_agent_manager):
         return True
     if b"Agent Not Running" in probe:
         return False
-    assert False, "cannot tell if the core agent is running"
+    raise AssertionError("cannot tell if the core agent is running")
 
 
 def shutdown(core_agent_manager):

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -72,7 +72,7 @@ def test_instrument_decorator_default_tags(tracked_request):
 
     assert len(tracked_request.active_spans) == 0
     assert len(tracked_request.complete_spans) == 1
-    assert tracked_request.complete_spans[0].tags["x"] == 99
+    assert tracked_request.complete_spans[0].tags == {"x": 99}
 
 
 def test_instrument_non_ascii_params(tracked_request):
@@ -137,6 +137,16 @@ def test_web_transaction_decorator(tracked_request):
     assert tracked_request.complete_spans[0].operation == "Controller/Bar"
 
 
+def test_web_transaction_default_tags(tracked_request):
+    @WebTransaction("Bar", tags={"x": 99})
+    def my_transaction():
+        pass
+
+    my_transaction()
+
+    assert tracked_request.tags["x"] == 99
+
+
 def test_web_transaction_non_ascii_params(tracked_request):
     @WebTransaction("Acheter du café")
     def buy_coffee():
@@ -194,6 +204,16 @@ def test_background_transaction_decorator(tracked_request):
     assert tracked_request.complete_spans[0].operation == "Job/Bar"
 
 
+def test_background_transaction_default_tags(tracked_request):
+    @BackgroundTransaction("Bar", tags={"x": 99})
+    def my_transaction():
+        pass
+
+    my_transaction()
+
+    assert tracked_request.tags["x"] == 99
+
+
 def test_background_transaction_non_ascii_params(tracked_request):
     @BackgroundTransaction("Acheter du café")
     def buy_coffee():
@@ -243,3 +263,11 @@ def test_rename_transaction(tracked_request):
     rename_transaction("Unit Test")
 
     assert tracked_request.tags["transaction.name"] == "Unit Test"
+
+
+def test_rename_transaction_none(tracked_request):
+    assert "transaction.name" not in tracked_request.tags
+
+    rename_transaction(None)
+
+    assert "transaction.name" not in tracked_request.tags

--- a/tox.ini
+++ b/tox.ini
@@ -60,6 +60,7 @@ deps =
     check-manifest
     black
     flake8
+    flake8-bugbear
     flake8-coding
     isort
     twine


### PR DESCRIPTION
Add this Flake8 plugin which has some good extra rules and is the recommended way of checking about Black's line length.

Fix these issues it flagged:

```
src/scout_apm/core/instrument_manager.py:22:22: B009 Do not call getattr with a constant attribute value, it is not any safer than normal property access.
src/scout_apm/core/web_requests.py:11:182: B950 line too long (181 > 80 characters)
src/scout_apm/api/__init__.py:45:55: B006 Do not use mutable data structures for argument defaults.  They are created during function definition time. All calls to the function reuse this one instance of that data structure, persisting changes between them.
src/scout_apm/api/__init__.py:73:35: B006 Do not use mutable data structures for argument defaults.  They are created during function definition time. All calls to the function reuse this one instance of that data structure, persisting changes between them.
src/scout_apm/api/__init__.py:78:37: B006 Do not use mutable data structures for argument defaults.  They are created during function definition time. All calls to the function reuse this one instance of that data structure, persisting changes between them.
src/scout_apm/api/__init__.py:108:31: B006 Do not use mutable data structures for argument defaults.  They are created during function definition time. All calls to the function reuse this one instance of that data structure, persisting changes between them.
src/scout_apm/api/__init__.py:117:31: B006 Do not use mutable data structures for argument defaults.  They are created during function definition time. All calls to the function reuse this one instance of that data structure, persisting changes between them.
tests/integration/app.py:103:66: E203 whitespace before ':'
tests/integration/core/test_core_agent_manager.py:42:5: B011 Do not call assert False since python -O removes these calls. Instead callers should raise AssertionError().
```