### PR TITLE
Fix release process for cibuildwheel 1.6.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,8 @@ jobs:
       run: python2.7 setup.py bdist_wheel
     - name: Build binary wheels
       env:
-        CIBW_SKIP: "cp27-* pp27-*"
+        # Disable for platforms where pure Python wheels would be generated.
+        CIBW_SKIP: "cp27-* pp27-* pp336-*"
       run: cibuildwheel
     - name: Check packages
       run: twine check dist/* wheelhouse/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       run: python2.7 setup.py bdist_wheel
     - name: Build binary wheels
       env:
-        CIBW_SKIP: "cp27-*"
+        CIBW_SKIP: "cp27-* pp27-*"
       run: cibuildwheel
     - name: Check packages
       run: twine check dist/* wheelhouse/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       run: python2.7 setup.py bdist_wheel
     - name: Build binary wheels
       env:
-        CIBW_SKIP: "cp27-* cp33-*"
+        CIBW_SKIP: "cp27-*"
       run: cibuildwheel
     - name: Check packages
       run: twine check dist/* wheelhouse/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,15 +18,22 @@ jobs:
     - uses: actions/setup-python@v2.1.1
       with:
         python-version: 3.7
+    - uses: actions/setup-python@v2.1.1
+      with:
+        python-version: 2.7
     - name: Install packaging tools
-      run: python -m pip install --upgrade cibuildwheel pip setuptools twine wheel
+      run: |
+        python2.7 -m pip install --upgrade pip setuptools wheel
+        python3.7 -m pip install --upgrade cibuildwheel pip setuptools twine wheel
     - name: Build sdist
-      run: python setup.py sdist
-    - name: Build wheels
+      run: python3.7 setup.py sdist
+    - name: Build Python 2 wheel
+      run: python2.7 setup.py bdist_wheel
+    - name: Build binary wheels
       env:
-        CIBW_SKIP: "cp33-*"
+        CIBW_SKIP: "cp27-* cp33-*"
       run: cibuildwheel
-    - name: Check wheels
+    - name: Check packages
       run: twine check dist/* wheelhouse/*
     - name: List files
       run: ls -al dist wheelhouse

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,18 +17,22 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2.1.1
       with:
-        python-version: 3.7
+        python-version: 3.8
     - uses: actions/setup-python@v2.1.1
       with:
         python-version: 2.7
     - name: Install packaging tools
       run: |
         python2.7 -m pip install --upgrade pip setuptools wheel
-        python3.7 -m pip install --upgrade cibuildwheel pip setuptools twine wheel
+        python3.8 -m pip install --upgrade cibuildwheel pip setuptools twine wheel
     - name: Build sdist
-      run: python3.7 setup.py sdist
+      run: python3.8 setup.py sdist
     - name: Build Python 2 wheel
       run: python2.7 setup.py bdist_wheel
+    - name: Build Python 3 wheel
+      env:
+        SCOUT_DISABLE_EXTENSIONS: "1"
+      run: python3.8 setup.py bdist_wheel
     - name: Build binary wheels
       env:
         # Disable for platforms where pure Python wheels would be generated.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Build binary wheels
       env:
         # Disable for platforms where pure Python wheels would be generated.
-        CIBW_SKIP: "cp27-* pp27-* pp336-*"
+        CIBW_SKIP: "cp27-* pp27-* pp36-*"
       run: cibuildwheel
     - name: Check packages
       run: twine check dist/* wheelhouse/*

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import os
 import sys
 
 from setuptools import Extension, find_packages, setup
@@ -19,6 +20,8 @@ compile_extensions = (
     and not sys.platform.startswith("java")
     # Not PyPy
     and "__pypy__" not in sys.builtin_module_names
+    # Not explicitly disabled
+    and (os.environ.get("SCOUT_DISABLE_EXTENSIONS", "") == "")
 )
 if compile_extensions:
     ext_modules = [


### PR DESCRIPTION
This version of cibuildwheel has disabled our extensionless wheel building since it sees that it's not a binary wheel and says to build it once yourself (see below logs). This PR does that by installing Python 2.7 on GitHub Actions and disabling all extensionless wheel building happening in cibuildwheel.

It also upgrades to using Python 3.8 for the build process.

```
Building wheels for collected packages: scout-apm
  Building wheel for scout-apm (PEP 517): started
  Building wheel for scout-apm (PEP 517): finished with status 'done'
  Created wheel for scout-apm: filename=scout_apm-2.16.0-py2-none-any.whl size=58254 sha256=f46f3bcd3b2100b905a05a8f3cfe89359eb97a6877e04bf5b0ea5114e0b1c904
  Stored in directory: /tmp/pip-ephem-wheel-cache-2UXuaG/wheels/ca/c1/c0/18849572a9d9850c185240b5123a2c0efd538774d2e703fcf9
Successfully built scout-apm
    + /opt/python/cp38-cp38/bin/python -c 'import sys, json, glob; json.dump(glob.glob('"'"'/tmp/cibuildwheel/built_wheel/*.whl'"'"'), sys.stdout)'
    + rm -rf /tmp/cibuildwheel/repaired_wheel
    + mkdir -p /tmp/cibuildwheel/repaired_wheel
cibuildwheel-d9327db8-1d52-4cf1-b190-06c4b1ac5a5c
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.7.9/x64/bin/cibuildwheel", line 8, in <module>
    sys.exit(main())
  File "/opt/hostedtoolcache/Python/3.7.9/x64/lib/python3.7/site-packages/cibuildwheel/__main__.py", line 234, in main
    cibuildwheel.linux.build(build_options)
  File "/opt/hostedtoolcache/Python/3.7.9/x64/lib/python3.7/site-packages/cibuildwheel/linux.py", line 183, in build
    raise NonPlatformWheelError()
cibuildwheel.util.NonPlatformWheelError:
cibuildwheel: Build failed because a pure Python wheel was generated.

If you intend to build a pure-Python wheel, you don't need cibuildwheel - use
`pip wheel -w DEST_DIR .` instead.

If you expected a platform wheel, check your project configuration, or run
cibuildwheel with CIBW_BUILD_VERBOSITY=1 to view build logs.
```