### PR TITLE
Convert shutdown_timeout_seconds to float

### DIFF
--- a/src/scout_apm/core/config.py
+++ b/src/scout_apm/core/config.py
@@ -221,7 +221,7 @@ class Defaults(object):
             "name": "",
             "revision_sha": self._git_revision_sha(),
             "scm_subdirectory": "",
-            "shutdown_timeout_seconds": 2,
+            "shutdown_timeout_seconds": 2.0,
             "uri_reporting": "filtered_params",
         }
 
@@ -260,11 +260,11 @@ def convert_to_bool(value):
     return False
 
 
-def convert_to_int(value):
+def convert_to_float(value):
     try:
-        return int(value)
+        return float(value)
     except ValueError:
-        return 0
+        return 0.0
 
 
 def convert_to_list(value):
@@ -285,7 +285,7 @@ CONVERSIONS = {
     "disabled_instruments": convert_to_list,
     "ignore": convert_to_list,
     "monitor": convert_to_bool,
-    "shutdown_timeout_seconds": convert_to_int,
+    "shutdown_timeout_seconds": convert_to_float,
 }
 
 

--- a/src/scout_apm/core/config.py
+++ b/src/scout_apm/core/config.py
@@ -260,6 +260,13 @@ def convert_to_bool(value):
     return False
 
 
+def convert_to_int(value):
+    try:
+        return int(value)
+    except ValueError:
+        return 0
+
+
 def convert_to_list(value):
     if isinstance(value, list):
         return value
@@ -275,9 +282,10 @@ def convert_to_list(value):
 CONVERSIONS = {
     "core_agent_download": convert_to_bool,
     "core_agent_launch": convert_to_bool,
-    "monitor": convert_to_bool,
     "disabled_instruments": convert_to_list,
     "ignore": convert_to_list,
+    "monitor": convert_to_bool,
+    "shutdown_timeout_seconds": convert_to_int,
 }
 
 

--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -186,6 +186,24 @@ def test_boolean_conversion_from_python(original, converted):
         ScoutConfig.reset_all()
 
 
+def test_int_conversion_from_env():
+    config = ScoutConfig()
+    with mock.patch.dict(os.environ, {"SCOUT_SHUTDOWN_TIMEOUT_SECONDS": "0"}):
+        assert config.value("shutdown_timeout_seconds") == 0
+
+
+@pytest.mark.parametrize(
+    "original, converted", [("0", 0), ("2", 2), ("x", 0)],
+)
+def test_int_conversion_from_python(original, converted):
+    ScoutConfig.set(shutdown_timeout_seconds=original)
+    config = ScoutConfig()
+    try:
+        assert config.value("shutdown_timeout_seconds") == converted
+    finally:
+        ScoutConfig.reset_all()
+
+
 def test_list_conversion_from_env():
     config = ScoutConfig()
     with mock.patch.dict(os.environ, {"SCOUT_DISABLED_INSTRUMENTS": "pymongo, redis"}):

--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -186,16 +186,18 @@ def test_boolean_conversion_from_python(original, converted):
         ScoutConfig.reset_all()
 
 
-def test_int_conversion_from_env():
+def test_float_conversion_from_env():
     config = ScoutConfig()
     with mock.patch.dict(os.environ, {"SCOUT_SHUTDOWN_TIMEOUT_SECONDS": "0"}):
-        assert config.value("shutdown_timeout_seconds") == 0
+        value = config.value("shutdown_timeout_seconds")
+    assert isinstance(value, float)
+    assert value == 0.0
 
 
 @pytest.mark.parametrize(
-    "original, converted", [("0", 0), ("2", 2), ("x", 0)],
+    "original, converted", [("0", 0.0), ("2", 2.0), ("x", 0.0)],
 )
-def test_int_conversion_from_python(original, converted):
+def test_float_conversion_from_python(original, converted):
     ScoutConfig.set(shutdown_timeout_seconds=original)
     config = ScoutConfig()
     try:


### PR DESCRIPTION
Fix new value from #474 being set as an environment variable, which will only be a string.