### PR TITLE
Move is_real_request to attribute

### DIFF
--- a/src/scout_apm/api/__init__.py
+++ b/src/scout_apm/api/__init__.py
@@ -85,7 +85,7 @@ class Transaction(ContextDecorator):
         operation = text(kind) + "/" + text(name)
 
         tracked_request = TrackedRequest.instance()
-        tracked_request.mark_real_request()
+        tracked_request.is_real_request = True
         span = tracked_request.start_span(
             operation=operation, should_capture_backtrace=False
         )

--- a/src/scout_apm/bottle.py
+++ b/src/scout_apm/bottle.py
@@ -37,7 +37,7 @@ class ScoutPlugin(object):
 
         def wrapper(*args, **kwargs):
             tracked_request = TrackedRequest.instance()
-            tracked_request.mark_real_request()
+            tracked_request.is_real_request = True
 
             path = request.path
             # allitems() is an undocumented bottle internal

--- a/src/scout_apm/celery.py
+++ b/src/scout_apm/celery.py
@@ -17,7 +17,7 @@ def before_publish_callback(headers=None, properties=None, **kwargs):
 
 def prerun_callback(task=None, **kwargs):
     tracked_request = TrackedRequest.instance()
-    tracked_request.mark_real_request()
+    tracked_request.is_real_request = True
 
     start = getattr(task.request, "scout_task_start", None)
     if start is not None:

--- a/src/scout_apm/core/tracked_request.py
+++ b/src/scout_apm/core/tracked_request.py
@@ -30,7 +30,7 @@ class TrackedRequest(ThreadLocalSingleton):
         "active_spans",
         "complete_spans",
         "tags",
-        "_is_real_request",
+        "is_real_request",
         "_memory_start",
         "callset",
     )
@@ -42,7 +42,7 @@ class TrackedRequest(ThreadLocalSingleton):
         self.active_spans = []
         self.complete_spans = []
         self.tags = {}
-        self._is_real_request = False
+        self.is_real_request = False
         self._memory_start = get_rss_in_mb()
         self.callset = NPlusOneCallSet()
         logger.debug("Starting request: %s", self.request_id)
@@ -52,12 +52,6 @@ class TrackedRequest(ThreadLocalSingleton):
         return "<TrackedRequest(request_id={}, tags={})>".format(
             repr(self.request_id), repr(self.tags)
         )
-
-    def mark_real_request(self):
-        self._is_real_request = True
-
-    def is_real_request(self):
-        return self._is_real_request
 
     def tag(self, key, value):
         if key in self.tags:
@@ -111,7 +105,7 @@ class TrackedRequest(ThreadLocalSingleton):
         logger.debug("Stopping request: %s", self.request_id)
         if self.end_time is None:
             self.end_time = dt.datetime.utcnow()
-        if self.is_real_request():
+        if self.is_real_request:
             self.tag("mem_delta", self._get_mem_delta())
             if not self.is_ignored():
                 batch_command = BatchCommand.from_tracked_request(self)

--- a/src/scout_apm/django/middleware.py
+++ b/src/scout_apm/django/middleware.py
@@ -190,7 +190,7 @@ class ViewTimingMiddleware(object):
         if not scout_config.value("monitor"):
             return
         tracked_request = TrackedRequest.instance()
-        tracked_request.mark_real_request()
+        tracked_request.is_real_request = True
 
         track_request_view_data(request, tracked_request)
 
@@ -252,7 +252,7 @@ class OldStyleViewMiddleware(object):
             # don't do anything
             return
 
-        tracked_request.mark_real_request()
+        tracked_request.is_real_request = True
 
         track_request_view_data(request, tracked_request)
 

--- a/src/scout_apm/dramatiq.py
+++ b/src/scout_apm/dramatiq.py
@@ -24,7 +24,7 @@ class ScoutMiddleware(dramatiq.Middleware):
         if self._do_nothing:
             return
         tracked_request = TrackedRequest.instance()
-        tracked_request.mark_real_request()
+        tracked_request.is_real_request = True
         if exception:
             tracked_request.tag("error", "true")
         tracked_request.stop_span()

--- a/src/scout_apm/falcon.py
+++ b/src/scout_apm/falcon.py
@@ -36,7 +36,7 @@ class ScoutMiddleware(object):
 
     def process_request(self, req, resp):
         tracked_request = TrackedRequest.instance()
-        tracked_request.mark_real_request()
+        tracked_request.is_real_request = True
         req.context.scout_tracked_request = tracked_request
 
         path = req.path

--- a/src/scout_apm/flask/__init__.py
+++ b/src/scout_apm/flask/__init__.py
@@ -61,7 +61,7 @@ class ScoutApm(object):
         operation = "Controller/" + name
 
         tracked_request = TrackedRequest.instance()
-        tracked_request.mark_real_request()
+        tracked_request.is_real_request = True
         span = tracked_request.start_span(
             operation=operation, should_capture_backtrace=False
         )

--- a/src/scout_apm/nameko.py
+++ b/src/scout_apm/nameko.py
@@ -19,7 +19,7 @@ class ScoutReporter(DependencyProvider):
         if self._do_nothing:
             return
         tracked_request = TrackedRequest.instance()
-        tracked_request.mark_real_request()
+        tracked_request.is_real_request = True
 
         # Get HTTP details for HTTP handlers
         if isinstance(worker_ctx.entrypoint, HttpRequestHandler):

--- a/src/scout_apm/pyramid.py
+++ b/src/scout_apm/pyramid.py
@@ -69,7 +69,7 @@ def instruments(handler, registry):
                     # Routing further down the call chain. So time it starting
                     # above, but only name it if it gets a name
                     if request.matched_route is not None:
-                        tracked_request.mark_real_request()
+                        tracked_request.is_real_request = True
                         span.operation = "Controller/" + request.matched_route.name
             except Exception:
                 tracked_request.tag("error", "true")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -134,7 +134,7 @@ def tracked_requests():
 
     @wrapt.decorator
     def capture_requests(wrapped, instance, args, kwargs):
-        if instance.is_real_request() and not instance.is_ignored():
+        if instance.is_real_request and not instance.is_ignored():
             requests.append(instance)
         return wrapped(*args, **kwargs)
 

--- a/tests/unit/core/test_tracked_request.py
+++ b/tests/unit/core/test_tracked_request.py
@@ -23,12 +23,7 @@ def test_tracked_request_instance_is_a_singleton():
 
 
 def test_is_real_request_default_false(tracked_request):
-    assert not tracked_request.is_real_request()
-
-
-def test_is_real_request_marked(tracked_request):
-    tracked_request.mark_real_request()
-    assert tracked_request.is_real_request()
+    assert not tracked_request.is_real_request
 
 
 def test_tag_request(tracked_request):
@@ -161,7 +156,7 @@ def test_finish_does_not_capture_memory(tracked_request):
 
 
 def test_finish_does_captures_memory_on_real_requests(tracked_request):
-    tracked_request.mark_real_request()
+    tracked_request.is_real_request = True
     tracked_request.finish()
 
     assert "mem_delta" in tracked_request.tags


### PR DESCRIPTION
Remove the unnecessary level of indirection from the methods. Generally in Python if we have a simple attribute, we don't need to add getters or setters.