### PR TITLE
Disable building PyPy 3.7 wheels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       env:
         # Disable for platforms where pure Python wheels would be generated,
         # and Python 3.9 since it's pre-release
-        CIBW_SKIP: "cp27-* cp39-* pp27-* pp36-*"
+        CIBW_SKIP: "cp27-* cp39-* pp27-* pp36-* pp37-*"
       run: cibuildwheel
     - name: Check packages
       run: twine check dist/* wheelhouse/*


### PR DESCRIPTION
cibuildwheel just added support for this, however it fails for us since our wheels are pure Python, on PyPy:

```
You should consider upgrading via the '/opt/pypy/pypy3.7-7.3.2/bin/pypy -m pip install --upgrade pip' command.
Processing /project
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
    Preparing wheel metadata: started
    Preparing wheel metadata: finished with status 'done'
Building wheels for collected packages: scout-apm
  Building wheel for scout-apm (PEP 517): started
  Building wheel for scout-apm (PEP 517): finished with status 'done'
  Created wheel for scout-apm: filename=scout_apm-2.16.2-py3-none-any.whl size=60196 sha256=89062ab215016f818af9eba0ff6260cd29d5dae9f20302e0520c5f0499be7854
  Stored in directory: /tmp/pip-ephem-wheel-cache-o5v0utd8/wheels/51/1e/86/e35ee69f9e0f5a748fdf1aa69c135ed26d3f41555386024d6a
Successfully built scout-apm
    + /opt/python/cp38-cp38/bin/python -c 'import sys, json, glob; json.dump(glob.glob('"'"'/tmp/cibuildwheel/built_wheel/*.whl'"'"'), sys.stdout)'
    + rm -rf /tmp/cibuildwheel/repaired_wheel
    + mkdir -p /tmp/cibuildwheel/repaired_wheel
cibuildwheel-a8afc078-5977-4770-aa44-000b96dc4a45
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.8.6/x64/bin/cibuildwheel", line 8, in <module>
    sys.exit(main())
  File "/opt/hostedtoolcache/Python/3.8.6/x64/lib/python3.8/site-packages/cibuildwheel/__main__.py", line 234, in main
    cibuildwheel.linux.build(build_options)
  File "/opt/hostedtoolcache/Python/3.8.6/x64/lib/python3.8/site-packages/cibuildwheel/linux.py", line 184, in build
    raise NonPlatformWheelError()
cibuildwheel.util.NonPlatformWheelError:
cibuildwheel: Build failed because a pure Python wheel was generated.
```