### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Python 2.7 or 3.4+.
 Scout APM has integrations for the following frameworks:
 
 * Bottle 0.12+
+* CherryPy 18.0.0+
 * Celery 3.1+
 * Django 1.8+
 * Dramatiq 1.0+
@@ -27,111 +28,19 @@ Scout APM has integrations for the following frameworks:
 * RQ 1.0+
 * Starlette 0.12+
 
-For other frameworks, you can use the agent's instrumentation API. See the [Python help docs](https://docs.scoutapm.com/#python-agent) for more information.
+For other frameworks, you can use the agent's instrumentation API.
 
-## Quick Start
-
-__A Scout account is required. [Signup for Scout](https://scoutapm.com/users/sign_up).__
-
-```sh
-pip install scout-apm
-```
-
-### Bottle
-
-```python
-from scout_apm.bottle import ScoutPlugin
-
-app = bottle.default_app()
-app.config.update({
-    "scout.name": "YOUR_APP_NAME",
-    "scout.key": "YOUR_KEY",
-    "scout.monitor": "true",
-})
-
-scout = ScoutPlugin()
-bottle.install(scout)
-```
-
-### Django
-
-```python
-# settings.py
-INSTALLED_APPS = [
-    "scout_apm.django",  # should be listed first
-    # ... other apps ...
-]
-
-# Scout settings
-SCOUT_MONITOR = True
-SCOUT_KEY = "[AVAILABLE IN THE SCOUT UI]"
-SCOUT_NAME = "A FRIENDLY NAME FOR YOUR APP"
-```
-
-### Falcon
-
-```python
-import falcon
-from scout_apm.falcon import ScoutMiddleware
-
-scout_middleware = ScoutMiddleware(config={
-    "key": "[AVAILABLE IN THE SCOUT UI]",
-    "monitor": True,
-    "name": "A FRIENDLY NAME FOR YOUR APP",
-})
-api = falcon.API(middleware=[ScoutMiddleware()])
-# Required for accessing extra per-request information
-scout_middleware.set_api(api)
-```
-
-### Flask
-
-These instructions assume the app uses `SQLAlchemy`. If that isn't the case, remove the referencing lines.
-
-```python
-from scout_apm.flask import ScoutApm
-from scout_apm.flask.sqlalchemy import instrument_sqlalchemy
-
-# Setup a flask 'app' as normal
-
-# Attach ScoutApm to the Flask App
-ScoutApm(app)
-
-# Instrument the SQLAlchemy handle
-instrument_sqlalchemy(db)
-
-# Scout settings
-app.config["SCOUT_MONITOR"] = True
-app.config["SCOUT_KEY"] = "[AVAILABLE IN THE SCOUT UI]"
-app.config["SCOUT_NAME"] = "A FRIENDLY NAME FOR YOUR APP"
-```
-
-### Pyramid
-
-Add the `SCOUT_*` settings to the Pyramid config, and then `config.include('scout_apm.pyramid')`
-
-
-```python
-import scout_apm.pyramid
-
-if __name__ == "__main__":
-    with Configurator() as config:
-        config.add_settings(
-            SCOUT_KEY="...",
-            SCOUT_MONITOR=True,
-            SCOUT_NAME="My Pyramid App"
-        )
-        config.include("scout_apm.pyramid")
-
-        # Rest of your config...
-```
+To use Scout, you'll need to
+[sign up for an account](https://scoutapm.com/users/sign_up) or use
+[our Heroku Addon](https://devcenter.heroku.com/articles/scout).
 
 ## Documentation
 
 For full installation instructions, including information on configuring Scout
-via environment variables and troubleshooting documentation, see our
+via environment variables and troubleshooting, see our
 [Python docs](https://docs.scoutapm.com/#python-agent).
 
 ## Support
 
-Please contact us at support@scoutapm.com or create an issue in this repo.
+Please email us at support@scoutapm.com or [create a GitHub
+issue](https://github.com/scoutapp/scout_apm_python/issues/).


### PR DESCRIPTION
* Feature CherryPy in list of integrated frameworks
* Remove install quick starts - they duplicate what's on the docs, and are incomplete compared to the list of frameworks. I think it's not really maintainable to duplicate the docs here given we now support quite a lot of different frameworks.
* Mention the Heroku addon.
* Link to GitHub issues since some people will be reading the README on PyPI and what "this repo" refers to is not so clear there.