### PR TITLE
Fix 2.9.0 release date in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - Fix recording of path for unicode query parameters on Python 2.7
   ([PR #419](https://github.com/scoutapp/scout_apm_python/pull/419)).
 
-## [2.9.0] 2019-11-29
+## [2.9.0] 2019-11-30
 
 ### Added
 


### PR DESCRIPTION
It was only released a day later due to problems getting release to work.