### PR TITLE
Actually error on warnings

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -34,7 +34,12 @@ addopts = --cov=scout_apm
           -p no:pytest_nameko
 norecursedirs = src
 filterwarnings =
-    default
+    error
+    error::DeprecationWarning
+    error::PendingDeprecationWarning
+    error::ImportWarning
+    always::ResourceWarning
+    ignore::ResourceWarning:httpretty.core
     ignore:the imp module is deprecated.*:DeprecationWarning:eventlet
     ignore:the imp module is deprecated.*:PendingDeprecationWarning:distutils
     ignore:dns.hash module will be removed.*:DeprecationWarning:dns.hash

--- a/pytest.ini
+++ b/pytest.ini
@@ -49,4 +49,6 @@ filterwarnings =
     ignore:Using or importing the ABCs from 'collections'.*:DeprecationWarning
     ; Deprecations in our libraries
     ignore:dns.hash module will be removed.*:DeprecationWarning:dns.hash
-    ignore:parameter codeset is deprecated:DeprecationWarning:gettext
+    ; Appears in both gettext and Django:
+    ignore:parameter codeset is deprecated:DeprecationWarning
+    ignore:"errors" is deprecated. Use "encoding_errors" instead:DeprecationWarning:redis.client

--- a/pytest.ini
+++ b/pytest.ini
@@ -34,13 +34,14 @@ addopts = --cov=scout_apm
           -p no:pytest_nameko
 norecursedirs = src
 filterwarnings =
+    always
     error
     error::DeprecationWarning
     error::PendingDeprecationWarning
     error::ImportWarning
-    ; Can't add this because ResourceWarning doesn't exist on Python 2:
+    ; Can't add these because ResourceWarning doesn't exist on Python 2:
     ; always::ResourceWarning
-    ignore::ResourceWarning:httpretty.core
+    ; ignore::ResourceWarning:httpretty.core
     ignore:the imp module is deprecated.*:DeprecationWarning:eventlet
     ignore:the imp module is deprecated.*:PendingDeprecationWarning:distutils
     ignore:dns.hash module will be removed.*:DeprecationWarning:dns.hash

--- a/pytest.ini
+++ b/pytest.ini
@@ -42,12 +42,11 @@ filterwarnings =
     ; Can't add these because ResourceWarning doesn't exist on Python 2:
     ; always::ResourceWarning
     ; ignore::ResourceWarning:httpretty.core
-    ignore:the imp module is deprecated.*:DeprecationWarning:eventlet
-    ignore:the imp module is deprecated.*:PendingDeprecationWarning:distutils
+    ; Too many things in the Python universe haven't updated for these moves,
+    ; so always ignore them:
+    ignore:the imp module is deprecated.*:DeprecationWarning
+    ignore:the imp module is deprecated.*:PendingDeprecationWarning
+    ignore:Using or importing the ABCs from 'collections'.*:DeprecationWarning
+    ; Deprecations in our libraries
     ignore:dns.hash module will be removed.*:DeprecationWarning:dns.hash
     ignore:parameter codeset is deprecated:DeprecationWarning:gettext
-    ignore:Using or importing the ABCs from 'collections'.*:DeprecationWarning:bs4.element
-    ignore:Using or importing the ABCs from 'collections'.*:DeprecationWarning:django.db.models.fields
-    ignore:Using or importing the ABCs from 'collections'.*:DeprecationWarning:django.db.models.sql.query
-    ignore:Using or importing the ABCs from 'collections'.*:DeprecationWarning:dns.namedict
-    ignore:Using or importing the ABCs from 'collections'.*:DeprecationWarning:nameko.exceptions

--- a/pytest.ini
+++ b/pytest.ini
@@ -38,7 +38,7 @@ filterwarnings =
     error
     error::DeprecationWarning
     error::PendingDeprecationWarning
-    error::ImportWarning
+    always::ImportWarning
     ; Can't add these because ResourceWarning doesn't exist on Python 2:
     ; always::ResourceWarning
     ; ignore::ResourceWarning:httpretty.core

--- a/pytest.ini
+++ b/pytest.ini
@@ -38,7 +38,8 @@ filterwarnings =
     error::DeprecationWarning
     error::PendingDeprecationWarning
     error::ImportWarning
-    always::ResourceWarning
+    ; Can't add this because ResourceWarning doesn't exist on Python 2:
+    ; always::ResourceWarning
     ignore::ResourceWarning:httpretty.core
     ignore:the imp module is deprecated.*:DeprecationWarning:eventlet
     ignore:the imp module is deprecated.*:PendingDeprecationWarning:distutils


### PR DESCRIPTION
PR #429 set the base configuration to "default" which just prints the warnings rather than erroring on them. This fixes that.

However, luckily the printing behaviour showed some warnings still - `ImportWarning`s and `ResourceWarning`s. By default [Python suppresses these](https://docs.python.org/3/library/warnings.html#default-warning-filter) and [Pytest doesn't replace those filters](https://docs.pytest.org/en/latest/warnings.html#deprecationwarning-and-pendingdeprecationwarning).

This PR sets the main action to 'error', and specifies extra filters to override the default ones Python configures.