### PR TITLE
Tidy TrackedRequest.start_span

### DIFF
--- a/src/scout_apm/core/tracked_request.py
+++ b/src/scout_apm/core/tracked_request.py
@@ -67,7 +67,13 @@ class TrackedRequest(object):
             )
         self.tags[key] = value
 
-    def start_span(self, operation, ignore=False, ignore_children=False, should_capture_backtrace=True):
+    def start_span(
+        self,
+        operation,
+        ignore=False,
+        ignore_children=False,
+        should_capture_backtrace=True,
+    ):
         parent = self.current_span()
         if parent is not None:
             parent_id = parent.span_id

--- a/src/scout_apm/core/tracked_request.py
+++ b/src/scout_apm/core/tracked_request.py
@@ -67,21 +67,24 @@ class TrackedRequest(object):
             )
         self.tags[key] = value
 
-    def start_span(self, *args, **kwargs):
-        maybe_parent = self.current_span()
-
-        if maybe_parent is not None:
-            parent_id = maybe_parent.span_id
-            if maybe_parent.ignore_children:
-                kwargs["ignore"] = True
-                kwargs["ignore_children"] = True
+    def start_span(self, operation, ignore=False, ignore_children=False, should_capture_backtrace=True):
+        parent = self.current_span()
+        if parent is not None:
+            parent_id = parent.span_id
+            if parent.ignore_children:
+                ignore = True
+                ignore_children = True
         else:
             parent_id = None
 
-        kwargs["parent"] = parent_id
-        kwargs["request_id"] = self.request_id
-
-        new_span = Span(**kwargs)
+        new_span = Span(
+            request_id=self.request_id,
+            operation=operation,
+            ignore=ignore,
+            ignore_children=ignore_children,
+            parent=parent_id,
+            should_capture_backtrace=should_capture_backtrace,
+        )
         self.active_spans.append(new_span)
         return new_span
 
@@ -100,7 +103,7 @@ class TrackedRequest(object):
             self.finish()
 
     def current_span(self):
-        if len(self.active_spans) > 0:
+        if self.active_spans:
             return self.active_spans[-1]
         else:
             return None

--- a/tests/unit/core/test_commands.py
+++ b/tests/unit/core/test_commands.py
@@ -257,7 +257,7 @@ def test_batch_command_from_tracked_request_with_tag():
 @skip_if_objtrace_not_extension
 def test_batch_command_from_tracked_request_with_span():
     tracked_request = TrackedRequest()
-    tracked_request.start_span()
+    tracked_request.start_span("myoperation")
     tracked_request.stop_span()
     make_tracked_request_instance_deterministic(tracked_request)
 
@@ -270,7 +270,7 @@ def test_batch_command_from_tracked_request_with_span():
     }
     assert message_commands[1] == {
         "StartSpan": {
-            "operation": None,
+            "operation": "myoperation",
             "parent_id": None,
             "request_id": REQUEST_ID,
             "span_id": SPAN_ID,
@@ -321,7 +321,7 @@ def test_batch_command_from_tracked_request_with_span():
 @skip_if_objtrace_not_extension
 def test_batch_command_from_tracked_request_with_span_no_objtrace():
     tracked_request = TrackedRequest()
-    tracked_request.start_span()
+    tracked_request.start_span(operation="myoperation")
     tracked_request.stop_span()
     make_tracked_request_instance_deterministic(tracked_request)
 
@@ -334,7 +334,7 @@ def test_batch_command_from_tracked_request_with_span_no_objtrace():
     }
     assert message_commands[1] == {
         "StartSpan": {
-            "operation": None,
+            "operation": "myoperation",
             "parent_id": None,
             "request_id": REQUEST_ID,
             "span_id": SPAN_ID,

--- a/tests/unit/core/test_tracked_request.py
+++ b/tests/unit/core/test_tracked_request.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import datetime as dt
+import sys
 
 from scout_apm.core import objtrace
 from scout_apm.core.tracked_request import TrackedRequest
@@ -44,7 +45,10 @@ def test_span_repr(tracked_request):
     tracked_request.stop_span()
 
     assert repr_.startswith("<Span(")
-    assert "operation='myoperation'" in repr_
+    if sys.version_info[0] == 2:
+        assert "operation=u'myoperation'" in repr_
+    else:
+        assert "operation='myoperation'" in repr_
 
 
 def test_tag_span(tracked_request):

--- a/tests/unit/core/test_tracked_request.py
+++ b/tests/unit/core/test_tracked_request.py
@@ -39,15 +39,16 @@ def test_tag_request_overwrite(tracked_request):
 
 
 def test_span_repr(tracked_request):
-    span = tracked_request.start_span()
-    try:
-        assert repr(span).startswith("<Span(")
-    finally:
-        tracked_request.stop_span()
+    span = tracked_request.start_span(operation="myoperation")
+    repr_ = repr(span)
+    tracked_request.stop_span()
+
+    assert repr_.startswith("<Span(")
+    assert "operation='myoperation'" in repr_
 
 
 def test_tag_span(tracked_request):
-    span = tracked_request.start_span()
+    span = tracked_request.start_span(operation="myoperation")
     span.tag("foo", "bar")
     tracked_request.stop_span()
 
@@ -55,7 +56,7 @@ def test_tag_span(tracked_request):
 
 
 def test_tag_span_overwrite(tracked_request):
-    span = tracked_request.start_span()
+    span = tracked_request.start_span(operation="myoperation")
     span.tag("foo", "bar")
     span.tag("foo", "baz")
     tracked_request.stop_span()
@@ -64,8 +65,8 @@ def test_tag_span_overwrite(tracked_request):
 
 
 def test_start_span_wires_parents(tracked_request):
-    span1 = tracked_request.start_span()
-    span2 = tracked_request.start_span()
+    span1 = tracked_request.start_span(operation="myoperation")
+    span2 = tracked_request.start_span(operation="myoperation2")
     assert span1.parent is None
     assert span2.parent == span1.span_id
 
@@ -73,7 +74,7 @@ def test_start_span_wires_parents(tracked_request):
 @skip_if_objtrace_not_extension
 def test_tags_allocations_for_spans(tracked_request):
     objtrace.enable()
-    span = tracked_request.start_span()
+    span = tracked_request.start_span(operation="myoperation")
     tracked_request.stop_span()
     assert span.tags["allocations"] > 0
 
@@ -81,17 +82,17 @@ def test_tags_allocations_for_spans(tracked_request):
 @skip_if_objtrace_is_extension
 def test_tags_allocations_for_spans_no_objtrace_extension(tracked_request):
     objtrace.enable()
-    span = tracked_request.start_span()
+    span = tracked_request.start_span(operation="myoperation")
     tracked_request.stop_span()
     assert "allocations" not in span.tags
 
 
 def test_start_span_does_not_ignore_children(tracked_request):
     tracked_request.start_span(operation="parent")
-    child1 = tracked_request.start_span()
+    child1 = tracked_request.start_span(operation="myoperation")
     assert not child1.ignore
     assert not child1.ignore_children
-    child2 = tracked_request.start_span()
+    child2 = tracked_request.start_span(operation="myoperation")
     assert not child2.ignore
     assert not child2.ignore_children
     tracked_request.stop_span()
@@ -103,10 +104,10 @@ def test_start_span_does_not_ignore_children(tracked_request):
 
 def test_start_span_ignores_children(tracked_request):
     tracked_request.start_span(operation="parent", ignore_children=True)
-    child1 = tracked_request.start_span()
+    child1 = tracked_request.start_span(operation="child1")
     assert child1.ignore
     assert child1.ignore_children
-    child2 = tracked_request.start_span()
+    child2 = tracked_request.start_span(operation="child2")
     assert child2.ignore
     assert child2.ignore_children
     tracked_request.stop_span()
@@ -125,7 +126,7 @@ def test_span_captures_backtrace(tracked_request):
 
 
 def test_should_capture_backtrace_default_true(tracked_request):
-    span = tracked_request.start_span("Something")
+    span = tracked_request.start_span(operation="Something")
     # Trigger 'slow' condition
     span.start_time -= dt.timedelta(seconds=2)
 


### PR DESCRIPTION
Restrict the arguments to require `operation` and prevent overriding of others such as the span ID.