### PR TITLE
Refactor use of utcnow to now(tz=utc)

### DIFF
--- a/src/scout_apm/celery.py
+++ b/src/scout_apm/celery.py
@@ -6,13 +6,13 @@ import datetime as dt
 from celery.signals import before_task_publish, task_postrun, task_prerun
 
 import scout_apm.core
-from scout_apm.compat import datetime_to_timestamp
+from scout_apm.compat import datetime_to_timestamp, utc
 from scout_apm.core.tracked_request import TrackedRequest
 
 
 def before_publish_callback(headers=None, properties=None, **kwargs):
     if "scout_task_start" not in headers:
-        headers["scout_task_start"] = datetime_to_timestamp(dt.datetime.utcnow())
+        headers["scout_task_start"] = datetime_to_timestamp(dt.datetime.now(tz=utc))
 
 
 def prerun_callback(task=None, **kwargs):
@@ -21,7 +21,7 @@ def prerun_callback(task=None, **kwargs):
 
     start = getattr(task.request, "scout_task_start", None)
     if start is not None:
-        now = datetime_to_timestamp(dt.datetime.utcnow())
+        now = datetime_to_timestamp(dt.datetime.now(tz=utc))
         try:
             queue_time = now - start
         except TypeError:

--- a/src/scout_apm/compat.py
+++ b/src/scout_apm/compat.py
@@ -34,15 +34,33 @@ except ImportError:
     # Python 2.x
     import Queue as queue
 
-# datetime_to_timestamp converts a naive UTC datetime to a unix timestamp
+
+if sys.version_info[0] >= 3:
+    utc = dt.timezone.utc
+else:
+    class UTC(dt.tzinfo):
+        _offset = dt.timedelta(0)
+
+        def utcoffset(self, dt):
+            return self._offset
+
+        def dst(self, dt):
+            return self._offset
+
+        def tzname(self, dt):
+            return "UTC"
+
+    utc = UTC()
+
+# datetime_to_timestamp converts a UTC datetime to a unix timestamp
 if sys.version_info >= (3, 3):
 
     def datetime_to_timestamp(datetime_obj):
-        return datetime_obj.replace(tzinfo=dt.timezone.utc).timestamp()
+        return datetime_obj.timestamp()
 
 
 else:
-    _EPOCH = dt.datetime(1970, 1, 1)
+    _EPOCH = dt.datetime(1970, 1, 1, tzinfo=utc)
 
     def datetime_to_timestamp(datetime_obj):
         return (datetime_obj - _EPOCH).total_seconds()

--- a/src/scout_apm/compat.py
+++ b/src/scout_apm/compat.py
@@ -38,6 +38,7 @@ except ImportError:
 if sys.version_info[0] >= 3:
     utc = dt.timezone.utc
 else:
+
     class UTC(dt.tzinfo):
         _offset = dt.timedelta(0)
 

--- a/src/scout_apm/core/metadata.py
+++ b/src/scout_apm/core/metadata.py
@@ -5,6 +5,7 @@ import datetime as dt
 import sys
 from os import getpid
 
+from scout_apm.compat import utc
 from scout_apm.core.commands import ApplicationEvent
 from scout_apm.core.config import scout_config
 from scout_apm.core.socket import CoreAgentSocket
@@ -16,7 +17,7 @@ def report_app_metadata():
             event_type="scout.metadata",
             event_value=get_metadata(),
             source="Pid: " + str(getpid()),
-            timestamp=dt.datetime.utcnow(),
+            timestamp=dt.datetime.now(tz=utc),
         )
     )
 
@@ -25,7 +26,7 @@ def get_metadata():
     data = {
         "language": "python",
         "language_version": "{}.{}.{}".format(*sys.version_info[:3]),
-        "server_time": dt.datetime.utcnow().isoformat() + "Z",
+        "server_time": dt.datetime.now(tz=utc).isoformat() + "Z",
         "framework": scout_config.value("framework"),
         "framework_version": scout_config.value("framework_version"),
         "environment": "",

--- a/src/scout_apm/core/samplers/cpu.py
+++ b/src/scout_apm/core/samplers/cpu.py
@@ -6,6 +6,8 @@ import logging
 
 import psutil
 
+from scout_apm.compat import utc
+
 logger = logging.getLogger(__name__)
 
 
@@ -15,7 +17,7 @@ class Cpu(object):
     human_name = "Process CPU"
 
     def __init__(self):
-        self.last_run = dt.datetime.utcnow()
+        self.last_run = dt.datetime.now(tz=utc)
         self.last_cpu_times = psutil.Process().cpu_times()
         self.num_processors = psutil.cpu_count()
         if self.num_processors is None:
@@ -23,7 +25,7 @@ class Cpu(object):
             self.num_processors = 1
 
     def run(self):
-        now = dt.datetime.utcnow()
+        now = dt.datetime.now(tz=utc)
         process = psutil.Process()  # get a handle on the current process
         cpu_times = process.cpu_times()
 

--- a/src/scout_apm/core/samplers/thread.py
+++ b/src/scout_apm/core/samplers/thread.py
@@ -6,6 +6,7 @@ import logging
 import os
 import threading
 
+from scout_apm.compat import utc
 from scout_apm.core.commands import ApplicationEvent
 from scout_apm.core.samplers.cpu import Cpu
 from scout_apm.core.samplers.memory import Memory
@@ -60,7 +61,7 @@ class SamplersThread(threading.Thread):
                     event = ApplicationEvent(
                         event_value=event_value,
                         event_type=event_type,
-                        timestamp=dt.datetime.utcnow(),
+                        timestamp=dt.datetime.now(tz=utc),
                         source="Pid: " + str(os.getpid()),
                     )
                     CoreAgentSocket.instance().send(event)

--- a/src/scout_apm/core/tracked_request.py
+++ b/src/scout_apm/core/tracked_request.py
@@ -5,6 +5,7 @@ import datetime as dt
 import logging
 from uuid import uuid4
 
+from scout_apm.compat import utc
 from scout_apm.core import backtrace, objtrace
 from scout_apm.core.commands import BatchCommand
 from scout_apm.core.n_plus_one_call_set import NPlusOneCallSet
@@ -42,7 +43,7 @@ class TrackedRequest(object):
 
     def __init__(self):
         self.request_id = "req-" + str(uuid4())
-        self.start_time = dt.datetime.utcnow()
+        self.start_time = dt.datetime.now(tz=utc)
         self.end_time = None
         self.active_spans = []
         self.complete_spans = []
@@ -118,7 +119,7 @@ class TrackedRequest(object):
     def finish(self):
         logger.debug("Stopping request: %s", self.request_id)
         if self.end_time is None:
-            self.end_time = dt.datetime.utcnow()
+            self.end_time = dt.datetime.now(tz=utc)
         if self.is_real_request:
             self.tag("mem_delta", self._get_mem_delta())
             if not self.is_ignored():
@@ -167,7 +168,7 @@ class Span(object):
         should_capture_backtrace=True,
     ):
         self.span_id = "span-" + str(uuid4())
-        self.start_time = dt.datetime.utcnow()
+        self.start_time = dt.datetime.now(tz=utc)
         self.end_time = None
         self.request_id = request_id
         self.operation = operation
@@ -186,7 +187,7 @@ class Span(object):
         )
 
     def stop(self):
-        self.end_time = dt.datetime.utcnow()
+        self.end_time = dt.datetime.now(tz=utc)
         self.end_objtrace_counts = objtrace.get_counts()
 
     def tag(self, key, value):
@@ -202,7 +203,7 @@ class Span(object):
             return (self.end_time - self.start_time).total_seconds()
         else:
             # Current, running duration
-            return (dt.datetime.utcnow() - self.start_time).total_seconds()
+            return (dt.datetime.now(tz=utc) - self.start_time).total_seconds()
 
     # Add any interesting annotations to the span. Assumes that we are in the
     # process of stopping this span.

--- a/src/scout_apm/rq.py
+++ b/src/scout_apm/rq.py
@@ -9,6 +9,7 @@ from rq import Worker as RqWorker
 from rq.job import Job
 
 import scout_apm.core
+from scout_apm.compat import utc
 from scout_apm.core.tracked_request import TrackedRequest
 
 install_attempted = False
@@ -61,7 +62,9 @@ def wrap_perform(wrapped, instance, args, kwargs):
     tracked_request.is_real_request = True
     tracked_request.tag("task_id", instance.get_id())
     tracked_request.tag("queue", instance.origin)
-    queue_time = (dt.datetime.utcnow() - instance.enqueued_at).total_seconds()
+    # rq stores UTC datetime as naive, we always use timezone aware datetimes
+    enqueued_at_utc = instance.enqueued_at.replace(tzinfo=utc)
+    queue_time = (dt.datetime.now(tz=utc) - enqueued_at_utc).total_seconds()
     tracked_request.tag("queue_time", queue_time)
     tracked_request.start_span(operation="Job/{}".format(instance.func_name))
     try:

--- a/tests/compat.py
+++ b/tests/compat.py
@@ -22,5 +22,4 @@ except ImportError:  # Python < 3.2
         finally:
             rmtree(tempdir)
 
-
 __all__ = ["mock", "TemporaryDirectory"]

--- a/tests/compat.py
+++ b/tests/compat.py
@@ -22,4 +22,5 @@ except ImportError:  # Python < 3.2
         finally:
             rmtree(tempdir)
 
+
 __all__ = ["mock", "TemporaryDirectory"]

--- a/tests/integration/test_bottle.py
+++ b/tests/integration/test_bottle.py
@@ -9,7 +9,7 @@ from webtest import TestApp
 
 from scout_apm.api import Config
 from scout_apm.bottle import ScoutPlugin
-from scout_apm.compat import datetime_to_timestamp
+from scout_apm.compat import datetime_to_timestamp, utc
 from tests.integration.util import (
     parametrize_filtered_params,
     parametrize_queue_time_header_name,
@@ -109,7 +109,7 @@ def test_user_ip(headers, client_address, expected, tracked_requests):
 @parametrize_queue_time_header_name
 def test_queue_time(header_name, tracked_requests):
     # Not testing floats due to Python 2/3 rounding differences
-    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow())) - 2
+    queue_start = int(datetime_to_timestamp(dt.datetime.now(tz=utc))) - 2
     with app_with_scout() as app:
         response = TestApp(app).get(
             "/", headers={header_name: str("t=") + str(queue_start)}
@@ -123,7 +123,7 @@ def test_queue_time(header_name, tracked_requests):
 
 
 def test_amazon_queue_time(tracked_requests):
-    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow())) - 2
+    queue_start = int(datetime_to_timestamp(dt.datetime.now(tz=utc))) - 2
     with app_with_scout() as app:
         response = TestApp(app).get(
             "/",

--- a/tests/integration/test_django.py
+++ b/tests/integration/test_django.py
@@ -15,7 +15,7 @@ from django.http import HttpResponse
 from django.test.utils import override_settings
 from webtest import TestApp
 
-from scout_apm.compat import datetime_to_timestamp
+from scout_apm.compat import datetime_to_timestamp, utc
 from scout_apm.core.config import scout_config
 from scout_apm.django.instruments.sql import ensure_sql_instrumented
 from scout_apm.django.instruments.template import ensure_templates_instrumented
@@ -654,7 +654,7 @@ def test_old_style_urlconf(tracked_requests):
 @parametrize_queue_time_header_name
 def test_queue_time(header_name, tracked_requests):
     # Not testing floats due to Python 2/3 rounding differences
-    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow())) - 2
+    queue_start = int(datetime_to_timestamp(dt.datetime.now(tz=utc))) - 2
     with app_with_scout() as app:
         response = TestApp(app).get(
             "/", headers={header_name: str("t=") + str(queue_start)}
@@ -668,7 +668,7 @@ def test_queue_time(header_name, tracked_requests):
 
 
 def test_amazon_queue_time(tracked_requests):
-    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow())) - 2
+    queue_start = int(datetime_to_timestamp(dt.datetime.now(tz=utc))) - 2
     with app_with_scout() as app:
         response = TestApp(app).get(
             "/",

--- a/tests/integration/test_falcon.py
+++ b/tests/integration/test_falcon.py
@@ -10,7 +10,7 @@ import pytest
 from webtest import TestApp
 
 from scout_apm.api import Config
-from scout_apm.compat import datetime_to_timestamp
+from scout_apm.compat import datetime_to_timestamp, utc
 from scout_apm.falcon import ScoutMiddleware
 from tests.integration.util import (
     parametrize_filtered_params,
@@ -193,7 +193,7 @@ def test_filtered_params(params, expected_path, tracked_requests):
 @parametrize_queue_time_header_name
 def test_queue_time(header_name, tracked_requests):
     # Not testing floats due to Python 2/3 rounding differences
-    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow())) - 2
+    queue_start = int(datetime_to_timestamp(dt.datetime.now(tz=utc))) - 2
     with app_with_scout() as app:
         response = TestApp(app).get(
             "/", headers={header_name: str("t=") + str(queue_start)}
@@ -207,7 +207,7 @@ def test_queue_time(header_name, tracked_requests):
 
 
 def test_amazon_queue_time(tracked_requests):
-    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow())) - 2
+    queue_start = int(datetime_to_timestamp(dt.datetime.now(tz=utc))) - 2
     with app_with_scout() as app:
         response = TestApp(app).get(
             "/",

--- a/tests/integration/test_flask.py
+++ b/tests/integration/test_flask.py
@@ -8,7 +8,7 @@ import flask
 from webtest import TestApp
 
 from scout_apm.api import Config
-from scout_apm.compat import datetime_to_timestamp
+from scout_apm.compat import datetime_to_timestamp, utc
 from scout_apm.flask import ScoutApm
 from tests.integration.util import (
     parametrize_filtered_params,
@@ -114,7 +114,7 @@ def test_user_ip(headers, client_address, expected, tracked_requests):
 @parametrize_queue_time_header_name
 def test_queue_time(header_name, tracked_requests):
     # Not testing floats due to Python 2/3 rounding differences
-    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow())) - 2
+    queue_start = int(datetime_to_timestamp(dt.datetime.now(tz=utc))) - 2
     with app_with_scout() as app:
         response = TestApp(app).get(
             "/", headers={header_name: str("t=") + str(queue_start)}
@@ -128,7 +128,7 @@ def test_queue_time(header_name, tracked_requests):
 
 
 def test_amazon_queue_time(tracked_requests):
-    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow())) - 2
+    queue_start = int(datetime_to_timestamp(dt.datetime.now(tz=utc))) - 2
     with app_with_scout() as app:
         response = TestApp(app).get(
             "/",

--- a/tests/integration/test_nameko.py
+++ b/tests/integration/test_nameko.py
@@ -11,7 +11,7 @@ from webtest import TestApp
 from werkzeug.wrappers import Response
 
 from scout_apm.api import Config
-from scout_apm.compat import datetime_to_timestamp
+from scout_apm.compat import datetime_to_timestamp, utc
 from scout_apm.nameko import ScoutReporter
 from tests.integration.util import (
     parametrize_filtered_params,
@@ -136,7 +136,7 @@ def test_user_ip(headers, client_address, expected, tracked_requests):
 @parametrize_queue_time_header_name
 def test_queue_time(header_name, tracked_requests):
     # Not testing floats due to Python 2/3 rounding differences
-    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow())) - 2
+    queue_start = int(datetime_to_timestamp(dt.datetime.now(tz=utc))) - 2
     with app_with_scout() as app:
         response = TestApp(app).get(
             "/", headers={header_name: str("t=") + str(queue_start)}
@@ -150,7 +150,7 @@ def test_queue_time(header_name, tracked_requests):
 
 
 def test_amazon_queue_time(tracked_requests):
-    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow())) - 2
+    queue_start = int(datetime_to_timestamp(dt.datetime.now(tz=utc))) - 2
     with app_with_scout() as app:
         response = TestApp(app).get(
             "/",

--- a/tests/integration/test_pyramid.py
+++ b/tests/integration/test_pyramid.py
@@ -10,7 +10,7 @@ from pyramid.response import Response
 from webtest import TestApp
 
 from scout_apm.api import Config
-from scout_apm.compat import datetime_to_timestamp
+from scout_apm.compat import datetime_to_timestamp, utc
 from tests.integration.util import (
     parametrize_filtered_params,
     parametrize_queue_time_header_name,
@@ -108,7 +108,7 @@ def test_user_ip(headers, client_address, expected, tracked_requests):
 @parametrize_queue_time_header_name
 def test_queue_time(header_name, tracked_requests):
     # Not testing floats due to Python 2/3 rounding differences
-    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow())) - 2
+    queue_start = int(datetime_to_timestamp(dt.datetime.now(tz=utc))) - 2
     with app_with_scout() as app:
         response = TestApp(app).get(
             "/", headers={header_name: str("t=") + str(queue_start)}
@@ -122,7 +122,7 @@ def test_queue_time(header_name, tracked_requests):
 
 
 def test_amazon_queue_time(tracked_requests):
-    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow())) - 2
+    queue_start = int(datetime_to_timestamp(dt.datetime.now(tz=utc))) - 2
     with app_with_scout() as app:
         response = TestApp(app).get(
             "/",

--- a/tests/integration/test_starlette_py36plus.py
+++ b/tests/integration/test_starlette_py36plus.py
@@ -16,7 +16,7 @@ from starlette.responses import PlainTextResponse
 
 from scout_apm.api import Config
 from scout_apm.async_.starlette import ScoutMiddleware
-from scout_apm.compat import datetime_to_timestamp
+from scout_apm.compat import datetime_to_timestamp, utc
 from tests.integration.util import (
     parametrize_filtered_params,
     parametrize_queue_time_header_name,
@@ -219,7 +219,7 @@ async def test_user_ip(headers, client_address, expected, tracked_requests):
 @async_test
 async def test_queue_time(header_name, tracked_requests):
     # Not testing floats due to Python 2/3 rounding differences
-    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow())) - 2
+    queue_start = int(datetime_to_timestamp(dt.datetime.now(tz=utc))) - 2
     with app_with_scout() as app:
         communicator = ApplicationCommunicator(
             app,
@@ -238,7 +238,7 @@ async def test_queue_time(header_name, tracked_requests):
 
 @async_test
 async def test_amazon_queue_time(tracked_requests):
-    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow())) - 2
+    queue_start = int(datetime_to_timestamp(dt.datetime.now(tz=utc))) - 2
     with app_with_scout() as app:
         communicator = ApplicationCommunicator(
             app,

--- a/tests/unit/core/samplers/test_cpu.py
+++ b/tests/unit/core/samplers/test_cpu.py
@@ -6,13 +6,14 @@ import logging
 
 from psutil._common import pcputimes
 
+from scout_apm.compat import utc
 from scout_apm.core.samplers.cpu import Cpu
 from tests.compat import mock
 
 
 def test_run_negative_time_elapsed(caplog):
     cpu = Cpu()
-    cpu.last_run = dt.datetime.utcnow() + dt.timedelta(days=100)
+    cpu.last_run = dt.datetime.now(tz=utc) + dt.timedelta(days=100)
 
     result = cpu.run()
 

--- a/tests/unit/core/test_tracked_request.py
+++ b/tests/unit/core/test_tracked_request.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import datetime as dt
 import sys
 
+from scout_apm.compat import utc
 from scout_apm.core import objtrace
 from scout_apm.core.tracked_request import TrackedRequest
 from tests.tools import skip_if_objtrace_is_extension, skip_if_objtrace_not_extension
@@ -124,7 +125,7 @@ def test_start_span_ignores_children(tracked_request):
 def test_span_captures_backtrace(tracked_request):
     span = tracked_request.start_span(operation="Sql/Work")
     # Pretend it was started 1 second ago
-    span.start_time = dt.datetime.utcnow() - dt.timedelta(seconds=1)
+    span.start_time = dt.datetime.now(tz=utc) - dt.timedelta(seconds=1)
     tracked_request.stop_span()
     assert "stack" in span.tags
 

--- a/tests/unit/core/test_web_requests.py
+++ b/tests/unit/core/test_web_requests.py
@@ -6,7 +6,7 @@ import time
 
 import pytest
 
-from scout_apm.compat import datetime_to_timestamp
+from scout_apm.compat import datetime_to_timestamp, utc
 from scout_apm.core.config import scout_config
 from scout_apm.core.web_requests import (
     CUTOFF_EPOCH_S,
@@ -89,7 +89,7 @@ def test_ignore_multiple_prefixes(path, expected):
 
 @pytest.mark.parametrize("with_t", [True, False])
 def test_track_request_queue_time_valid(with_t, tracked_request):
-    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow())) - 2
+    queue_start = int(datetime_to_timestamp(dt.datetime.now(tz=utc))) - 2
     if with_t:
         header_value = str("t=") + str(queue_start)
     else:
@@ -109,8 +109,8 @@ def test_track_request_queue_time_valid(with_t, tracked_request):
         str(""),
         str("t=X"),  # first character not a digit
         str("t=0.3f"),  # raises ValueError on float() conversion
-        str(datetime_to_timestamp(dt.datetime.utcnow()) + 3600.0),  # one hour in future
-        str(datetime_to_timestamp(dt.datetime(2009, 1, 1))),  # before ambig cutoff
+        str(datetime_to_timestamp(dt.datetime.now(tz=utc)) + 3600.0),  # one hour in future
+        str(datetime_to_timestamp(dt.datetime(2009, 1, 1, tzinfo=utc))),  # before ambig cutoff
     ],
 )
 def test_track_request_queue_time_invalid(header_value, tracked_request):
@@ -131,7 +131,7 @@ def test_track_request_queue_time_invalid(header_value, tracked_request):
     ],
 )
 def test_track_amazon_request_queue_time_valid(header_value, tracked_request):
-    start_time = int(datetime_to_timestamp(dt.datetime.utcnow())) - 2
+    start_time = int(datetime_to_timestamp(dt.datetime.now(tz=utc))) - 2
 
     result = track_amazon_request_queue_time(
         header_value.format(start_time=start_time), tracked_request

--- a/tests/unit/core/test_web_requests.py
+++ b/tests/unit/core/test_web_requests.py
@@ -109,8 +109,12 @@ def test_track_request_queue_time_valid(with_t, tracked_request):
         str(""),
         str("t=X"),  # first character not a digit
         str("t=0.3f"),  # raises ValueError on float() conversion
-        str(datetime_to_timestamp(dt.datetime.now(tz=utc)) + 3600.0),  # one hour in future
-        str(datetime_to_timestamp(dt.datetime(2009, 1, 1, tzinfo=utc))),  # before ambig cutoff
+        str(
+            datetime_to_timestamp(dt.datetime.now(tz=utc)) + 3600.0
+        ),  # one hour in future
+        str(
+            datetime_to_timestamp(dt.datetime(2009, 1, 1, tzinfo=utc))
+        ),  # before ambig cutoff
     ],
 )
 def test_track_request_queue_time_invalid(header_value, tracked_request):

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -5,7 +5,7 @@ import datetime as dt
 
 import pytest
 
-from scout_apm.compat import ContextDecorator, datetime_to_timestamp, text
+from scout_apm.compat import ContextDecorator, datetime_to_timestamp, text, utc
 
 
 def test_context_decorator():
@@ -33,10 +33,10 @@ def test_context_decorator():
 @pytest.mark.parametrize(
     "given, expected",
     [
-        (dt.datetime(1970, 1, 1), 0),
-        (dt.datetime(1970, 1, 1, 1), 3600.0),
-        (dt.datetime(1970, 1, 1, 0, 30), 1800.0),
-        (dt.datetime(2019, 7, 2, 9, 23, 41), 1562059421.0),
+        (dt.datetime(1970, 1, 1, tzinfo=utc), 0),
+        (dt.datetime(1970, 1, 1, 1, tzinfo=utc), 3600.0),
+        (dt.datetime(1970, 1, 1, 0, 30, tzinfo=utc), 1800.0),
+        (dt.datetime(2019, 7, 2, 9, 23, 41, tzinfo=utc), 1562059421.0),
     ],
 )
 def test_datetime_to_timestamp(given, expected):


### PR DESCRIPTION
Fixes #368. Avoids ambiguous datetimes throughout the system.