### PR TITLE
Ignore Redis warning triggered by rq

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -48,6 +48,7 @@ filterwarnings =
     ignore:Using or importing the ABCs from 'collections'.*:DeprecationWarning
     ; Deprecations in our libraries
     ignore:dns.hash module will be removed.*:DeprecationWarning:dns.hash
+    ignore:Pipeline\.hmset\(\) is deprecated\. Use Pipeline\.hset\(\) instead\.:DeprecationWarning
     ; Appears in both gettext and Django:
     ignore:parameter codeset is deprecated:DeprecationWarning
     ignore:"errors" is deprecated. Use "encoding_errors" instead:DeprecationWarning:redis.client


### PR DESCRIPTION
```
.tox/py27-django111/lib/python2.7/site-packages/rq/job.py:575: in save
    connection.hmset(key, self.to_dict(include_meta=include_meta))
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = Pipeline<ConnectionPool<Connection<host=localhost,port=6379,db=0>>>, name = 'rq:job:bbe77759-175d-4053-88f4-48d8b45844ce'
mapping = {'created_at': '2020-05-07T09:40:26.578828Z', 'data': 'x\x9ck`\xd2\x88\x90g``(I-.)\xd6\xcb\xcc+IM/J,\xc9\xcc\xcf\xd3\x...0\x9bO\x10\x88', 'description': 'tests.integration.test_rq.hello()', 'enqueued_at': '2020-05-07T09:40:26.578908Z', ...}

    def hmset(self, name, mapping):
        """
        Set key to value within hash ``name`` for each corresponding
        key and value from the ``mapping`` dict.
        """
        warnings.warn(
            '%s.hmset() is deprecated. Use %s.hset() instead.'
            % (self.__class__.__name__, self.__class__.__name__),
            DeprecationWarning,
>           stacklevel=2,
        )
E       DeprecationWarning: Pipeline.hmset() is deprecated. Use Pipeline.hset() instead.
```