### PR TITLE
Remove exec calls from Elasticsearch instrument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 - Track SQL Alchemy `executemany` calls as multi-queries
   ([PR #340](https://github.com/scoutapp/scout_apm_python/pull/340)).
+- Track Elasticsearch index name when it's not passed as a keyword argument
+  ([PR #348](https://github.com/scoutapp/scout_apm_python/pull/348)).
 
 ## [2.7.0] 2019-11-03
 

--- a/tests/integration/instruments/test_elasticsearch.py
+++ b/tests/integration/instruments/test_elasticsearch.py
@@ -166,7 +166,9 @@ def test_install_no_elasticsearch_module():
 
 
 def test_instrument_client_install_missing_attribute():
-    with mock.patch("scout_apm.instruments.elasticsearch.Elasticsearch") as mock_elasticsearch:
+    with mock.patch(
+        "scout_apm.instruments.elasticsearch.Elasticsearch"
+    ) as mock_elasticsearch:
         del mock_elasticsearch.bulk
     instrument.instrument_client()  # no crash
 


### PR DESCRIPTION
Part of #342.

Also tidy up the import pattern, smiilar to Redis changes in #341, and fix index name tracking when not passed as a keyword argument.

The speed difference is smaller than I thought.

Before:

```
In [2]: %timeit Instrument().install(); Instrument().uninstall()
95.5 µs ± 2.07 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```

After:
```
In [2]: %timeit Instrument().install(); Instrument().uninstall()
89.5 µs ± 674 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```

However the other benefits still stand - code being linted, etc.