### PR TITLE
Remove Flask 'name' tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@
 - Add CherryPy integration
   ([PR #431](https://github.com/scoutapp/scout_apm_python/pull/431)).
 
+### Removed
+
+- Removed the "name" context tag on Flask requests - it only duplicated the
+  request name
+  ([PR #432](https://github.com/scoutapp/scout_apm_python/pull/432)).
+
 ## [2.9.1] 2019-12-13
 
 ### Added

--- a/src/scout_apm/flask/__init__.py
+++ b/src/scout_apm/flask/__init__.py
@@ -48,7 +48,6 @@ class ScoutApm(object):
             operation=operation, should_capture_backtrace=False
         )
         request._scout_view_span = span
-        span.tag("name", name)
 
         werkzeug_track_request_data(request, tracked_request)
 

--- a/tests/integration/test_flask.py
+++ b/tests/integration/test_flask.py
@@ -74,7 +74,6 @@ def test_home(tracked_requests):
     assert tracked_request.tags["path"] == "/"
     span = tracked_request.complete_spans[0]
     assert span.operation == "Controller/tests.integration.test_flask.home"
-    assert span.tags["name"] == "tests.integration.test_flask.home"
 
 
 def test_home_ignored(tracked_requests):
@@ -158,7 +157,6 @@ def test_hello(tracked_requests):
     assert tracked_request.tags["path"] == "/hello/"
     span = tracked_request.complete_spans[0]
     assert span.operation == "Controller/tests.integration.test_flask.hello"
-    assert span.tags["name"] == "tests.integration.test_flask.hello"
 
 
 def test_hello_options(tracked_requests):
@@ -173,7 +171,6 @@ def test_hello_options(tracked_requests):
     assert tracked_request.tags["path"] == "/hello/"
     span = tracked_request.complete_spans[0]
     assert span.operation == "Controller/tests.integration.test_flask.hello"
-    assert span.tags["name"] == "tests.integration.test_flask.hello"
 
 
 def test_not_found(tracked_requests):
@@ -196,7 +193,6 @@ def test_server_error(tracked_requests):
     assert len(tracked_request.complete_spans) == 1
     span = tracked_request.complete_spans[0]
     assert span.operation == "Controller/tests.integration.test_flask.crash"
-    assert span.tags["name"] == "tests.integration.test_flask.crash"
 
 
 def test_return_error(tracked_requests):
@@ -211,7 +207,6 @@ def test_return_error(tracked_requests):
     assert len(tracked_request.complete_spans) == 1
     span = tracked_request.complete_spans[0]
     assert span.operation == "Controller/tests.integration.test_flask.return_error"
-    assert span.tags["name"] == "tests.integration.test_flask.return_error"
 
 
 def test_automatic_options(tracked_requests):


### PR DESCRIPTION
This duplicates the information in the Controller span and we don't do it for any of the other integrations.