### PR TITLE
Remove module-based test skips

### DIFF
--- a/tests/integration/instruments/test_elasticsearch.py
+++ b/tests/integration/instruments/test_elasticsearch.py
@@ -13,9 +13,10 @@ from tests.tools import pretend_package_unavailable
 
 # e.g. export ELASTICSEARCH_URL="http://localhost:9200/"
 ELASTICSEARCH_URL = os.environ.get("ELASTICSEARCH_URL")
-if ELASTICSEARCH_URL is None:
-    pytest.skip("Elasticsearch isn't available", allow_module_level=True)
 
+skip_if_elasticsearch_not_running = pytest.mark.skipif(
+    ELASTICSEARCH_URL is None, reason="MongoDB isn't available"
+)
 
 instrument = Instrument()
 
@@ -34,21 +35,25 @@ def es_with_scout():
         instrument.uninstall()
 
 
+@skip_if_elasticsearch_not_running
 def test_search():
     with es_with_scout() as es:
         es.search()
 
 
+@skip_if_elasticsearch_not_running
 def test_search_no_indexes_string():
     with es_with_scout() as es:
         es.search(index="", body={"query": {"term": {"user": "kimchy"}}})
 
 
+@skip_if_elasticsearch_not_running
 def test_search_no_indexes_list():
     with es_with_scout() as es:
         es.search(index=[], body={"query": {"term": {"user": "kimchy"}}})
 
 
+@skip_if_elasticsearch_not_running
 def test_perform_request_missing_url():
     with es_with_scout() as es:
         with pytest.raises(TypeError):
@@ -57,6 +62,7 @@ def test_perform_request_missing_url():
             es.transport.perform_request("GET", params={}, body=None)
 
 
+@skip_if_elasticsearch_not_running
 def test_perform_request_bad_url():
     with es_with_scout() as es:
         with pytest.raises(TypeError):
@@ -65,6 +71,7 @@ def test_perform_request_bad_url():
             es.transport.perform_request("GET", None, params={}, body=None)
 
 
+@skip_if_elasticsearch_not_running
 def test_perform_request_unknown_url():
     with es_with_scout() as es:
         # Transport instrumentation doesn't crash if url is unknown.

--- a/tests/integration/instruments/test_pymongo.py
+++ b/tests/integration/instruments/test_pymongo.py
@@ -13,9 +13,10 @@ from tests.tools import pretend_package_unavailable
 
 # e.g. export MONGODB_URL="mongodb://localhost:27017/"
 MONGODB_URL = os.environ.get("MONGODB_URL")
-if MONGODB_URL is None:
-    pytest.skip("MongoDB isn't available", allow_module_level=True)
 
+skip_if_mongodb_not_running = pytest.mark.skipif(
+    MONGODB_URL is None, reason="MongoDB isn't available"
+)
 
 instrument = Instrument()
 
@@ -34,11 +35,13 @@ def client_with_scout():
         instrument.uninstall()
 
 
+@skip_if_mongodb_not_running
 def test_find_one():
     with client_with_scout() as client:
         client.local.startup_log.find_one()
 
 
+@skip_if_mongodb_not_running
 def test_installed():
     assert not Instrument.installed
     with client_with_scout():
@@ -46,6 +49,7 @@ def test_installed():
     assert not Instrument.installed
 
 
+@skip_if_mongodb_not_running
 def test_installable():
     assert instrument.installable()
     with client_with_scout():

--- a/tests/integration/instruments/test_redis.py
+++ b/tests/integration/instruments/test_redis.py
@@ -13,9 +13,9 @@ from tests.tools import pretend_package_unavailable
 
 # e.g. export REDIS_URL="redis://localhost:6379/0"
 REDIS_URL = os.environ.get("REDIS_URL")
-if REDIS_URL is None:
-    pytest.skip("Redis isn't available", allow_module_level=True)
-
+skip_if_redis_not_running = pytest.mark.skipif(
+    REDIS_URL is None, reason="Redis isn't available"
+)
 
 instrument = Instrument()
 
@@ -35,11 +35,13 @@ def redis_with_scout():
         pass
 
 
+@skip_if_redis_not_running
 def test_echo():
     with redis_with_scout() as r:
         r.echo("Hello World!")
 
 
+@skip_if_redis_not_running
 def test_pipe_echo():
     with redis_with_scout() as r:
         with r.pipeline() as p:
@@ -47,6 +49,7 @@ def test_pipe_echo():
             p.execute()
 
 
+@skip_if_redis_not_running
 def test_perform_request_missing_url():
     with redis_with_scout() as r:
         with pytest.raises(IndexError):
@@ -56,6 +59,7 @@ def test_perform_request_missing_url():
             r.execute_command()
 
 
+@skip_if_redis_not_running
 def test_perform_request_bad_url():
     with redis_with_scout() as r:
         with pytest.raises(TypeError):

--- a/tests/integration/instruments/test_urllib3.py
+++ b/tests/integration/instruments/test_urllib3.py
@@ -14,9 +14,9 @@ from tests.tools import pretend_package_unavailable
 # e.g. export URLLIB3_URL="http://httpbin.org/"
 # or export URLLIB3_URL="http://localhost:9200/" (re-use Elasticsearch!)
 URLLIB3_URL = os.environ.get("URLLIB3_URL")
-if URLLIB3_URL is None:
-    pytest.skip("HTTP test server isn't available", allow_module_level=True)
-
+skip_if_urllib3_url_unavailable = pytest.mark.skipif(
+    URLLIB3_URL is None, reason="urllib3 URL isn't available"
+)
 
 instrument = Instrument()
 
@@ -34,6 +34,7 @@ def urllib3_with_scout():
         instrument.uninstall()
 
 
+@skip_if_urllib3_url_unavailable
 def test_request():
     with urllib3_with_scout():
         http = urllib3.PoolManager()
@@ -41,6 +42,7 @@ def test_request():
         assert response.status == 200
 
 
+@skip_if_urllib3_url_unavailable
 # I can't trigger a failure to get instrument data through a public API.
 # Somewhat surprisingly, the request still succeeds.
 @mock.patch("urllib3.HTTPConnectionPool._absolute_url", side_effect=RuntimeError)

--- a/tests/integration/test_dramatiq.py
+++ b/tests/integration/test_dramatiq.py
@@ -1,22 +1,26 @@
 # coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import sys
 from collections import namedtuple
 from contextlib import contextmanager
 
 import pytest
 
-if sys.version_info < (3, 5):  # Minimum version dramatiq should be installable on
-    pytest.skip(
-        "Dramatiq not installable on this Python version", allow_module_level=True
-    )
-else:
+try:
     import dramatiq
+except ImportError:
+    dramatiq = None
+else:
     from dramatiq.brokers.stub import StubBroker
 
     from scout_apm.api import Config
     from scout_apm.dramatiq import ScoutMiddleware
+
+
+skip_if_dramatiq_unavailable = pytest.mark.skipif(
+    dramatiq is None, reason="Dramatiq isn't available"
+)
+pytestmark = [skip_if_dramatiq_unavailable]
 
 
 @contextmanager


### PR DESCRIPTION
For two reasons:

1. These cause the test modules to not be collected so the tests don't even count as skipped in Pytest's output
2. Many of the tests within the modules don't actually rely on running servers so it's best to run them when we can!