### PR TITLE
Attempt to fix timing bug on Travis

### DIFF
--- a/tests/integration/test_bottle.py
+++ b/tests/integration/test_bottle.py
@@ -102,7 +102,7 @@ def test_user_ip(headers, extra_environ, expected, tracked_requests):
 @parametrize_queue_time_header_name
 def test_queue_time(header_name, tracked_requests):
     # Not testing floats due to Python 2/3 rounding differences
-    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow()) - 2)
+    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow())) - 2
     with app_with_scout() as app:
         response = TestApp(app).get(
             "/", headers={header_name: str("t=") + str(queue_start)}
@@ -116,7 +116,7 @@ def test_queue_time(header_name, tracked_requests):
 
 
 def test_amazon_queue_time(tracked_requests):
-    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow()) - 2)
+    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow())) - 2
     with app_with_scout() as app:
         response = TestApp(app).get(
             "/",

--- a/tests/integration/test_django.py
+++ b/tests/integration/test_django.py
@@ -481,7 +481,7 @@ def test_old_style_urlconf(tracked_requests):
 @parametrize_queue_time_header_name
 def test_queue_time(header_name, tracked_requests):
     # Not testing floats due to Python 2/3 rounding differences
-    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow()) - 2)
+    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow())) - 2
     with app_with_scout() as app:
         response = TestApp(app).get(
             "/", headers={header_name: str("t=") + str(queue_start)}
@@ -495,7 +495,7 @@ def test_queue_time(header_name, tracked_requests):
 
 
 def test_amazon_queue_time(tracked_requests):
-    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow()) - 2)
+    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow())) - 2
     with app_with_scout() as app:
         response = TestApp(app).get(
             "/",

--- a/tests/integration/test_falcon.py
+++ b/tests/integration/test_falcon.py
@@ -178,7 +178,7 @@ def test_filtered_params(params, expected_path, tracked_requests):
 @parametrize_queue_time_header_name
 def test_queue_time(header_name, tracked_requests):
     # Not testing floats due to Python 2/3 rounding differences
-    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow()) - 2)
+    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow())) - 2
     with app_with_scout() as app:
         response = TestApp(app).get(
             "/", headers={header_name: str("t=") + str(queue_start)}
@@ -192,7 +192,7 @@ def test_queue_time(header_name, tracked_requests):
 
 
 def test_amazon_queue_time(tracked_requests):
-    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow()) - 2)
+    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow())) - 2
     with app_with_scout() as app:
         response = TestApp(app).get(
             "/",

--- a/tests/integration/test_flask.py
+++ b/tests/integration/test_flask.py
@@ -108,7 +108,7 @@ def test_user_ip(headers, extra_environ, expected, tracked_requests):
 @parametrize_queue_time_header_name
 def test_queue_time(header_name, tracked_requests):
     # Not testing floats due to Python 2/3 rounding differences
-    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow()) - 2)
+    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow())) - 2
     with app_with_scout() as app:
         response = TestApp(app).get(
             "/", headers={header_name: str("t=") + str(queue_start)}
@@ -122,7 +122,7 @@ def test_queue_time(header_name, tracked_requests):
 
 
 def test_amazon_queue_time(tracked_requests):
-    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow()) - 2)
+    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow())) - 2
     with app_with_scout() as app:
         response = TestApp(app).get(
             "/",

--- a/tests/integration/test_nameko.py
+++ b/tests/integration/test_nameko.py
@@ -116,7 +116,7 @@ def test_user_ip(headers, extra_environ, expected, tracked_requests):
 @parametrize_queue_time_header_name
 def test_queue_time(header_name, tracked_requests):
     # Not testing floats due to Python 2/3 rounding differences
-    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow()) - 2)
+    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow())) - 2
     with app_with_scout() as app:
         response = TestApp(app).get(
             "/", headers={header_name: str("t=") + str(queue_start)}
@@ -130,7 +130,7 @@ def test_queue_time(header_name, tracked_requests):
 
 
 def test_amazon_queue_time(tracked_requests):
-    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow()) - 2)
+    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow())) - 2
     with app_with_scout() as app:
         response = TestApp(app).get(
             "/",

--- a/tests/integration/test_pyramid.py
+++ b/tests/integration/test_pyramid.py
@@ -101,7 +101,7 @@ def test_user_ip(headers, extra_environ, expected, tracked_requests):
 @parametrize_queue_time_header_name
 def test_queue_time(header_name, tracked_requests):
     # Not testing floats due to Python 2/3 rounding differences
-    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow()) - 2)
+    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow())) - 2
     with app_with_scout() as app:
         response = TestApp(app).get(
             "/", headers={header_name: str("t=") + str(queue_start)}
@@ -115,7 +115,7 @@ def test_queue_time(header_name, tracked_requests):
 
 
 def test_amazon_queue_time(tracked_requests):
-    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow()) - 2)
+    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow())) - 2
     with app_with_scout() as app:
         response = TestApp(app).get(
             "/",

--- a/tests/unit/core/test_web_requests.py
+++ b/tests/unit/core/test_web_requests.py
@@ -89,7 +89,7 @@ def test_ignore_multiple_prefixes(path, expected):
 
 @pytest.mark.parametrize("with_t", [True, False])
 def test_track_request_queue_time_valid(with_t, tracked_request):
-    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow()) - 2)
+    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow())) - 2
     if with_t:
         header_value = str("t=") + str(queue_start)
     else:
@@ -131,7 +131,7 @@ def test_track_request_queue_time_invalid(header_value, tracked_request):
     ],
 )
 def test_track_amazon_request_queue_time_valid(header_value, tracked_request):
-    start_time = int(datetime_to_timestamp(dt.datetime.utcnow()) - 2)
+    start_time = int(datetime_to_timestamp(dt.datetime.utcnow())) - 2
 
     result = track_amazon_request_queue_time(
         header_value.format(start_time=start_time), tracked_request


### PR DESCRIPTION
Have been seeing rare failures on Travis like:

```
=================================== FAILURES ===================================
_ test_track_amazon_request_queue_time_valid[Root=1-{start_time}-12456789abcdef012345678;CalledFrom=app] _
header_value = 'Root=1-{start_time}-12456789abcdef012345678;CalledFrom=app'
tracked_request = <TrackedRequest(request_id='req-ca2b1c89-b2b7-4f9a-b5a8-ffbde626c511', tags={'scout.queue_time_ns': 1999785984})>
    @pytest.mark.parametrize(
        "header_value",
        [
            "Root=1-{start_time}-12456789abcdef012345678",
            "Root=1-{start_time}-12456789abcdef012345678;CalledFrom=app",
            "Self=1-{start_time}-12456789abcdef012345678",
            "Self=1-{start_time}-12456789abcdef012345678;Root=1-123-abcdef012345678912345678",  # noqa: E501
            "Self=1-{start_time}-12456789abcdef012345678;Root=1-123-abcdef012345678912345678;CalledFrom=app",  # noqa: E501
        ],
    )
    def test_track_amazon_request_queue_time_valid(header_value, tracked_request):
        start_time = int(datetime_to_timestamp(dt.datetime.utcnow()) - 2)

        result = track_amazon_request_queue_time(
            header_value.format(start_time=start_time), tracked_request
        )

        assert result is True
        queue_time_ns = tracked_request.tags["scout.queue_time_ns"]
        # Upper bound assumes we didn't take more than 2s to run this test...
>       assert queue_time_ns >= 2000000000 and queue_time_ns < 4000000000
E       assert (1999785984 >= 2000000000)
```

2 seconds taking just less than 2 seconds, in nanoseconds.

Although they're rare, btween the mulpitle tests using the pattern and mutliple environmetns, it appears in ~1/3 of test runs at the moment.

This is an attempt to fix it by changing the failing pattern to potentially avoid floating point rounding errors.