### PR TITLE
Add and use common ASGI helpers

### DIFF
--- a/tests/integration/test_starlette_py36plus.py
+++ b/tests/integration/test_starlette_py36plus.py
@@ -24,7 +24,7 @@ from tests.integration.util import (
     parametrize_queue_time_header_name,
     parametrize_user_ip_headers,
 )
-from tests.tools import async_test
+from tests.tools import asgi_http_scope, async_test
 
 
 @contextmanager
@@ -96,28 +96,10 @@ def app_with_scout(*, middleware=None, scout_config=None):
         Config.reset_all()
 
 
-def get_scope(headers=None, **kwargs):
-    if headers is None:
-        headers = {}
-    headers = [
-        [k.lower().encode("latin-1"), v.encode("latin-1")] for k, v in headers.items()
-    ]
-    return {
-        "type": "http",
-        "asgi": {"version": "3.0", "spec_version": "2.1"},
-        "http_version": "1.1",
-        "method": "GET",
-        "query_string": b"",
-        "server": ("testserver", 80),
-        "headers": headers,
-        **kwargs,
-    }
-
-
 @async_test
 async def test_home(tracked_requests):
     with app_with_scout() as app:
-        communicator = ApplicationCommunicator(app, get_scope(path="/"))
+        communicator = ApplicationCommunicator(app, asgi_http_scope(path="/"))
         await communicator.send_input({"type": "http.request"})
         # Read the response.
         response_start = await communicator.receive_output()
@@ -141,7 +123,7 @@ async def test_home(tracked_requests):
 @async_test
 async def test_home_ignored(tracked_requests):
     with app_with_scout(scout_config={"ignore": ["/"]}) as app:
-        communicator = ApplicationCommunicator(app, get_scope(path="/"))
+        communicator = ApplicationCommunicator(app, asgi_http_scope(path="/"))
         await communicator.send_input({"type": "http.request"})
         # Read the response.
         response_start = await communicator.receive_output()
@@ -157,7 +139,7 @@ async def test_home_ignored(tracked_requests):
 @async_test
 async def test_hello(tracked_requests):
     with app_with_scout() as app:
-        communicator = ApplicationCommunicator(app, get_scope(path="/hello/"))
+        communicator = ApplicationCommunicator(app, asgi_http_scope(path="/hello/"))
         await communicator.send_input({"type": "http.request"})
         # Read the response.
         response_start = await communicator.receive_output()
@@ -181,7 +163,7 @@ async def test_hello(tracked_requests):
 @async_test
 async def test_not_found(tracked_requests):
     with app_with_scout() as app:
-        communicator = ApplicationCommunicator(app, get_scope(path="/not-found/"))
+        communicator = ApplicationCommunicator(app, asgi_http_scope(path="/not-found/"))
         await communicator.send_input({"type": "http.request"})
         # Read the response.
         response_start = await communicator.receive_output()
@@ -197,7 +179,8 @@ async def test_not_found(tracked_requests):
 async def test_filtered_params(params, expected_path, tracked_requests):
     with app_with_scout() as app:
         communicator = ApplicationCommunicator(
-            app, get_scope(path="/", query_string=urlencode(params).encode("utf-8"))
+            app,
+            asgi_http_scope(path="/", query_string=urlencode(params).encode("utf-8")),
         )
         await communicator.send_input({"type": "http.request"})
         response_start = await communicator.receive_output()
@@ -213,7 +196,8 @@ async def test_filtered_params(params, expected_path, tracked_requests):
 async def test_user_ip(headers, client_address, expected, tracked_requests):
     with app_with_scout() as app:
         communicator = ApplicationCommunicator(
-            app, get_scope(path="/", headers=headers, client=(client_address, None))
+            app,
+            asgi_http_scope(path="/", headers=headers, client=(client_address, None)),
         )
         await communicator.send_input({"type": "http.request"})
         response_start = await communicator.receive_output()
@@ -221,8 +205,7 @@ async def test_user_ip(headers, client_address, expected, tracked_requests):
 
     assert response_start["type"] == "http.response.start"
     assert response_start["status"] == 200
-    tracked_request = tracked_requests[0]
-    assert tracked_request.tags["user_ip"] == expected
+    assert tracked_requests[0].tags["user_ip"] == expected
 
 
 @parametrize_queue_time_header_name
@@ -233,7 +216,9 @@ async def test_queue_time(header_name, tracked_requests):
     with app_with_scout() as app:
         communicator = ApplicationCommunicator(
             app,
-            get_scope(path="/", headers={header_name: str("t=") + str(queue_start)}),
+            asgi_http_scope(
+                path="/", headers={header_name: str("t=") + str(queue_start)}
+            ),
         )
         await communicator.send_input({"type": "http.request"})
         response_start = await communicator.receive_output()
@@ -252,7 +237,7 @@ async def test_amazon_queue_time(tracked_requests):
     with app_with_scout() as app:
         communicator = ApplicationCommunicator(
             app,
-            get_scope(
+            asgi_http_scope(
                 path="/",
                 headers={
                     "X-Amzn-Trace-Id": "Self=1-{}-12456789abcdef012345678".format(
@@ -275,7 +260,7 @@ async def test_amazon_queue_time(tracked_requests):
 @async_test
 async def test_server_error(tracked_requests):
     with app_with_scout() as app:
-        communicator = ApplicationCommunicator(app, get_scope(path="/crash/"))
+        communicator = ApplicationCommunicator(app, asgi_http_scope(path="/crash/"))
         with pytest.raises(ValueError) as excinfo:
             await communicator.send_input({"type": "http.request"})
             await communicator.receive_output()
@@ -296,7 +281,9 @@ async def test_server_error(tracked_requests):
 @async_test
 async def test_return_error(tracked_requests):
     with app_with_scout() as app:
-        communicator = ApplicationCommunicator(app, get_scope(path="/return-error/"))
+        communicator = ApplicationCommunicator(
+            app, asgi_http_scope(path="/return-error/")
+        )
         await communicator.send_input({"type": "http.request"})
         response_start = await communicator.receive_output()
         await communicator.receive_output()
@@ -312,7 +299,7 @@ async def test_return_error(tracked_requests):
 @async_test
 async def test_no_monitor(tracked_requests):
     with app_with_scout(scout_config={"monitor": False}) as app:
-        communicator = ApplicationCommunicator(app, get_scope(path="/"))
+        communicator = ApplicationCommunicator(app, asgi_http_scope(path="/"))
         await communicator.send_input({"type": "http.request"})
         response_start = await communicator.receive_output()
         await communicator.receive_output()
@@ -336,7 +323,9 @@ async def test_unknown_asgi_scope(tracked_requests):
 @async_test
 async def test_background_jobs(tracked_requests):
     with app_with_scout() as app:
-        communicator = ApplicationCommunicator(app, get_scope(path="/background-jobs/"))
+        communicator = ApplicationCommunicator(
+            app, asgi_http_scope(path="/background-jobs/")
+        )
         await communicator.send_input({"type": "http.request"})
         response_start = await communicator.receive_output()
         response_body = await communicator.receive_output()
@@ -373,7 +362,7 @@ async def test_username(tracked_requests):
     middleware = [Middleware(AuthenticationMiddleware, backend=DummyBackend())]
 
     with app_with_scout(middleware=middleware) as app:
-        communicator = ApplicationCommunicator(app, get_scope(path="/"))
+        communicator = ApplicationCommunicator(app, asgi_http_scope(path="/"))
         await communicator.send_input({"type": "http.request"})
         response_start = await communicator.receive_output()
         await communicator.receive_output()
@@ -394,7 +383,7 @@ async def test_username_bad_user(tracked_requests):
     middleware = [Middleware(AuthenticationMiddleware, backend=BadUserBackend())]
 
     with app_with_scout(middleware=middleware) as app:
-        communicator = ApplicationCommunicator(app, get_scope(path="/"))
+        communicator = ApplicationCommunicator(app, asgi_http_scope(path="/"))
         await communicator.send_input({"type": "http.request"})
         response_start = await communicator.receive_output()
         await communicator.receive_output()

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -91,3 +91,22 @@ def async_test(func):
         return sync_func(*args, **kwargs)
 
     return wrapper
+
+
+def asgi_http_scope(headers=None, **kwargs):
+    if headers is None:
+        headers = {}
+    headers = [
+        [k.lower().encode("latin-1"), v.encode("latin-1")] for k, v in headers.items()
+    ]
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0", "spec_version": "2.1"},
+        "http_version": "1.1",
+        "method": "GET",
+        "query_string": b"",
+        "server": ("testserver", 80),
+        "headers": headers,
+    }
+    scope.update(kwargs)
+    return scope


### PR DESCRIPTION
Extracted from #412 whilst it's still in development:

* Move the Starlette-specific ASGI request data tracking into a generic helper `asgi_track_request_data` that should also do a bit less work.
* Move the test function `get_scope()` into a generic test tool `asgi_http_scope()`