### PR TITLE
Fix httpretty install

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -52,7 +52,8 @@ deps =
     flask-sqlalchemy
     huey
     hug>=2.5.1 ; python_version >= "3.5"
-    httpretty
+    httpretty<1 ; python_version < "3.5"
+    httpretty ; python_version >= "3.5"
     jinja2
     nameko<3
     mock ; python_version < "3.0"


### PR DESCRIPTION
They released a version that requires `typing`, which is in Python 3.5+ only, without using setuptools to restrict the version to 3.5+.