### PR TITLE
Move from requests to urllib3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@
 - Move from **requests** to underlying **urllib3** for downloads to reduce
   dependency footprint
   ([PR #480](https://github.com/scoutapp/scout_apm_python/pull/480)).
-- Retry downloading the core agent a few times
+- Retry downloading the core agent a few times, and use a timeout to prevent
+  startup hangs
   ([PR #480](https://github.com/scoutapp/scout_apm_python/pull/480)).
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 - Move from **requests** to underlying **urllib3** for downloads to reduce
   dependency footprint
   ([PR #480](https://github.com/scoutapp/scout_apm_python/pull/480)).
+- Retry downloading the core agent a few times
+  ([PR #480](https://github.com/scoutapp/scout_apm_python/pull/480)).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
   This ensures that all traces are recorded, rather than lost, especially
   useful for single-run background commands.
   ([Issue # 473](https://github.com/scoutapp/scout_apm_python/issues/473)).
+- Move from **requests** to underlying **urllib3** for downloads to reduce
+  dependency footprint
+  ([PR #480](https://github.com/scoutapp/scout_apm_python/pull/480)).
 
 ### Fixed
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -52,3 +52,5 @@ filterwarnings =
     ; Appears in both gettext and Django:
     ignore:parameter codeset is deprecated:DeprecationWarning
     ignore:"errors" is deprecated. Use "encoding_errors" instead:DeprecationWarning:redis.client
+    ; Triggered on Python 2.7 only:
+    ignore:unicode for buf is no longer accepted, use bytes:DeprecationWarning:urllib3.contrib.pyopenssl

--- a/setup.py
+++ b/setup.py
@@ -57,10 +57,10 @@ setup(
     },
     install_requires=[
         'asgiref ; python_version >= "3.5"',
-        "certifi",
         'importlib-metadata ; python_version < "3.8"',
         "psutil>=5,<6",
-        "urllib3>=1,<2",
+        'urllib3[secure] < 1.25 ; python_version < "3.5"',
+        'urllib3[secure] < 2 ; python_version >= "3.5"',
         "wrapt>=1.10,<2.0",
     ],
     keywords="apm performance monitoring development",

--- a/setup.py
+++ b/setup.py
@@ -57,9 +57,10 @@ setup(
     },
     install_requires=[
         'asgiref ; python_version >= "3.5"',
+        "certifi",
         'importlib-metadata ; python_version < "3.8"',
         "psutil>=5,<6",
-        "requests>=2,<3",
+        "urllib3>=1,<2",
         "wrapt>=1.10,<2.0",
     ],
     keywords="apm performance monitoring development",

--- a/src/scout_apm/compat.py
+++ b/src/scout_apm/compat.py
@@ -6,6 +6,9 @@ import inspect
 import sys
 from functools import wraps
 
+import certifi
+import urllib3
+
 string_type = str if sys.version_info[0] >= 3 else basestring  # noqa: F821
 text_type = str if sys.version_info[0] >= 3 else unicode  # noqa: F821
 string_types = tuple({string_type, text_type})
@@ -117,6 +120,14 @@ def kwargs_only(func):
         return func(*args, **kwargs)
 
     return wrapper
+
+
+def urllib3_cert_pool_manager(**kwargs):
+    if sys.version_info >= (3, 0):
+        CERT_REQUIRED = "CERT_REQUIRED"
+    else:
+        CERT_REQUIRED = b"CERT_REQUIRED"
+    return urllib3.PoolManager(cert_reqs=CERT_REQUIRED, ca_certs=certifi.where())
 
 
 __all__ = [

--- a/src/scout_apm/core/core_agent_manager.py
+++ b/src/scout_apm/core/core_agent_manager.py
@@ -10,6 +10,8 @@ import tarfile
 import time
 import warnings
 
+from urllib3.exceptions import HTTPError
+
 from scout_apm.compat import urllib3_cert_pool_manager
 from scout_apm.core.config import scout_config
 
@@ -154,7 +156,7 @@ class CoreAgentDownloader(object):
                 downloaded = self.download_package()
                 if downloaded:
                     self.untar()
-            except OSError:
+            except (OSError, HTTPError):
                 logger.exception("Exception raised while downloading Core Agent")
             finally:
                 self.release_download_lock()

--- a/tests/integration/instruments/test_urllib3.py
+++ b/tests/integration/instruments/test_urllib3.py
@@ -2,13 +2,12 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
-import sys
 
-import certifi
 import httpretty
 import pytest
 import urllib3
 
+from scout_apm.compat import urllib3_cert_pool_manager
 from scout_apm.instruments.urllib3 import ensure_installed
 from tests.compat import mock
 from tests.tools import delete_attributes
@@ -16,11 +15,6 @@ from tests.tools import delete_attributes
 mock_not_attempted = mock.patch(
     "scout_apm.instruments.urllib3.have_patched_pool_urlopen", new=False
 )
-
-if sys.version_info >= (3, 0):
-    CERT_REQUIRED = "CERT_REQUIRED"
-else:
-    CERT_REQUIRED = b"CERT_REQUIRED"
 
 
 def test_ensure_installed_twice(caplog):
@@ -86,7 +80,7 @@ def test_request(tracked_request):
             httpretty.GET, "https://example.com/", body="Hello World!"
         )
 
-        http = urllib3.PoolManager(cert_reqs=CERT_REQUIRED, ca_certs=certifi.where())
+        http = urllib3_cert_pool_manager()
         response = http.request("GET", "https://example.com")
 
     assert response.status == 200
@@ -100,7 +94,7 @@ def test_request(tracked_request):
 def test_request_type_error(tracked_request):
     ensure_installed()
     with pytest.raises(TypeError):
-        http = urllib3.PoolManager(cert_reqs=CERT_REQUIRED, ca_certs=certifi.where())
+        http = urllib3_cert_pool_manager()
         connection = http.connection_from_host("example.com", scheme="https")
         connection.urlopen()
 
@@ -118,7 +112,7 @@ def test_request_no_absolute_url(caplog, tracked_request):
             httpretty.GET, "https://example.com/", body="Hello World!"
         )
 
-        http = urllib3.PoolManager(cert_reqs=CERT_REQUIRED, ca_certs=certifi.where())
+        http = urllib3_cert_pool_manager()
         response = http.request("GET", "https://example.com")
 
     assert response.status == 200

--- a/tox.ini
+++ b/tox.ini
@@ -70,7 +70,6 @@ deps =
     six
     sqlalchemy
     starlette ; python_version >= "3.6"
-    urllib3[secure]
     webtest
 commands =
     pytest {posargs}


### PR DESCRIPTION
Basically avoid using `requests` so that we aren't pulling it in for people who aren't using it. Whilst popular I think some projects will be moving to httpx and it's best to minimize our footprint. We only use it for the single download of the core agent.