### PR TITLE
Convert user warnings from logging.warnings to warnings.warn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 
 ### Fixed
 
+- Moved some user-facing warnings, such as for deprecated features, from
+  `logging` to `warnings`, so they can be caught during testing
+  ([PR #468](https://github.com/scoutapp/scout_apm_python/pull/468)).
 - Fix Jinja2 asynchronous rendering instrumentation for Jinja2 2.11.0+
   ([PR #462](https://github.com/scoutapp/scout_apm_python/pull/462)).
 

--- a/src/scout_apm/core/config.py
+++ b/src/scout_apm/core/config.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import logging
 import os
+import warnings
 
 from scout_apm.compat import string_type
 from scout_apm.core import platform_detection
@@ -183,7 +184,7 @@ class Derived(object):
     def derive_core_agent_full_name(self):
         triple = self.config.value("core_agent_triple")
         if not platform_detection.is_valid_triple(triple):
-            logger.warning("Invalid value for core_agent_triple: %s", triple)
+            warnings.warn("Invalid value for core_agent_triple: {}".format(triple))
         return "{name}-{version}-{triple}".format(
             name="scout_apm_core",
             version=self.config.value("core_agent_version"),

--- a/src/scout_apm/core/core_agent_manager.py
+++ b/src/scout_apm/core/core_agent_manager.py
@@ -8,6 +8,7 @@ import os
 import subprocess
 import tarfile
 import time
+import warnings
 
 import requests
 
@@ -88,11 +89,12 @@ class CoreAgentManager(object):
         # Old deprecated name "log_level"
         log_level = scout_config.value("log_level")
         if log_level is not None:
-            logger.warning(
+            warnings.warn(
                 "The config name 'log_level' is deprecated - "
                 + "please use the new name 'core_agent_log_level' instead. "
                 + "This might be configured in your environment variables or "
-                + "framework settings as SCOUT_LOG_LEVEL."
+                + "framework settings as SCOUT_LOG_LEVEL.",
+                DeprecationWarning,
             )
         else:
             log_level = scout_config.value("core_agent_log_level")

--- a/src/scout_apm/falcon.py
+++ b/src/scout_apm/falcon.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
+import warnings
 
 import falcon
 
@@ -95,11 +96,12 @@ class ScoutMiddleware(object):
             return
 
         if self.api is None:
-            logger.warning(
+            warnings.warn(
                 (
                     "{}.set_api() should be called before requests begin for"
                     + " more detail."
-                ).format(self.__class__.__name__)
+                ).format(self.__class__.__name__),
+                RuntimeWarning,
             )
             operation = "Controller/{}.{}.{}".format(
                 resource.__module__, resource.__class__.__name__, req.method

--- a/tests/integration/core/test_core_agent_manager.py
+++ b/tests/integration/core/test_core_agent_manager.py
@@ -109,20 +109,16 @@ def test_log_level(caplog, core_agent_manager):
     assert caplog.record_tuples == []
 
 
-def test_log_level_deprecated(caplog, core_agent_manager):
+def test_log_level_deprecated(core_agent_manager, recwarn):
     scout_config.set(log_level="foo", core_agent_log_level="bar")
 
     result = core_agent_manager.log_level()
 
     assert result == ["--log-level", "foo"]
-    assert caplog.record_tuples == [
-        (
-            "scout_apm.core.core_agent_manager",
-            logging.WARNING,
-            (
-                "The config name 'log_level' is deprecated - please use the new name "
-                + "'core_agent_log_level' instead. This might be configured in your "
-                + "environment variables or framework settings as SCOUT_LOG_LEVEL."
-            ),
-        )
-    ]
+    assert len(recwarn) == 1
+    warning = recwarn.pop(DeprecationWarning)
+    assert str(warning.message) == (
+        "The config name 'log_level' is deprecated - please use the new name "
+        + "'core_agent_log_level' instead. This might be configured in your "
+        + "environment variables or framework settings as SCOUT_LOG_LEVEL."
+    )

--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -1,7 +1,6 @@
 # coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import logging
 import os
 import re
 import sys
@@ -65,7 +64,7 @@ def test_override_triple(caplog):
     assert caplog.record_tuples == []
 
 
-def test_override_triple_invalid(caplog):
+def test_override_triple_invalid(recwarn):
     bad_triple = "badtriple"
     ScoutConfig.set(core_agent_triple=bad_triple)
     config = ScoutConfig()
@@ -75,13 +74,9 @@ def test_override_triple_invalid(caplog):
         ScoutConfig.reset_all()
 
     assert full_name.endswith(bad_triple)
-    assert caplog.record_tuples == [
-        (
-            "scout_apm.core.config",
-            logging.WARNING,
-            "Invalid value for core_agent_triple: badtriple",
-        )
-    ]
+    assert len(recwarn) == 1
+    warning = recwarn.pop(Warning)
+    assert str(warning.message) == "Invalid value for core_agent_triple: badtriple"
 
 
 def test_get_default_config_value():


### PR DESCRIPTION
This is the recommended way for Python users to track down deprecations/problems in their code. We should have been using it all along.