### PR TITLE
Use latest GitHub Actions setup-python

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2.1.1
+    - uses: actions/setup-python@v2
       with:
         python-version: 3.8
-    - uses: actions/setup-python@v2.1.1
+    - uses: actions/setup-python@v2
       with:
         python-version: 2.7
     - name: Install packaging tools


### PR DESCRIPTION
This should stop this deprecation warning: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

We only pinned to a specific patch version since we needed the version that supported installing the latest Python. That's now been released onto the main `v2` tag/branch.