### PR TITLE
Correctly disable Bottle when agent fails to launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
   ([PR #247](https://github.com/scoutapp/scout_apm_python/pull/247)).
 - Fix the `RemovedInDjango20Warning` for `django.core.urlresolvers` on Django
   1.11 ([PR #359](https://github.com/scoutapp/scout_apm_python/pull/359)).
+- Correctly disable Bottle if the agent fails to launch
+  ([PR #364](https://github.com/scoutapp/scout_apm_python/pull/364)).
 
 ## [2.7.0] 2019-11-03
 

--- a/src/scout_apm/bottle.py
+++ b/src/scout_apm/bottle.py
@@ -30,10 +30,11 @@ class ScoutPlugin(object):
 
     def setup(self, app):
         self.set_config_from_bottle(app)
-        scout_apm.core.install()
+        installed = scout_apm.core.install()
+        self._do_nothing = not installed
 
     def apply(self, callback, context):
-        if not scout_config.value("monitor"):
+        if self._do_nothing:
             return callback
         return wrap_callback(callback)
 


### PR DESCRIPTION
Checking the result of `scout_apm.core.install()` brings it in line with other integrations, and means the tracking will be disabled if we fail to download the agent, are running on Windows, etc.