### PR TITLE
Improve Redis import pattern

### DIFF
--- a/src/scout_apm/instruments/redis.py
+++ b/src/scout_apm/instruments/redis.py
@@ -7,29 +7,26 @@ import wrapt
 
 from scout_apm.core.tracked_request import TrackedRequest
 
-logger = logging.getLogger(__name__)
-
-
-def import_Redis_and_Pipeline():
-    import redis  # noqa: F401
-
+try:
+    import redis
+except ImportError:
+    redis = None
+else:
     if redis.VERSION[0] >= 3:
-        from redis import Redis  # noqa: F401
-        from redis.client import Pipeline  # noqa: F401
+        from redis import Redis
+        from redis.client import Pipeline
     else:  # pragma: no cover
-        from redis import StrictRedis as Redis  # noqa: F401
-        from redis.client import BasePipeline as Pipeline  # noqa: F401
+        from redis import StrictRedis as Redis
+        from redis.client import BasePipeline as Pipeline
 
-    return Redis, Pipeline
+logger = logging.getLogger(__name__)
 
 
 class Instrument(object):
     installed = False
 
     def installable(self):
-        try:
-            Redis, Pipeline = import_Redis_and_Pipeline()
-        except ImportError:
+        if redis is None:
             logger.info("Unable to import for Redis instruments")
             return False
         if self.installed:
@@ -61,56 +58,52 @@ class Instrument(object):
         self.unpatch_pipeline()
 
     def patch_redis(self):
+        @wrapt.decorator
+        def wrapped_execute_command(wrapped, instance, args, kwargs):
+            try:
+                op = args[0]
+            except (IndexError, TypeError):
+                op = "Unknown"
+
+            tracked_request = TrackedRequest.instance()
+            tracked_request.start_span(operation="Redis/{}".format(op))
+
+            try:
+                return wrapped(*args, **kwargs)
+            finally:
+                tracked_request.stop_span()
+
         try:
-            Redis, _Pipeline = import_Redis_and_Pipeline()
-
-            @wrapt.decorator
-            def wrapped_execute_command(wrapped, instance, args, kwargs):
-                try:
-                    op = args[0]
-                except (IndexError, TypeError):
-                    op = "Unknown"
-
-                tracked_request = TrackedRequest.instance()
-                tracked_request.start_span(operation="Redis/{}".format(op))
-
-                try:
-                    return wrapped(*args, **kwargs)
-                finally:
-                    tracked_request.stop_span()
-
             Redis.execute_command = wrapped_execute_command(Redis.execute_command)
-
-        except Exception as e:
+        except Exception as exc:
             logger.warning(
-                "Unable to instrument for Redis StrictRedis.execute_command: %r", e
+                "Unable to instrument for Redis Redis.execute_command: %r",
+                exc,
+                exc_info=exc,
             )
 
     def unpatch_redis(self):
-        Redis, _Pipeline = import_Redis_and_Pipeline()
-
         Redis.execute_command = Redis.execute_command.__wrapped__
 
     def patch_pipeline(self):
+        @wrapt.decorator
+        def wrapped_execute(wrapped, instance, args, kwargs):
+            tracked_request = TrackedRequest.instance()
+            tracked_request.start_span(operation="Redis/MULTI")
+
+            try:
+                return wrapped(*args, **kwargs)
+            finally:
+                tracked_request.stop_span()
+
         try:
-            _Redis, Pipeline = import_Redis_and_Pipeline()
-
-            @wrapt.decorator
-            def wrapped_execute(wrapped, instance, args, kwargs):
-                tracked_request = TrackedRequest.instance()
-                tracked_request.start_span(operation="Redis/MULTI")
-
-                try:
-                    return wrapped(*args, **kwargs)
-                finally:
-                    tracked_request.stop_span()
-
             Pipeline.execute = wrapped_execute(Pipeline.execute)
-
-        except Exception as e:
-            logger.warning("Unable to instrument for Redis BasePipeline.execute: %r", e)
+        except Exception as exc:
+            logger.warning(
+                "Unable to instrument for Redis BasePipeline.execute: %r",
+                exc,
+                exc_info=exc,
+            )
 
     def unpatch_pipeline(self):
-        _Redis, Pipeline = import_Redis_and_Pipeline()
-
         Pipeline.execute = Pipeline.execute.__wrapped__

--- a/tests/integration/instruments/test_redis.py
+++ b/tests/integration/instruments/test_redis.py
@@ -98,16 +98,13 @@ def test_patch_redis_no_redis_module():
 def test_patch_redis_install_failure(mock_redis, caplog):
     del mock_redis.execute_command
     instrument.patch_redis()  # doesn't crash
-    assert caplog.record_tuples == [
-        (
-            "scout_apm.instruments.redis",
-            logging.WARNING,
-            (
-                "Unable to instrument for Redis Redis.execute_command: "
-                + "AttributeError('execute_command')"
-            ),
-        )
-    ]
+    assert len(caplog.record_tuples) == 1
+    logger, level, message = caplog.record_tuples[0]
+    assert logger == "scout_apm.instruments.redis"
+    assert level == logging.WARNING
+    assert message.startswith(
+        "Unable to instrument for Redis Redis.execute_command: AttributeError"
+    )
 
 
 def test_patch_pipeline_no_redis_module():
@@ -119,16 +116,14 @@ def test_patch_pipeline_no_redis_module():
 def test_patch_pipeline_install_failure(mock_pipeline, caplog):
     del mock_pipeline.execute
     instrument.patch_pipeline()  # doesn't crash
-    assert caplog.record_tuples == [
-        (
-            "scout_apm.instruments.redis",
-            30,
-            (
-                "Unable to instrument for Redis BasePipeline.execute: "
-                + "AttributeError('execute')"
-            ),
-        )
-    ]
+
+    assert len(caplog.record_tuples) == 1
+    logger, level, message = caplog.record_tuples[0]
+    assert logger == "scout_apm.instruments.redis"
+    assert level == logging.WARNING
+    assert message.startswith(
+        "Unable to instrument for Redis BasePipeline.execute: AttributeError"
+    )
 
 
 def test_install_is_idempotent():


### PR DESCRIPTION
Avoid importing in a function but do it up front once. Reduce `try / except` to assume that `wrapt.decorator` works.