### PR TITLE
Instrument new Elasticsearch methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Support Django's `BASE_DIR` setting being a `pathlib.Path`, as the default
   template in Django 3.1 will set.
   ([Issue #503](https://github.com/scoutapp/scout_apm_python/pull/503))
+- Instrument new Elasticsearch methods `get_script_context()` and
+  `get_script_languages()`.
+  ([PR #507](https://github.com/scoutapp/scout_apm_python/pull/507))
 
 ## [2.13.0] 2020-03-09
 

--- a/src/scout_apm/instruments/elasticsearch.py
+++ b/src/scout_apm/instruments/elasticsearch.py
@@ -47,6 +47,8 @@ CLIENT_METHODS = [
     ClientMethod("field_caps", True),
     ClientMethod("get", True),
     ClientMethod("get_script", False),
+    ClientMethod("get_script_context", False),
+    ClientMethod("get_script_languages", False),
     ClientMethod("get_source", True),
     ClientMethod("index", True),
     ClientMethod("info", False),


### PR DESCRIPTION
These methods seem to have been added in version 7.6.0, although that's [not documented](https://github.com/elastic/elasticsearch-py/issues/1168). Our test `test_all_client_attributes_accounted_for` started failing.

These methods don't take an index argument:

```
>>> import elasticsearch
>>> help(elasticsearch.Elasticsearch.get_script_context)
Help on function get_script_context in module elasticsearch.client:

get_script_context(self, params=None, headers=None)
    Returns all script contexts.

>>> help(elasticsearch.Elasticsearch.get_script_languages)
Help on function get_script_languages in module elasticsearch.client:

get_script_languages(self, params=None, headers=None)
    Returns available script types, languages and contexts
```