### PR TITLE
CHANGELOG link to importlib-metadata package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@
 ### Added
 
 - Use Python 3.8's standard library `importlib.metadata.distributions()` to
-  determine package versions, rather than `pkg_resources`. The backport
-  `importlib_metadata` is required on older Python versions
+  determine package versions, rather than `pkg_resources`. The [backport
+  package
+  `importlib_metadata`](https://pypi.org/project/importlib-metadata/) is
+  required on older Python versions
   ([PR #430](https://github.com/scoutapp/scout_apm_python/pull/430)).
 - Add CherryPy integration
   ([PR #431](https://github.com/scoutapp/scout_apm_python/pull/431)).


### PR DESCRIPTION
Clarify that it's from PyPI. Pip should pick it up but users might miss why there's a new dependency.