### PR TITLE
Make config object global

### DIFF
--- a/src/scout_apm/bottle.py
+++ b/src/scout_apm/bottle.py
@@ -4,8 +4,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from bottle import request
 
 import scout_apm.core
-from scout_apm.core.config import ScoutConfig
-from scout_apm.core.context import AgentContext
+from scout_apm.core.config import scout_config
 from scout_apm.core.tracked_request import TrackedRequest
 from scout_apm.core.web_requests import (
     create_filtered_path,
@@ -21,21 +20,19 @@ class ScoutPlugin(object):
         self.api = 2
 
     def set_config_from_bottle(self, app):
-        scout_config = ScoutConfig()
         bottle_configs = {}
-        for k in scout_config.known_keys():
-            value = app.config.get("scout.{}".format(k))
+        for key in scout_config.known_keys():
+            value = app.config.get("scout.{}".format(key))
             if value is not None and value != "":
-                bottle_configs[k] = value
+                bottle_configs[key] = value
         scout_config.set(**bottle_configs)
-        return scout_config
 
     def setup(self, app):
         self.set_config_from_bottle(app)
         scout_apm.core.install()
 
     def apply(self, callback, context):
-        if not AgentContext.instance.config.value("monitor"):
+        if not scout_config.value("monitor"):
             return callback
 
         def wrapper(*args, **kwargs):

--- a/src/scout_apm/core/__init__.py
+++ b/src/scout_apm/core/__init__.py
@@ -7,7 +7,7 @@ import os
 from kwargs_only import kwargs_only
 
 from scout_apm.core import objtrace
-from scout_apm.core.config import ScoutConfig
+from scout_apm.core.config import scout_config
 from scout_apm.core.context import AgentContext
 from scout_apm.core.core_agent_manager import CoreAgentManager
 from scout_apm.core.instrument_manager import InstrumentManager
@@ -18,10 +18,9 @@ logger = logging.getLogger(__name__)
 
 @kwargs_only
 def install(config=None):
-    scout_config = ScoutConfig()
     if config is not None:
         scout_config.set(**config)
-    context = AgentContext.build(config=scout_config)
+    AgentContext.build()
 
     if os.name == "nt":
         logger.info(
@@ -29,7 +28,7 @@ def install(config=None):
         )
         return False
 
-    if not context.config.value("monitor"):
+    if not scout_config.value("monitor"):
         logger.info(
             "APM Not Launching on PID: %s - Configuration 'monitor' is not true",
             os.getpid(),

--- a/src/scout_apm/core/config.py
+++ b/src/scout_apm/core/config.py
@@ -295,3 +295,6 @@ CONVERSIONS = {
     "disabled_instruments": convert_to_list,
     "ignore": convert_to_list,
 }
+
+
+scout_config = ScoutConfig()

--- a/src/scout_apm/core/context.py
+++ b/src/scout_apm/core/context.py
@@ -1,16 +1,15 @@
 # coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from scout_apm.core.config import ScoutConfig
+from scout_apm.core.config import scout_config
 from scout_apm.core.socket import CoreAgentSocket
 
 
 class AgentContext(object):
     instance = None
 
-    def __init__(self, *args, **kwargs):
-        self.config = kwargs.get("config", ScoutConfig())
-        self.config.log()
+    def __init__(self):
+        scout_config.log()
 
     @classmethod
     def build(cls, *args, **kwargs):
@@ -19,4 +18,4 @@ class AgentContext(object):
 
     @classmethod
     def socket(cls):
-        return CoreAgentSocket.instance(scout_config=ScoutConfig())
+        return CoreAgentSocket.instance()

--- a/src/scout_apm/core/core_agent_manager.py
+++ b/src/scout_apm/core/core_agent_manager.py
@@ -11,7 +11,7 @@ import time
 
 import requests
 
-from scout_apm.core.context import AgentContext
+from scout_apm.core.config import scout_config
 
 logger = logging.getLogger(__name__)
 
@@ -21,16 +21,15 @@ class CoreAgentManager(object):
         self.core_agent_bin_path = None
         self.core_agent_bin_version = None
         self.core_agent_dir = "{}/{}".format(
-            AgentContext.instance.config.value("core_agent_dir"),
-            AgentContext.instance.config.value("core_agent_full_name"),
+            scout_config.value("core_agent_dir"),
+            scout_config.value("core_agent_full_name"),
         )
         self.downloader = CoreAgentDownloader(
-            self.core_agent_dir,
-            AgentContext.instance.config.value("core_agent_full_name"),
+            self.core_agent_dir, scout_config.value("core_agent_full_name")
         )
 
     def launch(self):
-        if not AgentContext.instance.config.value("core_agent_launch"):
+        if not scout_config.value("core_agent_launch"):
             logger.debug(
                 "Not attempting to launch Core Agent "
                 "due to 'core_agent_launch' setting."
@@ -38,7 +37,7 @@ class CoreAgentManager(object):
             return False
 
         if not self.verify():
-            if not AgentContext.instance.config.value("core_agent_download"):
+            if not scout_config.value("core_agent_download"):
                 logger.debug(
                     "Not attempting to download Core Agent due "
                     "to 'core_agent_download' setting."
@@ -82,12 +81,12 @@ class CoreAgentManager(object):
         return ["--daemonize", "true"]
 
     def socket_path(self):
-        socket_path = AgentContext.instance.config.value("socket_path")
+        socket_path = scout_config.value("socket_path")
         return ["--socket", socket_path]
 
     def log_level(self):
         # Old deprecated name "log_level"
-        log_level = AgentContext.instance.config.value("log_level")
+        log_level = scout_config.value("log_level")
         if log_level is not None:
             logger.warning(
                 "The config name 'log_level' is deprecated - "
@@ -96,18 +95,18 @@ class CoreAgentManager(object):
                 + "framework settings as SCOUT_LOG_LEVEL."
             )
         else:
-            log_level = AgentContext.instance.config.value("core_agent_log_level")
+            log_level = scout_config.value("core_agent_log_level")
         return ["--log-level", log_level]
 
     def log_file(self):
-        path = AgentContext.instance.config.value("log_file")
+        path = scout_config.value("log_file")
         if path is not None:
             return ["--log-file", path]
         else:
             return []
 
     def config_file(self):
-        path = AgentContext.instance.config.value("config_file")
+        path = scout_config.value("config_file")
         if path is not None:
             return ["--config-file", path]
         else:
@@ -160,9 +159,7 @@ class CoreAgentDownloader(object):
 
     def create_core_agent_dir(self):
         try:
-            os.makedirs(
-                self.destination, AgentContext.instance.config.core_agent_permissions()
-            )
+            os.makedirs(self.destination, scout_config.core_agent_permissions())
         except OSError:
             pass
 
@@ -210,7 +207,7 @@ class CoreAgentDownloader(object):
         )
 
     def root_url(self):
-        return AgentContext.instance.config.value("download_url")
+        return scout_config.value("download_url")
 
 
 class CoreAgentManifest(object):

--- a/src/scout_apm/core/instrument_manager.py
+++ b/src/scout_apm/core/instrument_manager.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import importlib
 import logging
 
-from scout_apm.core.context import AgentContext
+from scout_apm.core.config import scout_config
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +35,6 @@ class InstrumentManager(object):
             )
 
     def is_disabled(self, module_name):
-        disabled = AgentContext.instance.config.value("disabled_instruments")
+        disabled = scout_config.value("disabled_instruments")
         if module_name in disabled:
             return True

--- a/src/scout_apm/core/metadata.py
+++ b/src/scout_apm/core/metadata.py
@@ -7,6 +7,7 @@ import sys
 from os import getpid
 
 from scout_apm.core.commands import ApplicationEvent
+from scout_apm.core.config import scout_config
 from scout_apm.core.context import AgentContext
 
 logger = logging.getLogger(__name__)
@@ -25,25 +26,24 @@ class AppMetadata(object):
 
     @classmethod
     def data(cls):
-        config = AgentContext.instance.config
         try:
             data = {
                 "language": "python",
                 "version": "{}.{}.{}".format(*sys.version_info[:3]),
                 "server_time": dt.datetime.utcnow().isoformat() + "Z",
-                "framework": config.value("framework"),
-                "framework_version": config.value("framework_version"),
+                "framework": scout_config.value("framework"),
+                "framework_version": scout_config.value("framework_version"),
                 "environment": "",
-                "app_server": config.value("app_server"),
-                "hostname": config.value("hostname"),
+                "app_server": scout_config.value("app_server"),
+                "hostname": scout_config.value("hostname"),
                 "database_engine": "",  # Detected
                 "database_adapter": "",  # Raw
                 "application_name": "",  # Environment.application_name,
                 "libraries": cls.get_python_packages_versions(),
                 "paas": "",
-                "application_root": config.value("application_root"),
-                "scm_subdirectory": config.value("scm_subdirectory"),
-                "git_sha": config.value("revision_sha"),
+                "application_root": scout_config.value("application_root"),
+                "scm_subdirectory": scout_config.value("scm_subdirectory"),
+                "git_sha": scout_config.value("revision_sha"),
             }
         except Exception as e:
             logger.debug("Exception in AppMetadata: %r", e)

--- a/src/scout_apm/core/socket.py
+++ b/src/scout_apm/core/socket.py
@@ -11,7 +11,7 @@ import time
 
 from scout_apm.compat import queue
 from scout_apm.core.commands import Register
-from scout_apm.core.config import ScoutConfig
+from scout_apm.core.config import scout_config
 
 SECOND = 1  # time unit - monkey-patched in tests to make them run faster
 
@@ -42,10 +42,8 @@ class CoreAgentSocket(threading.Thread):
 
     def __init__(self, *args, **kwargs):
         threading.Thread.__init__(self)
-        self.config = kwargs.get("scout_config", ScoutConfig())
-
         # Socket related
-        self.socket_path = self.config.value("socket_path")
+        self.socket_path = scout_config.value("socket_path")
         self.socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
 
         # Threading control related
@@ -198,9 +196,9 @@ class CoreAgentSocket(threading.Thread):
     def _register(self):
         self._send(
             Register(
-                app=self.config.value("name"),
-                key=self.config.value("key"),
-                hostname=self.config.value("hostname"),
+                app=scout_config.value("name"),
+                key=scout_config.value("key"),
+                hostname=scout_config.value("hostname"),
             )
         )
 

--- a/src/scout_apm/core/web_requests.py
+++ b/src/scout_apm/core/web_requests.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import time
 
 from scout_apm.compat import datetime_to_timestamp, urlencode
-from scout_apm.core.context import AgentContext
+from scout_apm.core.config import scout_config
 
 # Originally derived from:
 # 1. Rails:
@@ -40,7 +40,7 @@ FILTER_PARAMETERS = frozenset(
 
 
 def create_filtered_path(path, query_params):
-    if AgentContext.instance.config.value("uri_reporting") == "path":
+    if scout_config.value("uri_reporting") == "path":
         return path
     filtered_params = sorted(
         (
@@ -54,7 +54,7 @@ def create_filtered_path(path, query_params):
 
 
 def ignore_path(path):
-    ignored_paths = AgentContext.instance.config.value("ignore")
+    ignored_paths = scout_config.value("ignore")
     for ignored in ignored_paths:
         if path.startswith(ignored):
             return True

--- a/src/scout_apm/django/apps.py
+++ b/src/scout_apm/django/apps.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.test.signals import setting_changed
 
 import scout_apm.core
-from scout_apm.core.config import ScoutConfig
+from scout_apm.core.config import scout_config
 from scout_apm.django.instruments.sql import install_sql_instrumentation
 from scout_apm.django.instruments.template import install_template_instrumentation
 
@@ -47,9 +47,9 @@ class ScoutApmDjangoConfig(AppConfig):
             value = getattr(settings, setting)
         except AttributeError:
             # It was removed
-            ScoutConfig.unset(scout_name)
+            scout_config.unset(scout_name)
         else:
-            ScoutConfig.set(**{scout_name: value})
+            scout_config.set(**{scout_name: value})
 
     def install_middleware(self):
         """

--- a/src/scout_apm/django/middleware.py
+++ b/src/scout_apm/django/middleware.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import django
 from django.conf import settings
 
-from scout_apm.core.config import ScoutConfig
+from scout_apm.core.config import scout_config
 from scout_apm.core.tracked_request import TrackedRequest
 from scout_apm.core.web_requests import (
     create_filtered_path,
@@ -81,7 +81,7 @@ class MiddlewareTimingMiddleware(object):
         self.get_response = get_response
 
     def __call__(self, request):
-        if not ScoutConfig().value("monitor"):
+        if not scout_config.value("monitor"):
             return self.get_response(request)
 
         tracked_request = TrackedRequest.instance()
@@ -124,7 +124,7 @@ class ViewTimingMiddleware(object):
         be recorded.  This can happen if a middleware further along the stack
         doesn't call onward, and instead returns a response directly.
         """
-        if not ScoutConfig().value("monitor"):
+        if not scout_config.value("monitor"):
             return self.get_response(request)
 
         tracked_request = TrackedRequest.instance()
@@ -141,7 +141,7 @@ class ViewTimingMiddleware(object):
         """
         Capture details about the view_func that is about to execute
         """
-        if not ScoutConfig().value("monitor"):
+        if not scout_config.value("monitor"):
             return
         tracked_request = TrackedRequest.instance()
         tracked_request.mark_real_request()
@@ -158,7 +158,7 @@ class ViewTimingMiddleware(object):
 
         Does not modify or catch or otherwise change the exception thrown
         """
-        if not ScoutConfig().value("monitor"):
+        if not scout_config.value("monitor"):
             return
         TrackedRequest.instance().tag("error", "true")
 
@@ -170,7 +170,7 @@ class OldStyleMiddlewareTimingMiddleware(object):
     """
 
     def process_request(self, request):
-        if not ScoutConfig().value("monitor"):
+        if not scout_config.value("monitor"):
             return
         tracked_request = TrackedRequest.instance()
         request._scout_tracked_request = tracked_request

--- a/src/scout_apm/flask/__init__.py
+++ b/src/scout_apm/flask/__init__.py
@@ -5,7 +5,7 @@ from flask import current_app
 from flask.globals import _request_ctx_stack
 
 import scout_apm.core
-from scout_apm.core.config import ScoutConfig
+from scout_apm.core.config import scout_config
 from scout_apm.core.monkey import CallableProxy
 from scout_apm.core.tracked_request import TrackedRequest
 from scout_apm.core.web_requests import werkzeug_track_request_data
@@ -40,7 +40,7 @@ class ScoutApm(object):
                 value = current_app.config[name]
                 clean_name = name.replace("SCOUT_", "").lower()
                 configs[clean_name] = value
-        ScoutConfig.set(**configs)
+        scout_config.set(**configs)
 
     ############################
     #  Request Lifecycle hook  #

--- a/src/scout_apm/pyramid.py
+++ b/src/scout_apm/pyramid.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import scout_apm.core
-from scout_apm.core.config import ScoutConfig
+from scout_apm.core.config import scout_config
 from scout_apm.core.tracked_request import TrackedRequest
 from scout_apm.core.web_requests import (
     create_filtered_path,
@@ -20,7 +20,7 @@ def includeme(config):
             value = pyramid_config[name]
             clean_name = name.replace("SCOUT_", "").lower()
             configs[clean_name] = value
-    ScoutConfig.set(**configs)
+    scout_config.set(**configs)
 
     if scout_apm.core.install():
         config.add_tween("scout_apm.pyramid.instruments")

--- a/tests/integration/core/test_core_agent_manager.py
+++ b/tests/integration/core/test_core_agent_manager.py
@@ -7,7 +7,7 @@ import time
 
 import pytest
 
-from scout_apm.core.config import ScoutConfig
+from scout_apm.core.config import scout_config
 from scout_apm.core.context import AgentContext
 from scout_apm.core.core_agent_manager import CoreAgentManager
 from tests.compat import mock
@@ -19,14 +19,14 @@ def core_agent_manager(core_agent_dir):
     #   Error opening listener on socket: Custom { kind: InvalidInput,
     #   error: StringError("path must be shorter than SUN_LEN") }
     socket_path = "{}/test.sock".format(core_agent_dir)
-    ScoutConfig.set(core_agent_dir=core_agent_dir, socket_path=socket_path)
+    scout_config.set(core_agent_dir=core_agent_dir, socket_path=socket_path)
     AgentContext.build()
     core_agent_manager = CoreAgentManager()
     try:
         yield core_agent_manager
     finally:
         assert not is_running(core_agent_manager)
-        ScoutConfig.reset_all()
+        scout_config.reset_all()
 
 
 def is_running(core_agent_manager):
@@ -52,12 +52,12 @@ def shutdown(core_agent_manager):
 
 
 def test_no_launch(caplog, core_agent_manager):
-    ScoutConfig.set(core_agent_launch=False)
+    scout_config.set(core_agent_launch=False)
 
     try:
         result = core_agent_manager.launch()
     finally:
-        ScoutConfig.set(core_agent_launch=True)
+        scout_config.set(core_agent_launch=True)
 
     assert not result
     assert not is_running(core_agent_manager)
@@ -74,12 +74,12 @@ def test_no_launch(caplog, core_agent_manager):
 
 
 def test_no_verify(caplog, core_agent_manager):
-    ScoutConfig.set(core_agent_download=False)
+    scout_config.set(core_agent_download=False)
 
     try:
         result = core_agent_manager.launch()
     finally:
-        ScoutConfig.set(core_agent_download=True)
+        scout_config.set(core_agent_download=True)
 
     assert not result
     assert not is_running(core_agent_manager)
@@ -141,7 +141,7 @@ def test_launch_error(caplog, core_agent_manager):
 
 
 def test_log_level(caplog, core_agent_manager):
-    ScoutConfig.set(core_agent_log_level="foo")
+    scout_config.set(core_agent_log_level="foo")
 
     result = core_agent_manager.log_level()
 
@@ -150,7 +150,7 @@ def test_log_level(caplog, core_agent_manager):
 
 
 def test_log_level_deprecated(caplog, core_agent_manager):
-    ScoutConfig.set(log_level="foo", core_agent_log_level="bar")
+    scout_config.set(log_level="foo", core_agent_log_level="bar")
 
     result = core_agent_manager.log_level()
 

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -10,6 +10,7 @@ from scout_apm.api import (
     instrument,
     rename_transaction,
 )
+from scout_apm.core.config import scout_config
 
 
 def test_instrument_context_manager(tracked_request):
@@ -245,10 +246,12 @@ def test_context(tracked_request):
 
 
 def test_config():
+    sha = "4de21f8ea228a082d4f039c0c991ee41dfb6f9d8"
     try:
-        Config.set(revision_sha="4de21f8ea228a082d4f039c0c991ee41dfb6f9d8")
+        Config.set(revision_sha=sha)
+        assert scout_config.value("revision_sha") == sha
     finally:
-        Config.reset_all()
+        scout_config.reset_all()
 
 
 def test_ignore_transaction(tracked_request):

--- a/tests/unit/core/test_context.py
+++ b/tests/unit/core/test_context.py
@@ -1,14 +1,8 @@
 # coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from scout_apm.core.config import ScoutConfig
 from scout_apm.core.context import AgentContext
 from scout_apm.core.socket import CoreAgentSocket
-
-
-def test_agent_context_config():
-    context = AgentContext.build()
-    assert isinstance(context.config, ScoutConfig)
 
 
 def test_agent_context_provides_socket():

--- a/tests/unit/core/test_instrument_manager.py
+++ b/tests/unit/core/test_instrument_manager.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from scout_apm.core.config import ScoutConfig
+from scout_apm.core.config import scout_config
 from scout_apm.core.context import AgentContext
 from scout_apm.core.instrument_manager import InstrumentManager
 from tests.compat import mock
@@ -82,7 +82,7 @@ def test_handles_exception():
 
 def test_install_all_installs_only_enabled_instruments():
     # Disable all instruments except the last one.
-    ScoutConfig.set(disabled_instruments=InstrumentManager.DEFAULT_INSTRUMENTS[:-1])
+    scout_config.set(disabled_instruments=InstrumentManager.DEFAULT_INSTRUMENTS[:-1])
     AgentContext.build()
 
     try:
@@ -98,4 +98,4 @@ def test_install_all_installs_only_enabled_instruments():
                 )
             )
     finally:
-        ScoutConfig.reset_all()
+        scout_config.reset_all()

--- a/tests/unit/core/test_web_requests.py
+++ b/tests/unit/core/test_web_requests.py
@@ -7,6 +7,7 @@ import time
 import pytest
 
 from scout_apm.compat import datetime_to_timestamp
+from scout_apm.core.config import scout_config
 from scout_apm.core.context import AgentContext
 from scout_apm.core.web_requests import (
     CUTOFF_EPOCH_S,
@@ -50,11 +51,11 @@ def test_create_filtered_path(path, params, expected):
 def test_create_filtered_path_path(path, params):
     # If config filtered_params is set to "path", expect we always get the path
     # back
-    AgentContext.instance.config.set(uri_reporting="path")
+    scout_config.set(uri_reporting="path")
     try:
         assert create_filtered_path(path, params) == path
     finally:
-        AgentContext.instance.config.reset_all()
+        scout_config.reset_all()
 
 
 @pytest.mark.parametrize(
@@ -62,12 +63,12 @@ def test_create_filtered_path_path(path, params):
     [("/health", True), ("/health/foo", True), ("/users", False), ("/", False)],
 )
 def test_ignore(path, expected):
-    AgentContext.instance.config.set(ignore=["/health"])
+    scout_config.set(ignore=["/health"])
 
     try:
         result = ignore_path(path)
     finally:
-        AgentContext.instance.config.reset_all()
+        scout_config.reset_all()
 
     assert result == expected
 
@@ -84,12 +85,12 @@ def test_ignore(path, expected):
     ],
 )
 def test_ignore_multiple_prefixes(path, expected):
-    AgentContext.instance.config.set(ignore=["/health", "/api"])
+    scout_config.set(ignore=["/health", "/api"])
 
     try:
         result = ignore_path(path)
     finally:
-        AgentContext.instance.config.reset_all()
+        scout_config.reset_all()
 
     assert result == expected
 


### PR DESCRIPTION
Whilst investigating making the agent context configurable with running under async, I realized the `ScoutConfig` class does little as an instance - all the state is stored in globals and classes. Yet we recreate instances all over the place.

This PR turns into a true global object, a single instance of the class, so it's easier to import and share.