### PR TITLE
Limit traceback size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   [PR #460](https://github.com/scoutapp/scout_apm_python/pull/460)).
 - Add Hug integration
   ([PR #460](https://github.com/scoutapp/scout_apm_python/pull/460)).
+- Limit size of recorded tracebacks to reduce memory usage
+  ([PR #467](https://github.com/scoutapp/scout_apm_python/pull/467)).
 
 ### Fixed
 

--- a/src/scout_apm/core/backtrace.py
+++ b/src/scout_apm/core/backtrace.py
@@ -4,12 +4,20 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import sys
 import traceback
 
+# Maximum non-Scout frames to target retrieving
+LIMIT = 50
+# How many upper frames from inside Scout to ignore
+IGNORED = 1
+
+
 if sys.version_info >= (3, 5):
 
     def capture():
         return [
             {"file": frame.filename, "line": frame.lineno, "function": frame.name}
-            for frame in reversed(traceback.extract_stack()[:-1])
+            for frame in reversed(
+                traceback.extract_stack(limit=LIMIT + IGNORED)[:-IGNORED]
+            )
         ]
 
 
@@ -18,5 +26,7 @@ else:
     def capture():
         return [
             {"file": frame[0], "line": frame[1], "function": frame[3]}
-            for frame in reversed(traceback.extract_stack()[:-1])
+            for frame in reversed(
+                traceback.extract_stack(limit=LIMIT + IGNORED)[:-IGNORED]
+            )
         ]

--- a/tests/unit/core/test_backtrace.py
+++ b/tests/unit/core/test_backtrace.py
@@ -26,3 +26,14 @@ def format_py_filename(filename):
         # Python 2 will include .pyc filename if it's used, so strip that
         return filename[:-1]
     return filename
+
+
+def test_capture_limit():
+    def capture_recursive_bottom(limit):
+        if limit <= 1:
+            return backtrace.capture()
+        else:
+            return capture_recursive_bottom(limit - 1)
+
+    stack = capture_recursive_bottom(backtrace.LIMIT * 2)
+    assert len(stack) == backtrace.LIMIT


### PR DESCRIPTION
Copied from the Ruby agent: https://github.com/scoutapp/scout_apm_ruby/blob/84575a57f2fb64bced6f2394632212f2bfb0268f/lib/scout_apm/layer.rb#L116

Not strictly related to implementing the issue, but spotted whilst investigating it as an idea to reduce memory usage and overhead.