### PR TITLE
Ensure install() is called for Huey

### DIFF
--- a/src/scout_apm/huey.py
+++ b/src/scout_apm/huey.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from huey.exceptions import RetryTask, TaskLockedException
 from huey.signals import SIGNAL_CANCELED
 
+import scout_apm.core
 from scout_apm.core.tracked_request import TrackedRequest
 
 # Because neither hooks nor signals are called in *all* cases, we need to use
@@ -12,9 +13,11 @@ from scout_apm.core.tracked_request import TrackedRequest
 
 
 def attach_scout(huey):
-    huey.pre_execute()(scout_on_pre_execute)
-    huey.post_execute()(scout_on_post_execute)
-    huey.signal(SIGNAL_CANCELED)(scout_on_cancelled)
+    installed = scout_apm.core.install()
+    if installed:
+        huey.pre_execute()(scout_on_pre_execute)
+        huey.post_execute()(scout_on_post_execute)
+        huey.signal(SIGNAL_CANCELED)(scout_on_cancelled)
 
 
 def scout_on_pre_execute(task):

--- a/tests/integration/test_huey.py
+++ b/tests/integration/test_huey.py
@@ -124,3 +124,12 @@ def test_locked(tracked_requests):
 
     assert excinfo.value.metadata["error"].startswith("TaskLockedException")
     assert tracked_requests == []
+
+
+def test_no_monitor(tracked_requests):
+    with app_with_scout(scout_config={"monitor": False}) as app:
+        result = app.hello()
+        value = result(blocking=True, timeout=1)
+
+    assert value == "Hello World!"
+    assert tracked_requests == []


### PR DESCRIPTION
Ensure `scout_apm.core.install()` is called in the Huey integration, and don't monitor if install fails.