### PR TITLE
Fix objtrace C extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Pending
+
+### Fixed
+
+- Fixed memory allocation tracking, which has been broken since a refactor in
+  version 2.7.0.
+
 ## [2.8.0] 2019-11-08
 
 ### Added

--- a/src/scout_apm/core/_objtrace.c
+++ b/src/scout_apm/core/_objtrace.c
@@ -128,7 +128,7 @@ objtrace_reset_counts(PyObject *module)
 }
 
 PyDoc_STRVAR(module_doc,
-"scout_apm.core.objtrace module.");
+"scout_apm.core._objtrace module.");
 
 static PyMethodDef module_methods[] = {
     {"enable",
@@ -148,7 +148,7 @@ static PyMethodDef module_methods[] = {
 
 static struct PyModuleDef module_def = {
     PyModuleDef_HEAD_INIT,
-    "scout_apm.core.objtrace",
+    "scout_apm.core._objtrace",
     module_doc,
     0, /* non-negative size to be able to unload the module */
     module_methods,
@@ -159,7 +159,7 @@ static struct PyModuleDef module_def = {
 };
 
 PyMODINIT_FUNC
-PyInit_objtrace(void)
+PyInit__objtrace(void)
 {
     PyObject *m, *version;
 

--- a/src/scout_apm/core/objtrace.py
+++ b/src/scout_apm/core/objtrace.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 # implementation.
 
 try:
-    from scout_apm.core._objtrace import enable, disable, get_counts
+    from scout_apm.core._objtrace import enable, disable, get_counts, reset_counts
 except ImportError:  # pragma: no cover
 
     def enable():

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -73,7 +73,7 @@ def test_instrument_decorator_default_tags(tracked_request):
 
     assert len(tracked_request.active_spans) == 0
     assert len(tracked_request.complete_spans) == 1
-    assert tracked_request.complete_spans[0].tags == {"x": 99}
+    assert tracked_request.complete_spans[0].tags["x"] == 99
 
 
 def test_instrument_non_ascii_params(tracked_request):

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -18,7 +18,7 @@ skip_if_objtrace_not_extension = pytest.mark.skipif(
     not objtrace.is_extension, reason="Requires objtrace C extension"
 )
 skip_if_objtrace_is_extension = pytest.mark.skipif(
-    not objtrace.is_extension, reason="Requires no objtrace C extension"
+    objtrace.is_extension, reason="Requires no objtrace C extension"
 )
 
 

--- a/tests/unit/core/test_commands.py
+++ b/tests/unit/core/test_commands.py
@@ -328,7 +328,7 @@ def test_batch_command_from_tracked_request_with_span_no_objtrace():
     command = commands.BatchCommand.from_tracked_request(tracked_request)
 
     message_commands = command.message()["BatchCommand"]["commands"]
-    assert len(message_commands) == 4
+    assert len(message_commands) == 7
     assert message_commands[0] == {
         "StartRequest": {"request_id": REQUEST_ID, "timestamp": START_TIME_STR}
     }
@@ -342,12 +342,39 @@ def test_batch_command_from_tracked_request_with_span_no_objtrace():
         }
     }
     assert message_commands[2] == {
+        "TagSpan": {
+            "timestamp": START_TIME_STR,
+            "request_id": REQUEST_ID,
+            "span_id": SPAN_ID,
+            "tag": "allocations",
+            "value": 0,
+        }
+    }
+    assert message_commands[3] == {
+        "TagSpan": {
+            "timestamp": START_TIME_STR,
+            "request_id": REQUEST_ID,
+            "span_id": SPAN_ID,
+            "tag": "start_allocations",
+            "value": 0,
+        }
+    }
+    assert message_commands[4] == {
+        "TagSpan": {
+            "timestamp": START_TIME_STR,
+            "request_id": REQUEST_ID,
+            "span_id": SPAN_ID,
+            "tag": "stop_allocations",
+            "value": 0,
+        }
+    }
+    assert message_commands[5] == {
         "StopSpan": {
             "request_id": REQUEST_ID,
             "span_id": SPAN_ID,
             "timestamp": END_TIME_STR,
         }
     }
-    assert message_commands[3] == {
+    assert message_commands[6] == {
         "FinishRequest": {"request_id": REQUEST_ID, "timestamp": END_TIME_STR}
     }

--- a/tests/unit/core/test_commands.py
+++ b/tests/unit/core/test_commands.py
@@ -341,33 +341,35 @@ def test_batch_command_from_tracked_request_with_span_no_objtrace():
             "timestamp": START_TIME_STR,
         }
     }
-    assert message_commands[2] == {
-        "TagSpan": {
-            "timestamp": START_TIME_STR,
-            "request_id": REQUEST_ID,
-            "span_id": SPAN_ID,
-            "tag": "allocations",
-            "value": 0,
-        }
-    }
-    assert message_commands[3] == {
-        "TagSpan": {
-            "timestamp": START_TIME_STR,
-            "request_id": REQUEST_ID,
-            "span_id": SPAN_ID,
-            "tag": "start_allocations",
-            "value": 0,
-        }
-    }
-    assert message_commands[4] == {
-        "TagSpan": {
-            "timestamp": START_TIME_STR,
-            "request_id": REQUEST_ID,
-            "span_id": SPAN_ID,
-            "tag": "stop_allocations",
-            "value": 0,
-        }
-    }
+    assert sorted(message_commands[2:5], key=lambda c: c["TagSpan"]["tag"]) == [
+        {
+            "TagSpan": {
+                "timestamp": START_TIME_STR,
+                "request_id": REQUEST_ID,
+                "span_id": SPAN_ID,
+                "tag": "allocations",
+                "value": 0,
+            }
+        },
+        {
+            "TagSpan": {
+                "timestamp": START_TIME_STR,
+                "request_id": REQUEST_ID,
+                "span_id": SPAN_ID,
+                "tag": "start_allocations",
+                "value": 0,
+            }
+        },
+        {
+            "TagSpan": {
+                "timestamp": START_TIME_STR,
+                "request_id": REQUEST_ID,
+                "span_id": SPAN_ID,
+                "tag": "stop_allocations",
+                "value": 0,
+            }
+        },
+    ]
     assert message_commands[5] == {
         "StopSpan": {
             "request_id": REQUEST_ID,

--- a/tests/unit/core/test_objtrace.py
+++ b/tests/unit/core/test_objtrace.py
@@ -64,6 +64,10 @@ def test_get_counts_multiple_allocations():
 
 
 @skip_if_objtrace_not_extension
+@pytest.mark.skipif(
+    sys.version_info < (3, 5),
+    reason="For some reason can only force a realloc on Python 3.5+",
+)
 def test_get_counts_reallocations():
     items = []
     objtrace.enable()

--- a/tests/unit/core/test_objtrace.py
+++ b/tests/unit/core/test_objtrace.py
@@ -54,11 +54,11 @@ def test_get_counts_allocations():
 
 @skip_if_objtrace_not_extension
 @pytest.mark.skipif(
-    sys.version_info < (3, 5), reason="Mulitple allocations on Python 3.5+ only"
+    sys.version_info < (3, 5), reason="Multiple allocations on Python 3.5+ only"
 )
 def test_get_counts_multiple_allocations():
     objtrace.enable()
-    bytes("123")
+    bytes(123)
     counts = objtrace.get_counts()
     assert counts[1] > 0
 


### PR DESCRIPTION
Broken in #303 and not detected due to test suite skipping the tests, which need skipping on Python 2.7 because the extension isn't compatible with it.