### PR TITLE
Fix MANIFEST.in for check-manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
+prune tests
 include LICENSE
 include *.md
 exclude .pre-commit-config.yaml


### PR DESCRIPTION
For some reason it has started reporting about the tests not being included. Exclude them.