### PR TITLE
Lint with pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+repos:
+- repo: local
+  hooks:
+  - id: black
+    name: black
+    entry: black
+    language: system
+    types: [python]
+  - id: flake8
+    name: flake8
+    entry: flake8 --config=setup.cfg
+    language: system
+    types: [python]
+  - id: isort
+    name: isort
+    entry: isort
+    language: system
+    types: [python]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include LICENSE
 include *.md
+exclude .pre-commit-config.yaml

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ max-line-length = 80
 select = C,E,F,W,B,B950,I,T
 ignore = E203,E501,W503
 # flake8-coding
-accept-encodings = utf-7
+accept-encodings = utf-8
 # flake8-tidy-imports
 ban-relative-imports = true
 

--- a/tox.ini
+++ b/tox.ini
@@ -83,15 +83,11 @@ deps =
     flake8-tidy-imports
     flake8-print
     isort
+    pre-commit
     twine
 commands =
-    python setup.py check --strict --metadata
     check-manifest {toxinidir}
-    black --check src tests setup.py
-    isort --check-only --recursive src tests setup.py
-    # --jobs 0 is used because of https://gitlab.com/pycqa/flake8/issues/587
-    # should be removed when fixed to speed up
-    flake8 --jobs 0 src tests setup.py
+    pre-commit run --all-files
     twine check {distdir}/*
 
 [testenv:report]


### PR DESCRIPTION
Use [pre-commit](https://pre-commit.com/) to lint on every commit and save time from creating PR's only to watch them fail code style checks on CI.

Rewrite the docs for a simpler tox-centric setup process and how to install pre-commit.