### PR TITLE
Make all app_with_scout functions kwargs-only

### DIFF
--- a/src/scout_apm/compat.py
+++ b/src/scout_apm/compat.py
@@ -73,13 +73,13 @@ def kwargs_only(func):
     if hasattr(inspect, "signature"):  # pragma: no cover
         # Python 3
         signature = inspect.signature(func)
-        first_arg_name = list(signature.parameters.keys())[0]
+        arg_names = list(signature.parameters.keys())
     else:  # pragma: no cover
         # Python 2
         signature = inspect.getargspec(func)
-        first_arg_name = signature.args[0]
+        arg_names = signature.args
 
-    if first_arg_name in ("self", "cls"):
+    if len(arg_names) > 0 and arg_names[0] in ("self", "cls"):
         allowable_args = 1
     else:
         allowable_args = 0

--- a/tests/integration/test_bottle.py
+++ b/tests/integration/test_bottle.py
@@ -143,7 +143,7 @@ def test_amazon_queue_time(tracked_requests):
 
 
 def test_home_ignored(tracked_requests):
-    with app_with_scout({"scout.ignore": ["/"]}) as app:
+    with app_with_scout(config={"scout.ignore": ["/"]}) as app:
         response = TestApp(app).get("/")
 
     assert response.status_int == 200

--- a/tests/integration/test_bottle.py
+++ b/tests/integration/test_bottle.py
@@ -9,7 +9,7 @@ from webtest import TestApp
 
 from scout_apm.api import Config
 from scout_apm.bottle import ScoutPlugin
-from scout_apm.compat import datetime_to_timestamp
+from scout_apm.compat import datetime_to_timestamp, kwargs_only
 from tests.integration.util import (
     parametrize_filtered_params,
     parametrize_queue_time_header_name,
@@ -18,6 +18,7 @@ from tests.integration.util import (
 
 
 @contextmanager
+@kwargs_only
 def app_with_scout(config=None, catchall=False):
     """
     Context manager that configures and installs the Scout plugin for Bottle.
@@ -212,7 +213,7 @@ def test_named(tracked_requests):
 
 
 def test_no_monitor(tracked_requests):
-    with app_with_scout({"scout.monitor": False}) as app:
+    with app_with_scout(config={"scout.monitor": False}) as app:
         response = TestApp(app).get("/hello/")
 
     assert response.status_int == 200

--- a/tests/integration/test_celery.py
+++ b/tests/integration/test_celery.py
@@ -9,6 +9,7 @@ from celery.signals import setup_logging
 
 import scout_apm.celery
 from scout_apm.api import Config
+from scout_apm.compat import kwargs_only
 
 # http://docs.celeryproject.org/en/latest/userguide/testing.html#py-test
 skip_unless_celery_4_plus = pytest.mark.skipif(
@@ -25,6 +26,7 @@ def do_nothing(**kwargs):
 
 
 @contextmanager
+@kwargs_only
 def app_with_scout(app=None, config=None):
     """
     Context manager that configures a Celery app with Scout installed.

--- a/tests/integration/test_cherrypy.py
+++ b/tests/integration/test_cherrypy.py
@@ -9,7 +9,7 @@ from webtest import TestApp
 
 from scout_apm.api import Config
 from scout_apm.cherrypy import ScoutPlugin
-from scout_apm.compat import datetime_to_timestamp
+from scout_apm.compat import datetime_to_timestamp, kwargs_only
 from tests.integration.util import (
     parametrize_filtered_params,
     parametrize_queue_time_header_name,
@@ -18,6 +18,7 @@ from tests.integration.util import (
 
 
 @contextmanager
+@kwargs_only
 def app_with_scout(scout_config=None):
     """
     Context manager that configures and installs the Scout plugin for CherryPy.

--- a/tests/integration/test_django.py
+++ b/tests/integration/test_django.py
@@ -15,7 +15,7 @@ from django.http import HttpResponse
 from django.test.utils import override_settings
 from webtest import TestApp
 
-from scout_apm.compat import datetime_to_timestamp
+from scout_apm.compat import datetime_to_timestamp, kwargs_only
 from scout_apm.core.config import scout_config
 from scout_apm.django.instruments.huey import ensure_huey_instrumented
 from scout_apm.django.instruments.sql import ensure_sql_instrumented
@@ -63,6 +63,7 @@ def ensure_no_django_config_applied_after_tests():
 
 
 @contextmanager
+@kwargs_only
 def app_with_scout(**settings):
     """
     Context manager that simply overrides settings. Unlike the other web

--- a/tests/integration/test_dramatiq.py
+++ b/tests/integration/test_dramatiq.py
@@ -6,6 +6,8 @@ from contextlib import contextmanager
 
 import pytest
 
+from scout_apm.compat import kwargs_only
+
 try:
     import dramatiq
 except ImportError:
@@ -24,6 +26,7 @@ pytestmark = [skip_if_dramatiq_unavailable]
 
 
 @contextmanager
+@kwargs_only
 def app_with_scout(config=None):
     """
     Context manager that configures a Dramatiq app with Scout middleware

--- a/tests/integration/test_falcon.py
+++ b/tests/integration/test_falcon.py
@@ -10,7 +10,7 @@ import pytest
 from webtest import TestApp
 
 from scout_apm.api import Config
-from scout_apm.compat import datetime_to_timestamp
+from scout_apm.compat import datetime_to_timestamp, kwargs_only
 from scout_apm.falcon import ScoutMiddleware
 from tests.integration.util import (
     parametrize_filtered_params,
@@ -20,6 +20,7 @@ from tests.integration.util import (
 
 
 @contextmanager
+@kwargs_only
 def app_with_scout(config=None, middleware=None, set_api=True):
     """
     Context manager that yields a fresh Falcon app with Scout configured.
@@ -174,7 +175,7 @@ def test_home_suffixed(tracked_requests):
 
 
 def test_home_ignored(tracked_requests):
-    with app_with_scout({"ignore": ["/"]}) as app:
+    with app_with_scout(config={"ignore": ["/"]}) as app:
         response = TestApp(app).get("/")
 
     assert response.status_int == 200

--- a/tests/integration/test_flask.py
+++ b/tests/integration/test_flask.py
@@ -8,7 +8,7 @@ import flask
 from webtest import TestApp
 
 from scout_apm.api import Config
-from scout_apm.compat import datetime_to_timestamp
+from scout_apm.compat import datetime_to_timestamp, kwargs_only
 from scout_apm.flask import ScoutApm
 from tests.integration.util import (
     parametrize_filtered_params,
@@ -18,6 +18,7 @@ from tests.integration.util import (
 
 
 @contextmanager
+@kwargs_only
 def app_with_scout(config=None):
     """
     Context manager that configures and installs the Scout plugin for Bottle.
@@ -77,7 +78,7 @@ def test_home(tracked_requests):
 
 
 def test_home_ignored(tracked_requests):
-    with app_with_scout({"SCOUT_MONITOR": True, "SCOUT_IGNORE": "/"}) as app:
+    with app_with_scout(config={"SCOUT_MONITOR": True, "SCOUT_IGNORE": "/"}) as app:
         response = TestApp(app).get("/")
 
     assert response.status_int == 200
@@ -182,7 +183,7 @@ def test_not_found(tracked_requests):
 
 
 def test_server_error(tracked_requests):
-    with app_with_scout({"PROPAGATE_EXCEPTIONS": False}) as app:
+    with app_with_scout(config={"PROPAGATE_EXCEPTIONS": False}) as app:
         response = TestApp(app).get("/crash/", expect_errors=True)
 
     assert response.status_int == 500
@@ -242,7 +243,7 @@ def test_preprocessor_response(tracked_requests):
 
 
 def test_no_monitor(tracked_requests):
-    with app_with_scout({"SCOUT_MONITOR": False}) as app:
+    with app_with_scout(config={"SCOUT_MONITOR": False}) as app:
         response = TestApp(app).get("/hello/")
 
     assert response.status_int == 200

--- a/tests/integration/test_flask_sqlalchemy.py
+++ b/tests/integration/test_flask_sqlalchemy.py
@@ -6,11 +6,13 @@ from contextlib import contextmanager
 from flask_sqlalchemy import SQLAlchemy
 from webtest import TestApp
 
+from scout_apm.compat import kwargs_only
 from scout_apm.flask.sqlalchemy import instrument_sqlalchemy
 from tests.integration.test_flask import app_with_scout as flask_app_with_scout
 
 
 @contextmanager
+@kwargs_only
 def app_with_scout():
     with flask_app_with_scout() as app:
         app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"

--- a/tests/integration/test_huey.py
+++ b/tests/integration/test_huey.py
@@ -9,10 +9,12 @@ from huey import MemoryHuey
 from huey.exceptions import CancelExecution, HueyException, RetryTask, TaskException
 
 from scout_apm.api import Config
+from scout_apm.compat import kwargs_only
 from scout_apm.huey import attach_scout
 
 
 @contextmanager
+@kwargs_only
 def app_with_scout(scout_config=None):
     """
     Context manager that configures a Huey app with Scout installed.

--- a/tests/integration/test_nameko.py
+++ b/tests/integration/test_nameko.py
@@ -11,7 +11,7 @@ from webtest import TestApp
 from werkzeug.wrappers import Response
 
 from scout_apm.api import Config
-from scout_apm.compat import datetime_to_timestamp
+from scout_apm.compat import datetime_to_timestamp, kwargs_only
 from scout_apm.nameko import ScoutReporter
 from tests.integration.util import (
     parametrize_filtered_params,
@@ -21,6 +21,7 @@ from tests.integration.util import (
 
 
 @contextmanager
+@kwargs_only
 def app_with_scout(nameko_config=None, scout_config=None):
     """
     Context manager that yields a fresh Nameko WSGI app with Scout configured.

--- a/tests/integration/test_pyramid.py
+++ b/tests/integration/test_pyramid.py
@@ -10,7 +10,7 @@ from pyramid.response import Response
 from webtest import TestApp
 
 from scout_apm.api import Config
-from scout_apm.compat import datetime_to_timestamp
+from scout_apm.compat import datetime_to_timestamp, kwargs_only
 from tests.integration.util import (
     parametrize_filtered_params,
     parametrize_queue_time_header_name,
@@ -19,6 +19,7 @@ from tests.integration.util import (
 
 
 @contextmanager
+@kwargs_only
 def app_with_scout(config=None):
     """
     Context manager that configures and installs the Scout plugin for Bottle.
@@ -141,7 +142,7 @@ def test_amazon_queue_time(tracked_requests):
 
 
 def test_home_ignored(tracked_requests):
-    with app_with_scout({"SCOUT_MONITOR": True, "SCOUT_IGNORE": ["/"]}) as app:
+    with app_with_scout(config={"SCOUT_MONITOR": True, "SCOUT_IGNORE": ["/"]}) as app:
         response = TestApp(app).get("/")
 
     assert response.status_int == 200
@@ -202,7 +203,7 @@ def test_return_error(tracked_requests):
 
 def test_no_monitor(tracked_requests):
     # With an empty config, "SCOUT_MONITOR" defaults to False.
-    with app_with_scout({}) as app:
+    with app_with_scout(config={}) as app:
         response = TestApp(app).get("/hello/")
 
     assert response.status_int == 200

--- a/tests/integration/test_rq.py
+++ b/tests/integration/test_rq.py
@@ -8,8 +8,8 @@ from fakeredis import FakeStrictRedis
 from rq import Queue
 
 import scout_apm.rq
-from scout_apm import compat
 from scout_apm.api import Config
+from scout_apm.compat import kwargs_only, string_type
 
 
 def hello():
@@ -21,6 +21,7 @@ def fail():
 
 
 @contextmanager
+@kwargs_only
 def app_with_scout(scout_config=None):
     """
     Context manager that configures a Huey app with Scout installed.
@@ -58,7 +59,7 @@ def test_hello(tracked_requests):
     assert len(tracked_requests) == 1
     tracked_request = tracked_requests[0]
     task_id = tracked_request.tags["task_id"]
-    assert isinstance(task_id, compat.string_type) and len(task_id) == 36
+    assert isinstance(task_id, string_type) and len(task_id) == 36
     assert tracked_request.tags["queue"] == "myqueue"
     assert 0.0 < tracked_request.tags["queue_time"] < 60.0
     assert len(tracked_request.complete_spans) == 2
@@ -76,7 +77,7 @@ def test_fail(tracked_requests):
 
     tracked_request = tracked_requests[0]
     task_id = tracked_request.tags["task_id"]
-    assert isinstance(task_id, compat.string_type) and len(task_id) == 36
+    assert isinstance(task_id, string_type) and len(task_id) == 36
     assert tracked_request.tags["queue"] == "myqueue"
     assert 0.0 < tracked_request.tags["queue_time"] < 60.0
     assert tracked_request.tags["error"] == "true"


### PR DESCRIPTION
This helps reduce confusion especially when there are two config arguments - one for the library and one for Scout.