### PR TITLE
Lint with flake8-print

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ branch = True
 # core
 # black-recommended setup with flake8-bugbear
 max-line-length = 80
-select = C,E,F,W,B,B950,I
+select = C,E,F,W,B,B950,I,T
 ignore = E203,E501,W503
 # flake8-coding
 accept-encodings = utf-7

--- a/src/scout_apm/django/instruments/sql.py
+++ b/src/scout_apm/django/instruments/sql.py
@@ -71,7 +71,6 @@ def execute_wrapper(wrapped, instance, args, kwargs):
         sql = None
 
     if sql is not None:
-        print("Starting, sql = ", repr(sql))
         tracked_request = TrackedRequest.instance()
         span = tracked_request.start_span(operation="SQL/Query")
         span.tag("db.statement", sql)
@@ -97,7 +96,6 @@ def executemany_wrapper(wrapped, instance, args, kwargs):
         sql = None
 
     if sql is not None:
-        print("Starting, sql = ", repr(sql))
         tracked_request = TrackedRequest.instance()
         span = tracked_request.start_span(operation="SQL/Many")
         span.tag("db.statement", sql)

--- a/tests/integration/app.py
+++ b/tests/integration/app.py
@@ -16,11 +16,15 @@ Configure it with the SCOUT_MONITOR, SCOUT_KEY, and SCOUT_NAME env variables.
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import logging
+
 import scout_apm.api
 from tests.integration import test_bottle, test_django, test_flask, test_pyramid
 
+logger = logging.getLogger(__name__)
+
 # Launch Scout APM agent
-print("Installing Scout APM")
+logger.info("Installing Scout APM")
 scout_apm.api.install()
 
 # Create instrumented sub-apps
@@ -113,5 +117,5 @@ def app(environ, start_response):
 if __name__ == "__main__":
     from wsgiref.simple_server import make_server
 
-    print("Serving on http://0.0.0.0:8080")
+    logger.info("Serving on http://0.0.0.0:8080")
     make_server("", 8080, app).serve_forever()

--- a/tox.ini
+++ b/tox.ini
@@ -68,6 +68,7 @@ deps =
     flake8-coding
     flake8-comprehensions
     flake8-tidy-imports
+    flake8-print
     isort
     twine
 commands =


### PR DESCRIPTION
Prevent print() statements from getting into committed source code. This found some I accidentally left in #324, plus two in the 'integration all-in-one app' that I've rewritten with logging.