### PR TITLE
Bottle copy all config keys not just known keys

### DIFF
--- a/src/scout_apm/bottle.py
+++ b/src/scout_apm/bottle.py
@@ -22,10 +22,12 @@ class ScoutPlugin(object):
 
     def set_config_from_bottle(self, app):
         bottle_configs = {}
-        for key in scout_config.known_keys():
-            value = app.config.get("scout.{}".format(key))
-            if value is not None and value != "":
-                bottle_configs[key] = value
+        prefix = "scout."
+        prefix_len = len(prefix)
+        for key, value in app.config.items():
+            if key.startswith(prefix) and len(key) > prefix_len:
+                scout_key = key[prefix_len:]
+                bottle_configs[scout_key] = value
         scout_config.set(**bottle_configs)
 
     def setup(self, app):

--- a/tests/integration/test_bottle.py
+++ b/tests/integration/test_bottle.py
@@ -10,6 +10,7 @@ from webtest import TestApp
 from scout_apm.api import Config
 from scout_apm.bottle import ScoutPlugin
 from scout_apm.compat import datetime_to_timestamp, kwargs_only
+from scout_apm.core.config import scout_config
 from tests.integration.util import (
     parametrize_filtered_params,
     parametrize_queue_time_header_name,
@@ -65,6 +66,20 @@ def app_with_scout(config=None, catchall=False):
     finally:
         # Reset Scout configuration.
         Config.reset_all()
+
+
+def test_config_copied():
+    with app_with_scout(config={"scout.foo": "bar"}):
+        value = scout_config.value("foo")
+
+    assert value == "bar"
+
+
+def test_empty_config_not_copied():
+    with app_with_scout(config={"scout.": "foo"}):
+        value = scout_config.value("")
+
+    assert value is None
 
 
 def test_home(tracked_requests):


### PR DESCRIPTION
This brings us in line with the other integrations' "configuration copying" implementations and means that if we drop a key from `known_keys()` it will still apply.