### PR TITLE
Make tests error on any unknown warning

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -34,5 +34,9 @@ addopts = --cov=scout_apm
           -p no:pytest_nameko
 norecursedirs = src
 filterwarnings =
-    error:::scout_apm
-    error:::tests
+    error
+    ignore:the imp module is deprecated.*:DeprecationWarning:eventlet
+    ignore:dns.hash module will be removed.*:DeprecationWarning:dns.hash
+    ignore:Using or importing the ABCs from 'collections'.*:DeprecationWarning:dns.namedict
+    ignore:Using or importing the ABCs from 'collections'.*:DeprecationWarning:bs4.element
+    ignore:Using or importing the ABCs from 'collections'.*:DeprecationWarning:nameko.exceptions

--- a/pytest.ini
+++ b/pytest.ini
@@ -40,5 +40,6 @@ filterwarnings =
     ignore:parameter codeset is deprecated:DeprecationWarning:gettext
     ignore:Using or importing the ABCs from 'collections'.*:DeprecationWarning:bs4.element
     ignore:Using or importing the ABCs from 'collections'.*:DeprecationWarning:django.db.models.fields
+    ignore:Using or importing the ABCs from 'collections'.*:DeprecationWarning:django.db.models.sql.query
     ignore:Using or importing the ABCs from 'collections'.*:DeprecationWarning:dns.namedict
     ignore:Using or importing the ABCs from 'collections'.*:DeprecationWarning:nameko.exceptions

--- a/pytest.ini
+++ b/pytest.ini
@@ -36,9 +36,9 @@ norecursedirs = src
 filterwarnings =
     error
     ignore:the imp module is deprecated.*:DeprecationWarning:eventlet
+    ignore:the imp module is deprecated.*:PendingDeprecationWarning:distutils
     ignore:dns.hash module will be removed.*:DeprecationWarning:dns.hash
     ignore:parameter codeset is deprecated:DeprecationWarning:gettext
-    ignore:the imp module is deprecated.*:PendingDeprecationWarning:imp
     ignore:Using or importing the ABCs from 'collections'.*:DeprecationWarning:bs4.element
     ignore:Using or importing the ABCs from 'collections'.*:DeprecationWarning:django.db.models.fields
     ignore:Using or importing the ABCs from 'collections'.*:DeprecationWarning:django.db.models.sql.query

--- a/pytest.ini
+++ b/pytest.ini
@@ -38,6 +38,7 @@ filterwarnings =
     ignore:the imp module is deprecated.*:DeprecationWarning:eventlet
     ignore:dns.hash module will be removed.*:DeprecationWarning:dns.hash
     ignore:parameter codeset is deprecated:DeprecationWarning:gettext
+    ignore:the imp module is deprecated.*:PendingDeprecationWarning:imp
     ignore:Using or importing the ABCs from 'collections'.*:DeprecationWarning:bs4.element
     ignore:Using or importing the ABCs from 'collections'.*:DeprecationWarning:django.db.models.fields
     ignore:Using or importing the ABCs from 'collections'.*:DeprecationWarning:django.db.models.sql.query

--- a/pytest.ini
+++ b/pytest.ini
@@ -37,6 +37,8 @@ filterwarnings =
     error
     ignore:the imp module is deprecated.*:DeprecationWarning:eventlet
     ignore:dns.hash module will be removed.*:DeprecationWarning:dns.hash
-    ignore:Using or importing the ABCs from 'collections'.*:DeprecationWarning:dns.namedict
+    ignore:parameter codeset is deprecated:DeprecationWarning:gettext
     ignore:Using or importing the ABCs from 'collections'.*:DeprecationWarning:bs4.element
+    ignore:Using or importing the ABCs from 'collections'.*:DeprecationWarning:django.db.models.fields
+    ignore:Using or importing the ABCs from 'collections'.*:DeprecationWarning:dns.namedict
     ignore:Using or importing the ABCs from 'collections'.*:DeprecationWarning:nameko.exceptions

--- a/pytest.ini
+++ b/pytest.ini
@@ -34,7 +34,7 @@ addopts = --cov=scout_apm
           -p no:pytest_nameko
 norecursedirs = src
 filterwarnings =
-    error
+    default
     ignore:the imp module is deprecated.*:DeprecationWarning:eventlet
     ignore:the imp module is deprecated.*:PendingDeprecationWarning:distutils
     ignore:dns.hash module will be removed.*:DeprecationWarning:dns.hash

--- a/tests/integration/instruments/test_urllib3.py
+++ b/tests/integration/instruments/test_urllib3.py
@@ -8,6 +8,7 @@ import httpretty
 import pytest
 import urllib3
 
+from scout_apm.compat import string_type
 from scout_apm.instruments.urllib3 import ensure_installed
 from tests.compat import mock
 from tests.tools import delete_attributes
@@ -80,7 +81,9 @@ def test_request(tracked_request):
             httpretty.GET, "https://example.com/", body="Hello World!"
         )
 
-        http = urllib3.PoolManager(cert_reqs="CERT_REQUIRED", ca_certs=certifi.where())
+        http = urllib3.PoolManager(
+            cert_reqs=string_type("CERT_REQUIRED"), ca_certs=certifi.where()
+        )
         response = http.request("GET", "https://example.com")
 
     assert response.status == 200
@@ -94,7 +97,9 @@ def test_request(tracked_request):
 def test_request_type_error(tracked_request):
     ensure_installed()
     with pytest.raises(TypeError):
-        http = urllib3.PoolManager(cert_reqs="CERT_REQUIRED", ca_certs=certifi.where())
+        http = urllib3.PoolManager(
+            cert_reqs=string_type("CERT_REQUIRED"), ca_certs=certifi.where()
+        )
         connection = http.connection_from_host("example.com", scheme="https")
         connection.urlopen()
 

--- a/tests/integration/instruments/test_urllib3.py
+++ b/tests/integration/instruments/test_urllib3.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
+import sys
 
 import certifi
 import httpretty
@@ -15,6 +16,11 @@ from tests.tools import delete_attributes
 mock_not_attempted = mock.patch(
     "scout_apm.instruments.urllib3.have_patched_pool_urlopen", new=False
 )
+
+if sys.version_info >= (3, 0):
+    CERT_REQUIRED = "CERT_REQUIRED"
+else:
+    CERT_REQUIRED = b"CERT_REQUIRED"
 
 
 def test_ensure_installed_twice(caplog):
@@ -80,7 +86,7 @@ def test_request(tracked_request):
             httpretty.GET, "https://example.com/", body="Hello World!"
         )
 
-        http = urllib3.PoolManager(cert_reqs=b"CERT_REQUIRED", ca_certs=certifi.where())
+        http = urllib3.PoolManager(cert_reqs=CERT_REQUIRED, ca_certs=certifi.where())
         response = http.request("GET", "https://example.com")
 
     assert response.status == 200
@@ -94,7 +100,7 @@ def test_request(tracked_request):
 def test_request_type_error(tracked_request):
     ensure_installed()
     with pytest.raises(TypeError):
-        http = urllib3.PoolManager(cert_reqs=b"CERT_REQUIRED", ca_certs=certifi.where())
+        http = urllib3.PoolManager(cert_reqs=CERT_REQUIRED, ca_certs=certifi.where())
         connection = http.connection_from_host("example.com", scheme="https")
         connection.urlopen()
 
@@ -112,7 +118,7 @@ def test_request_no_absolute_url(caplog, tracked_request):
             httpretty.GET, "https://example.com/", body="Hello World!"
         )
 
-        http = urllib3.PoolManager(cert_reqs=b"CERT_REQUIRED", ca_certs=certifi.where())
+        http = urllib3.PoolManager(cert_reqs=CERT_REQUIRED, ca_certs=certifi.where())
         response = http.request("GET", "https://example.com")
 
     assert response.status == 200

--- a/tests/integration/instruments/test_urllib3.py
+++ b/tests/integration/instruments/test_urllib3.py
@@ -8,7 +8,6 @@ import httpretty
 import pytest
 import urllib3
 
-from scout_apm.compat import text_type
 from scout_apm.instruments.urllib3 import ensure_installed
 from tests.compat import mock
 from tests.tools import delete_attributes
@@ -82,7 +81,7 @@ def test_request(tracked_request):
         )
 
         http = urllib3.PoolManager(
-            cert_reqs=text_type("CERT_REQUIRED"), ca_certs=certifi.where()
+            cert_reqs=bytes("CERT_REQUIRED"), ca_certs=certifi.where()
         )
         response = http.request("GET", "https://example.com")
 
@@ -98,7 +97,7 @@ def test_request_type_error(tracked_request):
     ensure_installed()
     with pytest.raises(TypeError):
         http = urllib3.PoolManager(
-            cert_reqs=text_type("CERT_REQUIRED"), ca_certs=certifi.where()
+            cert_reqs=bytes("CERT_REQUIRED"), ca_certs=certifi.where()
         )
         connection = http.connection_from_host("example.com", scheme="https")
         connection.urlopen()

--- a/tests/integration/instruments/test_urllib3.py
+++ b/tests/integration/instruments/test_urllib3.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import logging
 
+import certifi
 import httpretty
 import pytest
 import urllib3
@@ -79,7 +80,7 @@ def test_request(tracked_request):
             httpretty.GET, "https://example.com/", body="Hello World!"
         )
 
-        http = urllib3.PoolManager()
+        http = urllib3.PoolManager(cert_reqs="CERT_REQUIRED", ca_certs=certifi.where())
         response = http.request("GET", "https://example.com")
 
     assert response.status == 200
@@ -93,7 +94,7 @@ def test_request(tracked_request):
 def test_request_type_error(tracked_request):
     ensure_installed()
     with pytest.raises(TypeError):
-        http = urllib3.PoolManager()
+        http = urllib3.PoolManager(cert_reqs="CERT_REQUIRED", ca_certs=certifi.where())
         connection = http.connection_from_host("example.com", scheme="https")
         connection.urlopen()
 
@@ -111,7 +112,7 @@ def test_request_no_absolute_url(caplog, tracked_request):
             httpretty.GET, "https://example.com/", body="Hello World!"
         )
 
-        http = urllib3.PoolManager()
+        http = urllib3.PoolManager(cert_reqs="CERT_REQUIRED", ca_certs=certifi.where())
         response = http.request("GET", "https://example.com")
 
     assert response.status == 200

--- a/tests/integration/instruments/test_urllib3.py
+++ b/tests/integration/instruments/test_urllib3.py
@@ -80,9 +80,7 @@ def test_request(tracked_request):
             httpretty.GET, "https://example.com/", body="Hello World!"
         )
 
-        http = urllib3.PoolManager(
-            cert_reqs=bytes("CERT_REQUIRED"), ca_certs=certifi.where()
-        )
+        http = urllib3.PoolManager(cert_reqs=b"CERT_REQUIRED", ca_certs=certifi.where())
         response = http.request("GET", "https://example.com")
 
     assert response.status == 200
@@ -96,9 +94,7 @@ def test_request(tracked_request):
 def test_request_type_error(tracked_request):
     ensure_installed()
     with pytest.raises(TypeError):
-        http = urllib3.PoolManager(
-            cert_reqs=bytes("CERT_REQUIRED"), ca_certs=certifi.where()
-        )
+        http = urllib3.PoolManager(cert_reqs=b"CERT_REQUIRED", ca_certs=certifi.where())
         connection = http.connection_from_host("example.com", scheme="https")
         connection.urlopen()
 
@@ -116,7 +112,7 @@ def test_request_no_absolute_url(caplog, tracked_request):
             httpretty.GET, "https://example.com/", body="Hello World!"
         )
 
-        http = urllib3.PoolManager(cert_reqs="CERT_REQUIRED", ca_certs=certifi.where())
+        http = urllib3.PoolManager(cert_reqs=b"CERT_REQUIRED", ca_certs=certifi.where())
         response = http.request("GET", "https://example.com")
 
     assert response.status == 200

--- a/tests/integration/instruments/test_urllib3.py
+++ b/tests/integration/instruments/test_urllib3.py
@@ -8,7 +8,7 @@ import httpretty
 import pytest
 import urllib3
 
-from scout_apm.compat import string_type
+from scout_apm.compat import text_type
 from scout_apm.instruments.urllib3 import ensure_installed
 from tests.compat import mock
 from tests.tools import delete_attributes
@@ -82,7 +82,7 @@ def test_request(tracked_request):
         )
 
         http = urllib3.PoolManager(
-            cert_reqs=string_type("CERT_REQUIRED"), ca_certs=certifi.where()
+            cert_reqs=text_type("CERT_REQUIRED"), ca_certs=certifi.where()
         )
         response = http.request("GET", "https://example.com")
 
@@ -98,7 +98,7 @@ def test_request_type_error(tracked_request):
     ensure_installed()
     with pytest.raises(TypeError):
         http = urllib3.PoolManager(
-            cert_reqs=string_type("CERT_REQUIRED"), ca_certs=certifi.where()
+            cert_reqs=text_type("CERT_REQUIRED"), ca_certs=certifi.where()
         )
         connection = http.connection_from_host("example.com", scheme="https")
         connection.urlopen()

--- a/tox.ini
+++ b/tox.ini
@@ -67,7 +67,7 @@ deps =
     six
     sqlalchemy
     starlette ; python_version >= "3.6"
-    urllib3
+    urllib3[secure]
     webtest
 commands =
     pytest {posargs}


### PR DESCRIPTION
Fixes #296. Seems there were less third party warnings to chase down than I thought.