### PR TITLE
Remove unnecesary 'return 0'

### DIFF
--- a/src/scout_apm/core/tracked_request.py
+++ b/src/scout_apm/core/tracked_request.py
@@ -240,7 +240,7 @@ class Span(object):
                 start_allocs,
                 end_allocs,
             )
-            return 0
+            return
 
         self.tag("allocations", end_allocs - start_allocs)
         self.tag("start_allocations", start_allocs)


### PR DESCRIPTION
This method's return value isn't used.