### PR TITLE
Ignore cryptography's warning about Python 2 EOL

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -57,3 +57,5 @@ filterwarnings =
     ; Triggered by asgiref on Python 3.7+:
     ignore:.*Task.all_tasks\(\) is deprecated, use asyncio.all_tasks\(\) instead.*:PendingDeprecationWarning
     ignore:.*Task.all_tasks\(\) is deprecated, use asyncio.all_tasks\(\) instead.*:DeprecationWarning
+    ; cryptography raises a deprecation warning on Python 2
+    ignore:Python 2 is no longer supported by the Python core team\..*


### PR DESCRIPTION
The 3.0 release added this warning on import under Python 2, crashing tests:

```
__ ERROR collecting tests/integration/test_nameko.py ___
tests/integration/test_nameko.py:8: in <module>
    from nameko.containers import get_container_cls
...
.tox/py27-django18/lib/python2.7/site-packages/OpenSSL/crypto.py:12: in <module>
    from cryptography import x509
.tox/py27-django18/lib/python2.7/site-packages/cryptography/__init__.py:39: in <module>
    CryptographyDeprecationWarning,
E   CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in a future release.
```