### PR TITLE
Fix Celery in tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ usedevelop = false
 deps =
     bottle
     cherrypy
-    celery
+    celery!=4.4.4  # https://github.com/celery/celery/issues/6153
     django18: Django>=1.8,<1.9
     django18: djangorestframework>=3.6,<3.7  # https://www.django-rest-framework.org/community/release-notes/
     django111: Django>=1.11,<2.0


### PR DESCRIPTION
Version 4.4.4 is missing a dependency in install_requires, so ignore it. See https://github.com/celery/celery/issues/6153 .