### PR TITLE
Connect to core agent over TCP by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Pending
 
+### Added
+
+- Changed default agent connection to use TCP rather than a unix socket. By
+  default the agent will be run on 127.0.0.1, port 6590. This should resolve
+  a number of connection issues customers have seen. To continue using a socket
+  connection, [configure
+  `core_agent_socket_path`](https://docs.scoutapm.com/#python-configuration).
+  ([Issue #553](https://github.com/scoutapp/scout_apm_python/issues/553))
+
 ### Fixed
 
 - Fixed validation check on length of key.

--- a/src/scout_apm/core/config.py
+++ b/src/scout_apm/core/config.py
@@ -219,6 +219,7 @@ class Defaults(object):
             "core_agent_launch": True,
             "core_agent_log_level": "info",
             "core_agent_permissions": 700,
+            "core_agent_socket_path": "tcp://127.0.0.1:6590",
             "core_agent_version": "v1.2.10",  # can be an exact tag name, or 'latest'
             "disabled_instruments": [],
             "download_url": "https://s3-us-west-1.amazonaws.com/scout-public-downloads/apm_core_agent/release",  # noqa: E501

--- a/src/scout_apm/core/core_agent_manager.py
+++ b/src/scout_apm/core/core_agent_manager.py
@@ -290,7 +290,7 @@ def sha256_digest(filename, block_size=65536):
         return None
 
 
-class SocketPath(str):
+class SocketPath(text_type):
     @property
     def is_tcp(self):
         return self.startswith("tcp://")

--- a/src/scout_apm/core/core_agent_manager.py
+++ b/src/scout_apm/core/core_agent_manager.py
@@ -88,7 +88,7 @@ class CoreAgentManager(object):
     def socket_path(self):
         path = get_socket_path()
         if path.is_tcp:
-            return ["--tcp", path]
+            return ["--tcp", path.tcp_address]
         else:
             return ["--socket", path]
 
@@ -294,6 +294,10 @@ class SocketPath(text_type):
     @property
     def is_tcp(self):
         return self.startswith("tcp://")
+
+    @property
+    def tcp_address(self):
+        return self[len("tcp://") :]
 
 
 def get_socket_path():

--- a/src/scout_apm/core/socket.py
+++ b/src/scout_apm/core/socket.py
@@ -6,6 +6,7 @@ import logging
 import os
 import socket
 import struct
+import sys
 import threading
 import time
 
@@ -207,6 +208,8 @@ class CoreAgentSocketThread(SingletonThread):
 
     def get_socket_address(self):
         if self.socket_path.is_tcp:
-            host, _, port = self.socket_path[len("tcp://") :].partition(":")
+            host, _, port = self.socket_path.tcp_address.partition(":")
+            if sys.version_info[0] == 2:
+                host = bytes(host)
             return host, int(port)
         return self.socket_path

--- a/tests/compat.py
+++ b/tests/compat.py
@@ -26,8 +26,8 @@ else:
     from tempfile import mkdtemp
 
     @contextmanager
-    def TemporaryDirectory():
-        tempdir = mkdtemp()
+    def TemporaryDirectory(*args, **kwargs):
+        tempdir = mkdtemp(*args, **kwargs)
         try:
             yield tempdir
         finally:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import os
 import subprocess
 import sys
 
+import psutil
 import pytest
 import wrapt
 from webtest import TestApp
@@ -106,21 +107,28 @@ def isolate_global_state():
                 )
 
 
+@pytest.fixture(autouse=True, scope="session")
+def terminate_running_core_agents():
+    for process in psutil.process_iter(["name"]):
+        if process.name() == "core-agent":
+            process.terminate()
+    yield
+
+
 # Create a temporary directory for isolation between test sessions.
 # Do it once per test session to avoid downloading the core agent repeatedly.
 @pytest.fixture(autouse=True, scope="session")
 def core_agent_dir():
-    with TemporaryDirectory() as temp_dir:
+    # Use /tmp/ to avoid core agent startup error:
+    #   [socket::server][ERROR] Error opening listener on socket: Custom
+    #   { kind: InvalidInput, error: "path must be shorter than SUN_LEN" }
+    with TemporaryDirectory(dir="/tmp/") as temp_dir:
         yield temp_dir
 
 
 @pytest.fixture
 def core_agent_manager(core_agent_dir):
-    # Shorten path to socket to prevent core-agent from failing with:
-    #   Error opening listener on socket: Custom { kind: InvalidInput,
-    #   error: StringError("path must be shorter than SUN_LEN") }
-    socket_path = "{}/test.sock".format(core_agent_dir)
-    scout_config.set(core_agent_dir=core_agent_dir, core_agent_socket_path=socket_path)
+    scout_config.set(core_agent_dir=core_agent_dir)
     core_agent_manager = CoreAgentManager()
     try:
         yield core_agent_manager
@@ -132,20 +140,12 @@ def core_agent_manager(core_agent_dir):
 def is_running(core_agent_manager):
     if core_agent_manager.core_agent_bin_path is None:
         return False
-    agent_binary = [core_agent_manager.core_agent_bin_path, "probe"]
-    socket_path = core_agent_manager.socket_path()
-    probe = subprocess.check_output(agent_binary + socket_path)
-    if b"Agent found" in probe:
-        return True
-    if b"Agent Not Running" in probe:
-        return False
-    raise AssertionError("cannot tell if the core agent is running")
+
+    return any(p.name() == "core-agent" for p in psutil.process_iter(["name"]))
 
 
 def shutdown(core_agent_manager):
-    agent_binary = [core_agent_manager.core_agent_bin_path, "shutdown"]
-    socket_path = core_agent_manager.socket_path()
-    subprocess.check_call(agent_binary + socket_path)
+    subprocess.check_call([core_agent_manager.core_agent_bin_path, "shutdown"])
 
 
 # Make all timeouts shorter so that tests exercising them run faster.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import logging
 import os
-import subprocess
 import sys
 
 import psutil
@@ -108,10 +107,8 @@ def isolate_global_state():
 
 
 @pytest.fixture(autouse=True, scope="session")
-def terminate_running_core_agents():
-    for process in psutil.process_iter(["name"]):
-        if process.name() == "core-agent":
-            process.terminate()
+def terminate_core_agent_processes_at_start_of_tests():
+    terminate_core_agent_processes()
     yield
 
 
@@ -141,8 +138,10 @@ def core_agent_is_running():
     return any(p.name() == "core-agent" for p in psutil.process_iter(["name"]))
 
 
-def shutdown(core_agent_manager):
-    subprocess.check_call([core_agent_manager.core_agent_bin_path, "shutdown"])
+def terminate_core_agent_processes():
+    for process in psutil.process_iter(["name"]):
+        if process.name() == "core-agent":
+            process.terminate()
 
 
 # Make all timeouts shorter so that tests exercising them run faster.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -133,14 +133,11 @@ def core_agent_manager(core_agent_dir):
     try:
         yield core_agent_manager
     finally:
-        assert not is_running(core_agent_manager)
+        assert not core_agent_is_running()
         scout_config.reset_all()
 
 
-def is_running(core_agent_manager):
-    if core_agent_manager.core_agent_bin_path is None:
-        return False
-
+def core_agent_is_running():
     return any(p.name() == "core-agent" for p in psutil.process_iter(["name"]))
 
 

--- a/tests/integration/core/test_core_agent_manager.py
+++ b/tests/integration/core/test_core_agent_manager.py
@@ -9,7 +9,7 @@ import pytest
 from scout_apm.core.config import scout_config
 from scout_apm.core.core_agent_manager import CoreAgentManager
 from tests.compat import mock
-from tests.conftest import core_agent_is_running, shutdown
+from tests.conftest import core_agent_is_running, terminate_core_agent_processes
 
 # Tests must execute in the order in which they are defined.
 
@@ -60,8 +60,8 @@ def test_no_verify(caplog, core_agent_manager):
     "path",
     [
         None,
-        # "tcp://127.0.0.1:5678",
-        # "/tmp/scout-tests.sock",
+        "tcp://127.0.0.1:5678",
+        "/tmp/scout-tests.sock",
     ],
 )
 def test_download_and_launch(path, core_agent_manager):
@@ -81,7 +81,7 @@ def test_download_and_launch(path, core_agent_manager):
         else:
             raise AssertionError("Could not find core agent running")
 
-        shutdown(core_agent_manager)
+        terminate_core_agent_processes()
     finally:
         scout_config.reset_all()
 

--- a/tests/integration/core/test_core_agent_manager.py
+++ b/tests/integration/core/test_core_agent_manager.py
@@ -5,6 +5,7 @@ import logging
 import time
 
 from scout_apm.core.config import scout_config
+from scout_apm.core.core_agent_manager import CoreAgentManager
 from tests.compat import mock
 from tests.conftest import is_running, shutdown
 
@@ -55,8 +56,13 @@ def test_no_verify(caplog, core_agent_manager):
 
 def test_download_and_launch(core_agent_manager):
     assert core_agent_manager.launch()
-    time.sleep(0.01)  # wait for agent to start running
-    assert is_running(core_agent_manager)
+    time.sleep(0.10)  # wait for agent to start running
+    for _ in range(10):
+        if is_running(core_agent_manager):
+            break
+        time.sleep(0.1)
+    else:
+        raise AssertionError("Could not find core agent running")
     shutdown(core_agent_manager)
 
 
@@ -86,8 +92,9 @@ def test_verify_error(caplog, core_agent_manager):
 def test_launch_error(caplog, core_agent_manager):
     caplog.set_level(logging.ERROR)
     exception = ValueError("Hello Fail")
-    with mock.patch(
-        "scout_apm.core.core_agent_manager.CoreAgentManager.agent_binary",
+    with mock.patch.object(
+        CoreAgentManager,
+        "agent_binary",
         side_effect=exception,
     ):
         result = core_agent_manager.launch()
@@ -98,67 +105,3 @@ def test_launch_error(caplog, core_agent_manager):
         ("scout_apm.core.core_agent_manager", logging.ERROR, "Error running Core Agent")
     ]
     assert caplog.records[0].exc_info[1] is exception
-
-
-def test_socket_path(core_agent_manager):
-    scout_config.set(core_agent_socket_path="foo")
-
-    result = core_agent_manager.socket_path()
-
-    assert result == ["--socket", "foo"]
-
-
-def test_socket_path_old_name_takes_precedence(core_agent_manager):
-    scout_config.set(socket_path="foo", core_agent_socket_path="bar")
-
-    result = core_agent_manager.socket_path()
-
-    assert result == ["--socket", "foo"]
-
-
-def test_log_level(core_agent_manager):
-    scout_config.set(core_agent_log_level="foo")
-
-    result = core_agent_manager.log_level()
-
-    assert result == ["--log-level", "foo"]
-
-
-def test_log_level_old_name_takes_precedence(core_agent_manager):
-    scout_config.set(log_level="foo", core_agent_log_level="bar")
-
-    result = core_agent_manager.log_level()
-
-    assert result == ["--log-level", "foo"]
-
-
-def test_log_file(core_agent_manager):
-    scout_config.set(core_agent_log_file="foo")
-
-    result = core_agent_manager.log_file()
-
-    assert result == ["--log-file", "foo"]
-
-
-def test_log_file_old_name_takes_precedence(core_agent_manager):
-    scout_config.set(log_file="foo", core_agent_log_file="bar")
-
-    result = core_agent_manager.log_file()
-
-    assert result == ["--log-file", "foo"]
-
-
-def test_config_file(core_agent_manager):
-    scout_config.set(core_agent_config_file="foo")
-
-    result = core_agent_manager.config_file()
-
-    assert result == ["--config-file", "foo"]
-
-
-def test_config_file_old_name_takes_precedence(core_agent_manager):
-    scout_config.set(config_file="foo", core_agent_config_file="bar")
-
-    result = core_agent_manager.config_file()
-
-    assert result == ["--config-file", "foo"]

--- a/tests/integration/core/test_socket.py
+++ b/tests/integration/core/test_socket.py
@@ -14,8 +14,15 @@ from tests.conftest import core_agent_is_running, terminate_core_agent_processes
 def running_agent(core_agent_manager):
     assert not core_agent_is_running()
     assert core_agent_manager.launch()
-    time.sleep(0.01)  # wait for agent to start running
-    assert core_agent_is_running()
+
+    # Wait for agent to start running
+    for _ in range(400):
+        if core_agent_is_running():
+            break
+        time.sleep(0.01)
+    else:
+        raise AssertionError("Core agent did not start in 4 second")
+
     try:
         yield
     finally:
@@ -58,8 +65,6 @@ def test_send_network_error(sendall, socket):
 
 
 def test_wait_until_drained_empty(socket):
-    CoreAgentSocketThread.ensure_stopped()
-
     empty = CoreAgentSocketThread.wait_until_drained()
     assert empty
 
@@ -67,7 +72,7 @@ def test_wait_until_drained_empty(socket):
 def test_wait_until_drained_one_item(socket):
     CoreAgentSocketThread._command_queue.put(Command(), False)
 
-    empty = CoreAgentSocketThread.wait_until_drained(timeout_seconds=0.1)
+    empty = CoreAgentSocketThread.wait_until_drained()
     assert empty
 
 

--- a/tests/integration/core/test_socket.py
+++ b/tests/integration/core/test_socket.py
@@ -7,7 +7,7 @@ import pytest
 
 from scout_apm.core.socket import CoreAgentSocketThread
 from tests.compat import mock
-from tests.conftest import core_agent_is_running, shutdown
+from tests.conftest import core_agent_is_running, terminate_core_agent_processes
 
 
 @pytest.fixture
@@ -19,7 +19,7 @@ def running_agent(core_agent_manager):
     try:
         yield
     finally:
-        shutdown(core_agent_manager)
+        terminate_core_agent_processes()
         assert not core_agent_is_running()
 
 

--- a/tests/integration/core/test_socket.py
+++ b/tests/integration/core/test_socket.py
@@ -7,20 +7,20 @@ import pytest
 
 from scout_apm.core.socket import CoreAgentSocketThread
 from tests.compat import mock
-from tests.conftest import is_running, shutdown
+from tests.conftest import core_agent_is_running, shutdown
 
 
 @pytest.fixture
 def running_agent(core_agent_manager):
-    assert not is_running(core_agent_manager)
+    assert not core_agent_is_running()
     assert core_agent_manager.launch()
     time.sleep(0.01)  # wait for agent to start running
-    assert is_running(core_agent_manager)
+    assert core_agent_is_running()
     try:
         yield
     finally:
         shutdown(core_agent_manager)
-        assert not is_running(core_agent_manager)
+        assert not core_agent_is_running()
 
 
 @pytest.fixture

--- a/tests/unit/core/test_core_agent_manager.py
+++ b/tests/unit/core/test_core_agent_manager.py
@@ -127,9 +127,16 @@ class TestGetSocketPath(object):
         finally:
             scout_config.reset_all()
 
-    def test_derived(self):
-        scout_config.set(core_agent_dir="/tmp/mydir", core_agent_full_name="my-agent")
+    def test_not_tcp(self):
+        scout_config.set(core_agent_socket_path="/tmp/that.sock")
         try:
-            assert get_socket_path() == "/tmp/mydir/my-agent/scout-agent.sock"
+            assert not get_socket_path().is_tcp
+        finally:
+            scout_config.reset_all()
+
+    def test_tcp(self):
+        scout_config.set(core_agent_socket_path="tcp://127.0.0.1:1234")
+        try:
+            assert get_socket_path().is_tcp
         finally:
             scout_config.reset_all()

--- a/tests/unit/core/test_core_agent_manager.py
+++ b/tests/unit/core/test_core_agent_manager.py
@@ -6,8 +6,94 @@ import logging
 import sys
 
 from scout_apm.core.config import scout_config
-from scout_apm.core.core_agent_manager import get_socket_path, parse_manifest
+from scout_apm.core.core_agent_manager import (
+    CoreAgentManager,
+    get_socket_path,
+    parse_manifest,
+)
 from tests.compat import mock
+
+
+class TestCoreAgentManager(object):
+    def test_socket_path_path(self):
+        scout_config.set(core_agent_socket_path="/tmp/foo.sock")
+
+        try:
+            result = CoreAgentManager().socket_path()
+        finally:
+            scout_config.reset_all()
+
+        assert result == ["--socket", "/tmp/foo.sock"]
+
+    def test_socket_path_tcp(self):
+        scout_config.set(core_agent_socket_path="tcp://127.0.0.1:7894")
+
+        try:
+            result = CoreAgentManager().socket_path()
+        finally:
+            scout_config.reset_all()
+
+        assert result == ["--tcp", "tcp://127.0.0.1:7894"]
+
+    def test_log_level(self):
+        scout_config.set(core_agent_log_level="foo")
+
+        try:
+            result = CoreAgentManager().log_level()
+        finally:
+            scout_config.reset_all()
+
+        assert result == ["--log-level", "foo"]
+
+    def test_log_level_old_name_takes_precedence(self):
+        scout_config.set(log_level="foo", core_agent_log_level="bar")
+
+        try:
+            result = CoreAgentManager().log_level()
+        finally:
+            scout_config.reset_all()
+
+        assert result == ["--log-level", "foo"]
+
+    def test_log_file(self):
+        scout_config.set(core_agent_log_file="foo")
+
+        try:
+            result = CoreAgentManager().log_file()
+        finally:
+            scout_config.reset_all()
+
+        assert result == ["--log-file", "foo"]
+
+    def test_log_file_old_name_takes_precedence(self):
+        scout_config.set(log_file="foo", core_agent_log_file="bar")
+
+        try:
+            result = CoreAgentManager().log_file()
+        finally:
+            scout_config.reset_all()
+
+        assert result == ["--log-file", "foo"]
+
+    def test_config_file(self):
+        scout_config.set(core_agent_config_file="foo")
+
+        try:
+            result = CoreAgentManager().config_file()
+        finally:
+            scout_config.reset_all()
+
+        assert result == ["--config-file", "foo"]
+
+    def test_config_file_old_name_takes_precedence(self):
+        scout_config.set(config_file="foo", core_agent_config_file="bar")
+
+        try:
+            result = CoreAgentManager().config_file()
+        finally:
+            scout_config.reset_all()
+
+        assert result == ["--config-file", "foo"]
 
 
 class TestParseManifest(object):

--- a/tests/unit/core/test_core_agent_manager.py
+++ b/tests/unit/core/test_core_agent_manager.py
@@ -33,7 +33,7 @@ class TestCoreAgentManager(object):
         finally:
             scout_config.reset_all()
 
-        assert result == ["--tcp", "tcp://127.0.0.1:7894"]
+        assert result == ["--tcp", "127.0.0.1:7894"]
 
     def test_log_level(self):
         scout_config.set(core_agent_log_level="foo")


### PR DESCRIPTION
Fixes #553.

Because the `probe` and `shutdown` core-agent commands don't work with TCP mode, this moves the relevant test functions to instead check for the process, and terminate it for shutdown.