### PR TITLE
Fix for upgraded flake8-comprehensions

### DIFF
--- a/src/scout_apm/core/metadata.py
+++ b/src/scout_apm/core/metadata.py
@@ -51,9 +51,7 @@ def get_python_packages_versions():
     except ImportError:
         return []
 
-    return list(
-        sorted(
-            (distribution.project_name, distribution.version)
-            for distribution in pkg_resources.working_set
-        )
+    return sorted(
+        (distribution.project_name, distribution.version)
+        for distribution in pkg_resources.working_set
     )


### PR DESCRIPTION
Now it errors on `list(sorted(x))` because `sorted()` already returns a list.