### PR TITLE
Track CherryPy static files

### DIFF
--- a/src/scout_apm/cherrypy.py
+++ b/src/scout_apm/cherrypy.py
@@ -116,7 +116,7 @@ def get_operation_name(request):
             pass
         else:
             try:
-                return wrapped_tool.__name__
+                return "Controller/{}".format(wrapped_tool.__name__)
             except AttributeError:
                 pass
 

--- a/src/scout_apm/cherrypy.py
+++ b/src/scout_apm/cherrypy.py
@@ -108,6 +108,18 @@ def get_operation_name(request):
     while hasattr(real_handler, "callable"):
         real_handler = real_handler.callable
 
+    # Looks like it's from HandlerTool
+    if getattr(real_handler, "__name__", "") == "handle_func":
+        try:
+            wrapped_tool = real_handler.__closure__[2].cell_contents.callable
+        except (AttributeError, IndexError):
+            pass
+        else:
+            try:
+                return wrapped_tool.__name__
+            except AttributeError:
+                pass
+
     # Not a method? Not from an exposed view then
     if not hasattr(real_handler, "__self__"):
         return None

--- a/tests/integration/test_cherrypy.py
+++ b/tests/integration/test_cherrypy.py
@@ -48,7 +48,7 @@ def app_with_scout(scout_config=None):
             return "Something went wrong"
 
         # Something like this??
-        # static_file = tools.staticfile.handler("")
+        static_file = cherrypy.tools.staticfile.handler(__file__)
 
     app = cherrypy.Application(Views(), "/", config=None)
 
@@ -75,21 +75,6 @@ def test_home(tracked_requests):
     assert tracked_request.tags["path"] == "/"
     span = tracked_request.complete_spans[0]
     assert span.operation == "Controller/tests.integration.test_cherrypy.Views.index"
-
-
-def test_static_favicon(tracked_requests):
-    with app_with_scout() as app:
-        # CherryPy serves its built-in favicon by default
-        response = TestApp(app).get("/favicon.ico")
-
-    assert response.status_int == 200
-    assert response.headers["content-type"] == "image/x-icon"
-    assert len(tracked_requests) == 1
-    tracked_request = tracked_requests[0]
-    assert len(tracked_request.complete_spans) == 1
-    assert tracked_request.tags["path"] == "/"
-    span = tracked_request.complete_spans[0]
-    assert span.operation == "Controller/staticfile"
 
 
 def test_home_ignored(tracked_requests):
@@ -204,6 +189,20 @@ def test_return_error(tracked_requests):
         span.operation
         == "Controller/tests.integration.test_cherrypy.Views.return_error"
     )
+
+
+def test_static_file(tracked_requests):
+    with app_with_scout() as app:
+        # CherryPy serves its built-in favicon by default
+        response = TestApp(app).get("/static-file/")
+
+    assert response.status_int == 200
+    assert response.headers["content-type"] == "text/x-python;charset=utf-8"
+    assert len(tracked_requests) == 1
+    tracked_request = tracked_requests[0]
+    assert len(tracked_request.complete_spans) == 1
+    span = tracked_request.complete_spans[0]
+    assert span.operation == "Controller/staticfile"
 
 
 def test_not_found(tracked_requests):

--- a/tests/integration/test_cherrypy.py
+++ b/tests/integration/test_cherrypy.py
@@ -47,7 +47,7 @@ def app_with_scout(scout_config=None):
             cherrypy.response.status = 503
             return "Something went wrong"
 
-        # Something like this??
+        # Serve this source file statically
         static_file = cherrypy.tools.staticfile.handler(__file__)
 
     app = cherrypy.Application(Views(), "/", config=None)


### PR DESCRIPTION
When testing the integration added in #431, I found that the `favicon.ico` route added by `cherrypy.quickstart()` was showing up as "Unknown" controller in the Scout UI. This should fix that.