### PR TITLE
Tag Falcon 5XX responses as errors

### DIFF
--- a/src/scout_apm/falcon.py
+++ b/src/scout_apm/falcon.py
@@ -109,7 +109,7 @@ class ScoutMiddleware(object):
 
         # Falcon only stores the response status line, we have to parse it
         try:
-            status_code = int(resp.status.split(' ', maxsplit=1)[0])
+            status_code = int(resp.status.split(" ")[0])
         except ValueError:
             # Bad status line - force it to be tagged as an error because
             # client will experience it as one

--- a/src/scout_apm/falcon.py
+++ b/src/scout_apm/falcon.py
@@ -107,7 +107,15 @@ class ScoutMiddleware(object):
             # Somehow we didn't start a request
             return
 
-        if not req_succeeded:
+        # Falcon only stores the response status line, we have to parse it
+        try:
+            status_code = int(resp.status.split(' ', maxsplit=1)[0])
+        except ValueError:
+            # Bad status line - force it to be tagged as an error because
+            # client will experience it as one
+            status_code = 500
+
+        if not req_succeeded or 500 <= status_code <= 599:
             tracked_request.tag("error", "true")
 
         span = getattr(req.context, "scout_resource_span", None)

--- a/tests/integration/test_falcon.py
+++ b/tests/integration/test_falcon.py
@@ -69,14 +69,14 @@ def app_with_scout(config=None, middleware=None, set_api=True):
 
     class ReturnErrorResource(object):
         def on_get(self, req, resp):
-            resp.status = '503 Something went wrong'
+            resp.status = "503 Something went wrong"
             resp.body = "Something went wrong"
 
     app.add_route("/return-error", ReturnErrorResource())
 
     class BadStatusResource(object):
         def on_get(self, req, resp):
-            resp.status = 'bad'
+            resp.status = "bad"
 
     app.add_route("/bad-status", BadStatusResource())
 


### PR DESCRIPTION
Ref #383.

Also, since Falcon allows directly setting the status line, test the case where a bad one is set, and report that as an error too.