### PR TITLE
Raise exception on final connect attempt

### DIFF
--- a/src/scout_apm/core/agent/socket.py
+++ b/src/scout_apm/core/agent/socket.py
@@ -178,14 +178,14 @@ class CoreAgentSocketThread(SingletonThread):
                 self.socket.connect(self.get_socket_address())
                 self.socket.settimeout(3 * SECOND)
                 logger.debug("CoreAgentSocketThread connected")
-                return True
+                return
             except socket.error as exc:
                 logger.debug(
                     "CoreAgentSocketThread connection error: %r", exc, exc_info=exc
                 )
                 # Return without waiting when reaching the maximum number of attempts.
-                if attempt >= connect_attempts:
-                    return False
+                if attempt == connect_attempts:
+                    raise
                 time.sleep(retry_wait_secs * SECOND)
 
     def _disconnect(self):


### PR DESCRIPTION
Previously a failed connection would count as a success, and the thread would continue to try registering, which failed with a `BrokenPipeError`:

```
2020-09-03T16:38:38+0100 DEBUG CoreAgentSocketThread connection error: OSError(22, 'Invalid argument')
Traceback (most recent call last):
  File "/.../scout_apm_python/src/scout_apm/core/agent/socket.py", line 178, in _connect
    self.socket.connect(self.get_socket_address())
OSError: [Errno 22] Invalid argument
2020-09-03T16:38:38+0100 INFO Registering with app=Test Django App key_prefix=... key_format_validated=True host=None
2020-09-03T16:38:38+0100 DEBUG CoreAgentSocketThread exception on _send: BrokenPipeError(32, 'Broken pipe') on PID: 95487 on thread: <CoreAgentSocketThread(Thread-1, started daemon 123145577099264)>
Traceback (most recent call last):
  File "/.../scout_apm_python/src/scout_apm/core/agent/socket.py", line 117, in _send
    self.socket.sendall(full_data)
BrokenPipeError: [Errno 32] Broken pipe
```

By raising the exception, the outer `try/except` can log the exception and stop the thread rather than try and do something that's guaranteed to fail.