### PR TITLE
Tidy jinja2 and urllib3 import patterns

### DIFF
--- a/src/scout_apm/instruments/jinja2.py
+++ b/src/scout_apm/instruments/jinja2.py
@@ -37,7 +37,9 @@ class Instrument(object):
         try:
             Template.render = wrapped_render(Template.render)
         except Exception as exc:
-            logger.warning("Unable to instrument for Jinja2 Template.render: %r", exc, exc_info=exc)
+            logger.warning(
+                "Unable to instrument for Jinja2 Template.render: %r", exc, exc_info=exc
+            )
             return False
         logger.info("Instrumented Jinja2")
         return True

--- a/src/scout_apm/instruments/jinja2.py
+++ b/src/scout_apm/instruments/jinja2.py
@@ -7,6 +7,11 @@ import wrapt
 
 from scout_apm.core.tracked_request import TrackedRequest
 
+try:
+    from jinja2 import Template
+except ImportError:
+    Template = None
+
 logger = logging.getLogger(__name__)
 
 
@@ -14,9 +19,7 @@ class Instrument(object):
     installed = False
 
     def installable(self):
-        try:
-            from jinja2 import Template  # noqa: F401
-        except ImportError:
+        if Template is None:
             logger.info("Unable to import for Jinja2 instruments")
             return False
         if self.installed:
@@ -32,25 +35,11 @@ class Instrument(object):
         self.__class__.installed = True
 
         try:
-            from jinja2 import Template
-
-            @wrapt.decorator
-            def wrapped_render(wrapped, instance, args, kwargs):
-                tracked_request = TrackedRequest.instance()
-                span = tracked_request.start_span(operation="Template/Render")
-                span.tag("name", instance.name)
-                try:
-                    return wrapped(*args, **kwargs)
-                finally:
-                    tracked_request.stop_span()
-
             Template.render = wrapped_render(Template.render)
-
-            logger.info("Instrumented Jinja2")
-
-        except Exception as e:
-            logger.warning("Unable to instrument for Jinja2 Template.render: %r", e)
+        except Exception as exc:
+            logger.warning("Unable to instrument for Jinja2 Template.render: %r", exc, exc_info=exc)
             return False
+        logger.info("Instrumented Jinja2")
         return True
 
     def uninstall(self):
@@ -60,6 +49,15 @@ class Instrument(object):
 
         self.__class__.installed = False
 
-        from jinja2 import Template
-
         Template.render = Template.render.__wrapped__
+
+
+@wrapt.decorator
+def wrapped_render(wrapped, instance, args, kwargs):
+    tracked_request = TrackedRequest.instance()
+    span = tracked_request.start_span(operation="Template/Render")
+    span.tag("name", instance.name)
+    try:
+        return wrapped(*args, **kwargs)
+    finally:
+        tracked_request.stop_span()

--- a/tests/integration/instruments/test_elasticsearch.py
+++ b/tests/integration/instruments/test_elasticsearch.py
@@ -170,10 +170,11 @@ def test_instrument_client_install_missing_attribute():
         "scout_apm.instruments.elasticsearch.Elasticsearch"
     ) as mock_elasticsearch:
         del mock_elasticsearch.bulk
-    try:
-        instrument.instrument_client()  # no crash
-    finally:
-        instrument.uninstrument_client()
+
+        try:
+            instrument.instrument_client()  # no crash
+        finally:
+            instrument.uninstrument_client()
 
 
 @mock.patch(

--- a/tests/integration/instruments/test_jinja2.py
+++ b/tests/integration/instruments/test_jinja2.py
@@ -7,7 +7,6 @@ import jinja2
 
 from scout_apm.instruments.jinja2 import Instrument
 from tests.compat import mock
-from tests.tools import pretend_package_unavailable
 
 instrument = Instrument()
 
@@ -46,23 +45,27 @@ def test_installable():
 
 
 def test_installable_no_jinja2_module():
-    with pretend_package_unavailable("jinja2"):
+    with mock.patch("scout_apm.instruments.jinja2.Template", new=None):
         assert not instrument.installable()
 
 
 def test_install_no_jinja2_module():
-    with pretend_package_unavailable("jinja2"):
+    with mock.patch("scout_apm.instruments.jinja2.Template", new=None):
         assert not instrument.install()
         assert not Instrument.installed
 
 
-@mock.patch("scout_apm.instruments.jinja2.wrapt.decorator", side_effect=RuntimeError)
-def test_install_failure(mock_decorator):
-    try:
-        assert not instrument.install()  # doesn't crash
-    finally:
-        # Currently installed = True even if installing failed.
-        Instrument.installed = False
+def test_install_failure_():
+    with mock.patch(
+        "scout_apm.instruments.jinja2.Template"
+    ) as mock_template:
+        del mock_template.render
+
+        try:
+            assert not instrument.install()  # doesn't crash
+        finally:
+            # Currently installed = True even if installing failed.
+            Instrument.installed = False
 
 
 def test_install_is_idempotent():

--- a/tests/integration/instruments/test_jinja2.py
+++ b/tests/integration/instruments/test_jinja2.py
@@ -56,9 +56,7 @@ def test_install_no_jinja2_module():
 
 
 def test_install_failure_no_render_attribute():
-    with mock.patch(
-        "scout_apm.instruments.jinja2.Template"
-    ) as mock_template:
+    with mock.patch("scout_apm.instruments.jinja2.Template") as mock_template:
         del mock_template.render
 
         try:

--- a/tests/integration/instruments/test_jinja2.py
+++ b/tests/integration/instruments/test_jinja2.py
@@ -55,7 +55,7 @@ def test_install_no_jinja2_module():
         assert not Instrument.installed
 
 
-def test_install_failure_():
+def test_install_failure_no_render_attribute():
     with mock.patch(
         "scout_apm.instruments.jinja2.Template"
     ) as mock_template:


### PR DESCRIPTION
Modify the last two instruments to do import-time importing, rather than re-importing in several different places. This is the same as done for Redis in #341.