### PR TITLE
Add tracking for missing Elasticsearch client methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
   ([PR #431](https://github.com/scoutapp/scout_apm_python/pull/431)).
 - Added tracking for missing PyMongo Collection methods
   ([PR #436](https://github.com/scoutapp/scout_apm_python/pull/436)).
+- Added tracking for missing Elasticsearch client methods
+  ([PR #438](https://github.com/scoutapp/scout_apm_python/pull/438)).
 
 ### Removed
 

--- a/src/scout_apm/compat.py
+++ b/src/scout_apm/compat.py
@@ -95,6 +95,18 @@ def kwargs_only(func):
     return wrapper
 
 
+if sys.version_info >= (3, 0):
+
+    def get_function_argument_names(func):
+        return set(inspect.signature(func).parameters)
+
+
+else:
+
+    def get_function_argument_names(func):
+        return set(inspect.getargspec(func).args)
+
+
 __all__ = [
     "ContextDecorator",
     "datetime_to_timestamp",

--- a/src/scout_apm/compat.py
+++ b/src/scout_apm/compat.py
@@ -95,18 +95,6 @@ def kwargs_only(func):
     return wrapper
 
 
-if sys.version_info >= (3, 0):
-
-    def get_function_argument_names(func):
-        return set(inspect.signature(func).parameters)
-
-
-else:
-
-    def get_function_argument_names(func):
-        return set(inspect.getargspec(func).args)
-
-
 __all__ = [
     "ContextDecorator",
     "datetime_to_timestamp",

--- a/tests/integration/instruments/test_elasticsearch.py
+++ b/tests/integration/instruments/test_elasticsearch.py
@@ -27,12 +27,13 @@ def test_all_client_attributes_accounted_for():
         m for m in dir(elasticsearch.Elasticsearch) if not m.startswith("_")
     }
     deliberately_ignored_attributes = set()
+    wrapped_methods = {m.name for m in CLIENT_METHODS}
     assert (
-        public_attributes - deliberately_ignored_attributes - set(CLIENT_METHODS)
+        public_attributes - deliberately_ignored_attributes - wrapped_methods
     ) == set()
 
 
-@pytest.mark.parametrize(["method_name"], [[x] for x in CLIENT_METHODS])
+@pytest.mark.parametrize(["method_name"], [[m.name] for m in CLIENT_METHODS])
 def test_all_client_methods_exist(method_name):
     assert hasattr(elasticsearch.Elasticsearch, method_name)
 


### PR DESCRIPTION
Fixes #435. Copying what #436 did for PyMongo.