### PR TITLE
Fix elasticsearch 7.5.1 issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@
 
 - Fix Jinja2 asynchronous rendering instrumentation for Jinja2 2.11.0+
   ([PR #462](https://github.com/scoutapp/scout_apm_python/pull/462)).
+- Stop patching `elasticsearch`'s `scripts_painless_context()`, because it has
+  been removed in version 7.5.1
+  ([Issue #454](https://github.com/scoutapp/scout_apm_python/issues/454)).
+- Fix for `elasticsearch` version 7.5.1's change of positional argument order
+  ([Issue #456](https://github.com/scoutapp/scout_apm_python/issues/456)).
 
 ## [2.10.0] 2020-01-02
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -58,11 +58,14 @@ Some of the tests require external services to run against. These are specified
 by environment variables. These are:
 
 * `ELASTICSEARCH_URL` - point to a running Elasticsearch instance, e.g.
-  "http://localhost:9200/"
+  "http://localhost:9200/" . You can start it with:
+  `docker run --detach --name elasticsearch --publish 9200:9200 -e "discovery.type=single-node" elasticsearch:7.5.2` .
 * `MONGODB_URL` - point to a running MongoDB instance e.g.
-  "mongodb://localhost:27017/"
+  "mongodb://localhost:27017/" . You can start it with:
+  `docker run --detach --name mongo --publish 27017:27017 mongo:4.0` .
 * `REDIS_URL` - point to a running Redis instance e.g.
-  "redis://localhost:6379/0"
+  "redis://localhost:6379/0" . You can start it with:
+  `docker run --detach --name redis --publish 6379:6379 redis:5` .
 
 You can `export` any of these environment variables and run the respective
 tests with `tox`.

--- a/src/scout_apm/compat.py
+++ b/src/scout_apm/compat.py
@@ -63,8 +63,21 @@ else:
     from urlparse import parse_qsl
 
 
+if sys.version_info >= (3, 0):
+
+    def get_pos_args(func):
+        return inspect.getfullargspec(func).args
+
+
+else:
+
+    def get_pos_args(func):
+        return inspect.getargspec(func).args
+
+
 def kwargs_only(func):
     """
+    Source: https://pypi.org/project/kwargs-only/
     Make a function only accept keyword arguments.
     This can be dropped in Python 3 in lieu of:
         def foo(*, bar=default):

--- a/tests/integration/instruments/test_elasticsearch.py
+++ b/tests/integration/instruments/test_elasticsearch.py
@@ -149,6 +149,7 @@ def test_search(elasticsearch_client, tracked_request):
     assert span.operation == "Elasticsearch/Unknown/Search"
 
 
+@skip_if_python_2  # Cannot unwrap decorators on Python 2
 def test_search_arg_named_index(elasticsearch_client, tracked_request):
     with pytest.raises(elasticsearch.exceptions.NotFoundError):
         # body, index

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -5,7 +5,7 @@ import datetime as dt
 
 import pytest
 
-from scout_apm.compat import ContextDecorator, datetime_to_timestamp, text
+from scout_apm.compat import ContextDecorator, datetime_to_timestamp, get_pos_args, text
 
 
 def test_context_decorator():
@@ -48,3 +48,17 @@ def test_datetime_to_timestamp(given, expected):
 )
 def test_text(given, expected):
     assert text(given) == expected
+
+
+def test_get_pos_args_args():
+    def foo(bar, baz):
+        pass
+
+    assert get_pos_args(foo) == ["bar", "baz"]
+
+
+def test_get_pos_args_kwargs():
+    def foo(bar, baz=None):
+        pass
+
+    assert get_pos_args(foo) == ["bar", "baz"]


### PR DESCRIPTION
Fixes #454. Fixes #456. Work around positional arguments changing order through function inspection. Stop patching scripts_painless_context() since it has been removed with no intention of re-adding.