### PR TITLE
Set default app name to "Python App"

### DIFF
--- a/src/scout_apm/core/config.py
+++ b/src/scout_apm/core/config.py
@@ -218,7 +218,7 @@ class Defaults(object):
             "hostname": None,
             "key": "",
             "monitor": False,
-            "name": "",
+            "name": "Python App",
             "revision_sha": self._git_revision_sha(),
             "scm_subdirectory": "",
             "shutdown_timeout_seconds": 2.0,


### PR DESCRIPTION
Fixes #492.