### PR TITLE
Ignore false positive from flake8-bugbear B014

### DIFF
--- a/src/scout_apm/core/core_agent_manager.py
+++ b/src/scout_apm/core/core_agent_manager.py
@@ -221,7 +221,8 @@ class CoreAgentManifest(object):
         self.valid = False
         try:
             self.parse()
-        except (ValueError, TypeError, OSError, IOError) as exc:
+        # noqa for this issue: https://github.com/PyCQA/flake8-bugbear/issues/110
+        except (ValueError, TypeError, OSError, IOError) as exc:  # noqa: B014
             logger.debug("Error parsing Core Agent Manifest", exc_info=exc)
 
     def parse(self):


### PR DESCRIPTION
As per referenced issue, OSError and IOError are only the same thing on Python 3, but we support Python 2.