### PR TITLE
Make tests error on any warnings we raise

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -33,3 +33,6 @@ addopts = --cov=scout_apm
           # E               TypeError: wrap_socket() got an unexpected keyword argument '_context'
           -p no:pytest_nameko
 norecursedirs = src
+filterwarnings =
+    error:::scout_apm
+    error:::tests

--- a/tests/unit/core/test_util.py
+++ b/tests/unit/core/test_util.py
@@ -1,6 +1,8 @@
 # coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import pytest
+
 from scout_apm.core.util import octal
 
 
@@ -13,7 +15,5 @@ def test_octal_with_valid_string():
 
 
 def test_octal_raises_valueerror_on_invalid_value():
-    try:
+    with pytest.raises(ValueError):
         octal("THIS IS INVALID")
-    except ValueError:
-        pass


### PR DESCRIPTION
Ref #296. Configure warnings through Pytest's [filterwarnings option](https://docs.pytest.org/en/latest/warnings.html) so if we cause a warning to be raised, the test fails. Also improve octal tests slightly.