### PR TITLE
Use latest twine again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,10 +41,11 @@ jobs:
         - CIBW_SKIP="cp33-*"
         - TWINE_NON_INTERACTIVE=1
         - TWINE_USERNAME=scout
+        # TWINE_PASSWORD:
         - secure: "ohvspT59/b71SdnIFf/HA5552tGaYWLYTUV2IQ/ZNxrTiJd/hcm5eBbfAkOUiC6l2cxdHt+cAyRh27us32z7F29qzlSzrWkTD18pvFKjSGtaa2X0aBTiollfiGgiXpdT5wiDoyjyGWti3q4CpwOZjrpB/rZx0DUxdRejf0cQfs/6W8xqei/PeSTAY+58eRxKUo9JOsEObDgpjJFSWTHVip6Rm0C8zG5fEal6OEMozP+LncSzxIPZiaA0x82nYSMSBQiJXqgX6x1iNDUVl9W1wwghPjCxhz1n6kUtoKOnLcz2VhtmzR+rFDXcdgIr3l9HsSaj8t/jRIPwyUuB1DDamKWuEC0dFrqeTraOKz/t7eZkSpKa+jRaNUC4RLPSSNJVC3hEH8WlNIAyCGyvYv0RAGEYzrWcl0QZQgn1s205uIVKF8v3bepAV4oPUOEjhAk3+kVhBDLrUHWnDtLzQxPJOcC/PpMIkXx5+ZCADJrkmppEAtv+gAbHIE5gcodvyGgUc1ynp/Ul2LQxUX7KUopZBkBtFomRJWOXli5rV9tc8It+m91Xua6+jRB8UePyHw2KLGoABulNNoGSvr+uRdH8Ph/4des33iikTEnEDBk740NAsMW1pExMMlXAdaYScpBjCu7z3MrSCs4oraCVJ1g9nqbc7ugxVqMPC97fu7XKpe8="
       script:
         - python setup.py sdist
-        - pip install --upgrade cibuildwheel twine==3.1.0
+        - pip install --upgrade cibuildwheel twine
         - cibuildwheel
         - twine check dist/* wheelhouse/*
         - ls -al dist wheelhouse


### PR DESCRIPTION
After reviewing the changes to Twine and the slightly panicked changes I made to the Travis config to ship 2.9.0, I think the configuration I ended up with should work on Twine 3.1.1 as well. Fixes #411.

We'll only be able to test on next release.