### PR TITLE
Remove fakeredis

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,6 @@ deps =
     django30: djangorestframework
     dramatiq>=1.0.0 ; python_version >= "3.5"
     elasticsearch
-    fakeredis
     falcon
     flask
     flask-sqlalchemy


### PR DESCRIPTION
It's incompatible with the latest redis-py 3.4.0: https://github.com/jamesls/fakeredis/issues/260

We only used it for a few tests. It's easier to simply use the Redis server we already run during normal tests.