### PR TITLE
Make objtrace C extension optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Pending
+
+### Fixed
+
+- Made installation of the objtrace C extension optional, so that if it fails
+  due to your C compiler being old, Scout can still install
+  ([Issue #488](https://github.com/scoutapp/scout_apm_python/issues/488)).
+
 ## [2.11.0] 2020-02-17
 
 ### Added

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,9 @@ compile_extensions = (
 if compile_extensions:
     ext_modules = [
         Extension(
-            str("scout_apm.core._objtrace"), [str("src/scout_apm/core/_objtrace.c")]
+            name=str("scout_apm.core._objtrace"),
+            sources=[str("src/scout_apm/core/_objtrace.c")],
+            optional=True,
         )
     ]
 else:


### PR DESCRIPTION
Fixes #488.

I tested this by deliberately introducing a syntax error into `_objtrace.c`. Without `optional=True`, installation in a virtual environment failed; with it, it passes, and without any error message.