### PR TITLE
Instrument Elasticsearch.close()

### DIFF
--- a/src/scout_apm/instruments/elasticsearch.py
+++ b/src/scout_apm/instruments/elasticsearch.py
@@ -35,6 +35,7 @@ ClientMethod = namedtuple("ClientMethod", ["name", "takes_index_argument"])
 CLIENT_METHODS = [
     ClientMethod("bulk", True),
     ClientMethod("clear_scroll", False),
+    ClientMethod("close", False),
     ClientMethod("count", True),
     ClientMethod("create", True),
     ClientMethod("delete", True),


### PR DESCRIPTION
This new method has appeared, it seems it would be worth instrumenting in case it takes a noticeable amount of time to close the connection.