### PR TITLE
Remove dead Django custom template tag instrumentation

### DIFF
--- a/src/scout_apm/core/stacktracer.py
+++ b/src/scout_apm/core/stacktracer.py
@@ -32,33 +32,3 @@ def trace_method(cls, method_name=None):
         return wrapper
 
     return decorator
-
-
-def trace_function(func, info):
-    try:
-
-        @wrapt.decorator
-        def wrapper(wrapped, instance, args, kwargs):
-            if callable(info):
-                entry_type, detail = info(*args, **kwargs)
-            else:
-                entry_type, detail = info
-
-            operation = entry_type
-            if detail["name"] is not None:
-                operation = operation + "/" + detail["name"]
-
-            tracked_request = TrackedRequest.instance()
-            span = tracked_request.start_span(operation=operation)
-            for key in detail:
-                span.tag(key, detail[key])
-
-            try:
-                return wrapped(*args, **kwargs)
-            finally:
-                tracked_request.stop_span()
-
-        return wrapper(func)
-    except Exception:
-        # If we can't wrap for any reason, just return the original
-        return func

--- a/src/scout_apm/django/instruments/template.py
+++ b/src/scout_apm/django/instruments/template.py
@@ -3,73 +3,18 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import logging
 
-from django.template import Library, Template, defaulttags
+from django.template import Template
 from django.template.loader_tags import BlockNode
 
-from scout_apm.core.stacktracer import trace_function, trace_method
+from scout_apm.core.stacktracer import trace_method
 
 logger = logging.getLogger(__name__)
-
-register = Library()
-
-
-class DecoratingParserProxy(object):  # pragma: no cover
-    """
-    Mocks out the django template parser, passing templatetags through but
-    first wrapping them to include performance data
-    """
-
-    def __init__(self, parser):
-        self.parser = parser
-
-    def add_library(self, library):
-        wrapped_library = Library()
-        wrapped_library.filters = library.filters
-        for name, tag_compiler in library.tags.items():
-            wrapped_library.tags[name] = self.wrap_compile_function(name, tag_compiler)
-        self.parser.add_library(wrapped_library)
-
-    def wrap_compile_function(self, name, tag_compiler):
-        def compile(*args, **kwargs):
-            node = tag_compiler(*args, **kwargs)
-            node.render = trace_function(node.render, ("Template/Tag", {"name": name}))
-            return node
-
-        return compile
-
-
-@register.tag
-def load(parser, token):  # pragma: no cover
-    decorating_parser = DecoratingParserProxy(parser)
-    return defaulttags.load(decorating_parser, token)
 
 
 def install_template_instrumentation():
     if getattr(install_template_instrumentation, "installed", False):
         return
     install_template_instrumentation.installed = True
-
-    # Our eventual aim is to patch the render() method on the Node objects
-    # corresponding to custom template tags. However we have to jump through
-    # a number of hoops in order to get access to the object.
-    #
-    # 1. Add ourselves to the set of built in template tags
-    #    This allows us to replace the 'load' template tag which controls
-    #    the loading of custom template tags
-    # 2. Delegate to default load with replaced parser
-    #    We provide our own parser class so we can catch and intercept
-    #    calls to add_library.
-    # 3. add_library receives a library of template tags
-    #    It iterates through each template tag, wrapping its compile function
-    # 4. compile is called as part of compiling the template
-    #    Our wrapper is called instead of the original templatetag compile
-    #    function. We delegate to the original function, but then modify
-    #    the resulting object by wrapping its render() function. This
-    #    render() function is what ends up being timed and appearing in the
-    #    tree.
-
-    # XXX: Stopped working in Django 1.9
-    #  add_to_builtins('apm.instruments.view')
 
     @trace_method(Template)
     def __init__(self, *args, **kwargs):

--- a/tests/unit/core/test_stacktracer.py
+++ b/tests/unit/core/test_stacktracer.py
@@ -1,11 +1,7 @@
 # coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import pytest
-
-from scout_apm.core.stacktracer import trace_function, trace_method
-from scout_apm.core.tracked_request import TrackedRequest
-from tests.compat import mock
+from scout_apm.core.stacktracer import trace_method
 
 
 class TraceMe(object):
@@ -15,46 +11,6 @@ class TraceMe(object):
 
 def trace_me(*args, **kwargs):
     return args, kwargs
-
-
-@pytest.fixture
-def tracked_request():
-    request = TrackedRequest.instance()
-    request.start_span()  # prevent request from finalizing
-    try:
-        yield request
-    finally:
-        request.stop_span()
-
-
-def test_trace_function(tracked_request):
-    traced = trace_function(trace_me, ("Test/Function", {"name": "trace_me"}))
-    traced()
-
-    span = tracked_request.complete_spans[0]
-    assert span.operation == "Test/Function/trace_me"
-
-
-def test_trace_function_callable_info(tracked_request):
-    traced = trace_function(trace_me, lambda: ("Test/Function", {"name": "trace_me"}))
-    traced()
-
-    span = tracked_request.complete_spans[0]
-    assert span.operation == "Test/Function/trace_me"
-
-
-@mock.patch("scout_apm.core.stacktracer.wrapt.decorator", side_effect=RuntimeError)
-def test_trace_function_exception(mock_decorator, tracked_request):
-    traced = trace_function(trace_me, lambda: ("Test/Function", {"name": "trace_me"}))
-    assert traced is trace_me  # patching failed
-
-
-def test_trace_function_no_name(tracked_request):
-    traced = trace_function(trace_me, ("Test/Function", {"name": None}))
-    traced()
-
-    span = tracked_request.complete_spans[0]
-    assert span.operation == "Test/Function"
 
 
 def test_trace_method(tracked_request):


### PR DESCRIPTION
This code hasn't been active since it was added in the first commit: 4de21f8ea228a082d4f039c0c991ee41dfb6f9d8. Remove it for now, though it could provide a useful starting point for reimplementation in issue #313.