### PR TITLE
Ignore unrecognized responses from the core agent

### DIFF
--- a/src/scout_apm/core/socket.py
+++ b/src/scout_apm/core/socket.py
@@ -179,6 +179,9 @@ class CoreAgentSocket(threading.Thread):
     def _read_response(self):
         try:
             raw_size = self.socket.recv(4)
+            if len(raw_size) != 4:
+                # Ignore invalid responses
+                return None
             size = struct.unpack(">I", raw_size)[0]
             message = bytearray(0)
 


### PR DESCRIPTION
Fixes #405.

Tested by modifying `StartSpan` to output in valid datetime strings. Saw `NoParse` in the core agent logs, Python socket thread didn't crash.