### PR TITLE
Add pyproject.toml

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,6 +5,7 @@ include CHANGELOG.md
 include DEVELOPMENT.md
 include LICENSE
 include README.md
+include pyproject.toml
 exclude .pre-commit-config.yaml
 exclude .python-version
 exclude pytest.ini

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = ["setuptools >= 40.6.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.black]
+target-version = ["py27"]


### PR DESCRIPTION
Declare Python 2.7 compatible output for Black and allow PEP517 builds.