### PR TITLE
Fix some instrument tests

### DIFF
--- a/tests/integration/instruments/test_elasticsearch.py
+++ b/tests/integration/instruments/test_elasticsearch.py
@@ -79,14 +79,12 @@ def test_perform_request_unknown_url():
 
 
 def test_installed():
-    assert not Instrument.installed
     with es_with_scout():
         assert Instrument.installed
     assert not Instrument.installed
 
 
 def test_installable():
-    assert instrument.installable()
     with es_with_scout():
         assert not instrument.installable()
     assert instrument.installable()

--- a/tests/integration/instruments/test_pymongo.py
+++ b/tests/integration/instruments/test_pymongo.py
@@ -25,7 +25,6 @@ instrument = Instrument()
 def client_with_scout():
     """
     Create an instrumented MongoDB connection.
-
     """
     client = pymongo.MongoClient(MONGODB_URL)
     instrument.install()
@@ -65,7 +64,6 @@ def test_installable_no_pymongo_module():
 def test_install_no_pymongo_module():
     with pretend_package_unavailable("pymongo"):
         assert not instrument.install()
-        assert not Instrument.installed
 
 
 @mock.patch(

--- a/tests/integration/instruments/test_redis.py
+++ b/tests/integration/instruments/test_redis.py
@@ -16,6 +16,7 @@ REDIS_URL = os.environ.get("REDIS_URL")
 skip_if_redis_not_running = pytest.mark.skipif(
     REDIS_URL is None, reason="Redis isn't available"
 )
+pytestmark = [skip_if_redis_not_running]
 
 instrument = Instrument()
 
@@ -35,13 +36,11 @@ def redis_with_scout():
         pass
 
 
-@skip_if_redis_not_running
 def test_echo():
     with redis_with_scout() as r:
         r.echo("Hello World!")
 
 
-@skip_if_redis_not_running
 def test_pipe_echo():
     with redis_with_scout() as r:
         with r.pipeline() as p:
@@ -49,7 +48,6 @@ def test_pipe_echo():
             p.execute()
 
 
-@skip_if_redis_not_running
 def test_perform_request_missing_url():
     with redis_with_scout() as r:
         with pytest.raises(IndexError):
@@ -59,7 +57,6 @@ def test_perform_request_missing_url():
             r.execute_command()
 
 
-@skip_if_redis_not_running
 def test_perform_request_bad_url():
     with redis_with_scout() as r:
         with pytest.raises(TypeError):
@@ -69,14 +66,12 @@ def test_perform_request_bad_url():
 
 
 def test_installed():
-    assert not Instrument.installed
     with redis_with_scout():
         assert Instrument.installed
     assert not Instrument.installed
 
 
 def test_installable():
-    assert instrument.installable()
     with redis_with_scout():
         assert not instrument.installable()
     assert instrument.installable()

--- a/tests/integration/instruments/test_urllib3.py
+++ b/tests/integration/instruments/test_urllib3.py
@@ -54,14 +54,12 @@ def test_urlopen_exception(_absolute_url):
 
 
 def test_installed():
-    assert not Instrument.installed
     with urllib3_with_scout():
         assert Instrument.installed
     assert not Instrument.installed
 
 
 def test_installable():
-    assert instrument.installable()
     with urllib3_with_scout():
         assert not instrument.installable()
     assert instrument.installable()


### PR DESCRIPTION
Since #320 some of these tests have started failing when the respective libraries are not available. To fix them I removed some of the precondition assertions which don't hold if the other tests get skipped, and made some more of the Redis tests automatically get skipped.