### PR TITLE
Stop Pytest collecting tests from src/

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -32,3 +32,4 @@ addopts = --cov=scout_apm
           #                 )
           # E               TypeError: wrap_socket() got an unexpected keyword argument '_context'
           -p no:pytest_nameko
+norecursedirs = src


### PR DESCRIPTION
Prevent this error in the Python 3.5 environment:

```
ImportError while importing test module '/Users/chainz/Documents/Projects/scout_apm_python/src/scout_apm/async_/__init__.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
ImportError: No module named 'scout_apm.async_'
```

It seems the latest version of Pytest checks for tests in the repo src directory but then tries to import those modules from the installed directory. It can't import `scout_apm.async_` since it doesn't exist on Python < 3.6 due to logic in the `setup.py`.

This fixes it by telling it not to look in `src/` ever.