### PR TITLE
Remove passenv = * from tox config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,9 @@ setenv =
     PYTHONPATH={toxinidir}/tests
     PYTHONUNBUFFERED=yes
 passenv =
-    *
+    ELASTICSEARCH_URL
+    MONGODB_URL
+    REDIS_URL
 usedevelop = false
 deps =
     bottle


### PR DESCRIPTION
Only pass the environment variables we know the test suite uses. This prevents unintended overrides. `SCOUT_*` env vars are already cleared in `conftest.py` thanks to 475620d3 but this is a more solid approach.