### PR TITLE
Always convert collect_remote_ip to a boolean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Pending
+
+### Fixed
+
+- Always convert `collect_remote_ip` to boolean.
+  ([Issue #542](https://github.com/scoutapp/scout_apm_python/issues/542))
+
 ## [2.15.0] 2020-07-22
 
 ### Added

--- a/src/scout_apm/core/config.py
+++ b/src/scout_apm/core/config.py
@@ -293,6 +293,7 @@ def convert_to_list(value):
 
 
 CONVERSIONS = {
+    "collect_remote_ip": convert_to_bool,
     "core_agent_download": convert_to_bool,
     "core_agent_launch": convert_to_bool,
     "disabled_instruments": convert_to_list,


### PR DESCRIPTION
Otherwise `export SCOUT_COLLECT_REMOTE_IP=false` comes in as the string `"false"` which is truthy.