### PR TITLE
adding support for aioredis (#534)

### DIFF
--- a/src/scout_apm/async_/instruments/redis.py
+++ b/src/scout_apm/async_/instruments/redis.py
@@ -1,0 +1,83 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import logging
+
+import wrapt
+
+from scout_apm.core.tracked_request import TrackedRequest
+
+try:
+    import aioredis
+except ImportError:
+    aioredis = None
+else:
+    from aioredis import Redis as AioRedis
+    from aioredis.commands import Pipeline as AioPipeline
+
+logger = logging.getLogger(__name__)
+
+
+have_patched_aioredis_execute = False
+have_patched_aiopipeline_execute = False
+
+
+def ensure_async_installed():
+    global have_patched_aioredis_execute, have_patched_aiopipeline_execute
+
+    if aioredis is None:
+        logger.debug("Couldn't import aioredis - probably not installed")
+        return
+
+    if wrapped_execute_async is None or wrapped_execute_command_async is None:
+        logger.debug("Couldn't import async wrapper - probably async not supported")
+        return
+
+    if not have_patched_aioredis_execute:
+        try:
+            AioRedis.execute = wrapped_execute_command_async(AioRedis.execute)
+        except Exception as exc:
+            logger.warning(
+                "Failed to instrument aioredis.Redis.execute: %r", exc, exc_info=exc
+            )
+        else:
+            have_patched_aioredis_execute = True
+
+    if not have_patched_aiopipeline_execute:
+        try:
+            AioPipeline.execute = wrapped_execute_command_async(AioPipeline.execute)
+        except Exception as exc:
+            logger.warning(
+                "Failed to instrument aioredis.Redis.execute: %r", exc, exc_info=exc
+            )
+        else:
+            have_patched_aiopipeline_execute = True
+
+
+@wrapt.decorator
+async def wrapped_execute_command_async(wrapped, instance, args, kwargs):
+    try:
+        op = args[0]
+        if isinstance(op, bytes):
+            op = op.decode()
+    except (IndexError, TypeError):
+        op = "Unknown"
+
+    tracked_request = TrackedRequest.instance()
+    tracked_request.start_span(operation="Redis/{}".format(op))
+
+    try:
+        return await wrapped(*args, **kwargs)
+    finally:
+        tracked_request.stop_span()
+
+
+@wrapt.decorator
+async def wrapped_execute_async(wrapped, instance, args, kwargs):
+    tracked_request = TrackedRequest.instance()
+    tracked_request.start_span(operation="Redis/MULTI")
+
+    try:
+        return await wrapped(*args, **kwargs)
+    finally:
+        tracked_request.stop_span()

--- a/src/scout_apm/instruments/redis.py
+++ b/src/scout_apm/instruments/redis.py
@@ -19,6 +19,11 @@ else:
         from redis import StrictRedis as Redis
         from redis.client import BasePipeline as Pipeline
 
+try:
+    from scout_apm.async_.instruments.redis import ensure_async_installed
+except ImportError:
+    ensure_async_installed = None
+
 logger = logging.getLogger(__name__)
 
 
@@ -55,6 +60,9 @@ def ensure_installed():
                 )
             else:
                 have_patched_pipeline_execute = True
+
+    if ensure_async_installed is not None:
+        ensure_async_installed()
 
     return True
 


### PR DESCRIPTION
An initial PR for adding support `aioredis`, ref #534 I have encountered an unfortunate limitation.
When using:

```python
# view code

async def redis_pool():
    # Redis client bound to pool of connections (auto-reconnecting).
    redis = await aioredis.create_redis_pool(
        'redis://localhost')
    await redis.set('my-key', 'value')
    val = await redis.get('my-key')
    print(val)

    # gracefully closing underlying connection
    redis.close()
    await redis.wait_closed()

def index(request):
    loop = get_event_loop()
    loop.run_until_complete(redis_pool())

```

Looking at the trace it seems that scout doesn't recognize that the task is coming from the same thread (the trace is missing the aioredis) segment.

This has already an issue https://github.com/scoutapp/scout_apm_python/issues/469

When using `async_to_sync` it works