### PR TITLE
Update CoreAgent version to 1.2.6, with several bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Pending
+
+### Added
+
+- Updated CoreAgent version to 1.2.6, fixing serveral bugs (#415)
+  - SQL statements will now have better names in the Timeline Traces
+  - Standardized a `language_version` key in Metadata
+  - Autocloses spans that are still running when Request completes
+
 ## [2.9.0] 2019-11-29
 
 ### Added

--- a/src/scout_apm/core/config.py
+++ b/src/scout_apm/core/config.py
@@ -223,7 +223,7 @@ class ScoutConfigDefaults(object):
             "core_agent_launch": True,
             "core_agent_log_level": "info",
             "core_agent_permissions": 700,
-            "core_agent_version": "v1.2.4",  # can be an exact tag name, or 'latest'
+            "core_agent_version": "v1.2.6",  # can be an exact tag name, or 'latest'
             "disabled_instruments": [],
             "download_url": "https://s3-us-west-1.amazonaws.com/scout-public-downloads/apm_core_agent/release",  # noqa: E501
             "framework": "",


### PR DESCRIPTION
(from CA's changelog)

[1.2.6] 2019-12-03

Fixed:

* Use SQL derived names in SpanTraces (#97)

[1.2.5] 2019-12-02

Added:

* Autoclose running spans when request finishes (#93)
* Rate Limit AppServerLoad metadata (#94)
* Add `language_version` key to AppServerLoad metadata (#95)

Fixed:

* Prevent errors if AppServerLoad metadata is not set (#92)