### PR TITLE
Fix Travis config warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
+os: linux
 dist: xenial
+
 env:
   global:
     - ELASTICSEARCH_URL="http://localhost:9200/"
@@ -8,8 +10,7 @@ services:
   - docker
   - elasticsearch
   - mongodb
-  - redis-server
-sudo: required
+  - redis
 
 language: python
 


### PR DESCRIPTION
Fix some warnings seen in "Build config validation" on [a recent build](https://travis-ci.org/github/scoutapp/scout_apm_python/builds/684191778/config):

* root: deprecated key sudo (The key `sudo` has no effect anymore.)
* root: missing os, using the default linux
* services: value redis-server is an alias for redis, using redis