### PR TITLE
Use Python version checking for all compat imports

### DIFF
--- a/src/scout_apm/compat.py
+++ b/src/scout_apm/compat.py
@@ -10,8 +10,9 @@ string_type = str if sys.version_info[0] >= 3 else basestring  # noqa: F821
 text_type = str if sys.version_info[0] >= 3 else unicode  # noqa: F821
 string_types = tuple({string_type, text_type})
 
-# Python 2 (and very early 3.x) didn't have ContextDecorator, so define it for ourselves
-if sys.version_info < (3, 2):
+if sys.version_info >= (3, 2):
+    from contextlib import ContextDecorator
+else:
     import functools
 
     class ContextDecorator(object):
@@ -24,14 +25,9 @@ if sys.version_info < (3, 2):
             return decorated
 
 
-else:
-    from contextlib import ContextDecorator
-
-try:
-    # Python 3.x
+if sys.version_info >= (3, 0):
     import queue
-except ImportError:
-    # Python 2.x
+else:
     import Queue as queue
 
 # datetime_to_timestamp converts a naive UTC datetime to a unix timestamp
@@ -60,9 +56,9 @@ def text(value, encoding="utf-8", errors="strict"):
         return text_type(value)
 
 
-try:
+if sys.version_info >= (3, 0):
     from urllib.parse import urlencode
-except ImportError:
+else:
     from urllib import urlencode
 
 

--- a/tests/compat.py
+++ b/tests/compat.py
@@ -3,15 +3,14 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import sys
 
-try:
-    from unittest import mock
-except ImportError:
-    # Python 2
+if sys.version_info >= (3, 0):
     import mock
+else:
+    from unittest import mock
 
-try:
+if sys.version_info >= (3, 2):
     from tempfile import TemporaryDirectory
-except ImportError:  # Python < 3.2
+else:
     from contextlib import contextmanager
     from tempfile import mkdtemp
     from shutil import rmtree

--- a/tests/compat.py
+++ b/tests/compat.py
@@ -4,9 +4,9 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import sys
 
 if sys.version_info >= (3, 0):
-    import mock
-else:
     from unittest import mock
+else:
+    import mock
 
 if sys.version_info >= (3, 2):
     from tempfile import TemporaryDirectory

--- a/tox.ini
+++ b/tox.ini
@@ -54,7 +54,7 @@ deps =
     httpretty
     jinja2
     nameko<3
-    py27: mock
+    mock ; python_version < "3.0"
     psutil
     pymongo
     pyramid


### PR DESCRIPTION
We were doing this inconsistently.  I prefer checking versions as it avoids burying errors. See https://twitter.com/nicoddemus/status/1146196274309414912 .