### PR TITLE
Support hexidecimal amazon time strings.

### DIFF
--- a/src/scout_apm/core/web_requests.py
+++ b/src/scout_apm/core/web_requests.py
@@ -137,8 +137,10 @@ def track_amazon_request_queue_time(header_value, tracked_request):
     if not first_char.isdigit():
         return False
 
+    # If the timestamp is 8 characters long, it's in hexadecimal format.
+    base = 16 if len(timestamp_str) == 8 else 10
     try:
-        start_timestamp_ns = int(timestamp_str) * 1000000000.0
+        start_timestamp_ns = int(timestamp_str, base) * 1000000000.0
     except ValueError:
         return False
 

--- a/tests/unit/core/test_web_requests.py
+++ b/tests/unit/core/test_web_requests.py
@@ -146,6 +146,27 @@ def test_track_amazon_request_queue_time_valid(header_value, tracked_request):
     queue_time_ns = tracked_request.tags["scout.queue_time_ns"]
     assert isinstance(queue_time_ns, int) and queue_time_ns > 0
 
+@pytest.mark.parametrize(
+    "header_value",
+    [
+        "Root=1-{start_time}-12456789abcdef012345678",
+        "Root=1-{start_time}-12456789abcdef012345678;CalledFrom=app",
+        "Self=1-{start_time}-12456789abcdef012345678",
+        "Self=1-{start_time}-12456789abcdef012345678;Root=1-123-abcdef012345678912345678",  # noqa: E501
+        "Self=1-{start_time}-12456789abcdef012345678;Root=1-123-abcdef012345678912345678;CalledFrom=app",  # noqa: E501
+    ],
+)
+def test_track_amazon_request_queue_time_hexidecimal_valid(header_value, tracked_request):
+    start_time = int(datetime_to_timestamp(dt.datetime.utcnow()), 16) - 2
+
+    result = track_amazon_request_queue_time(
+        "Root=1-{start_time}-12456789abcdef012345678".format(start_time=start_time), tracked_request
+    )
+
+    assert result is True
+    queue_time_ns = tracked_request.tags["scout.queue_time_ns"]
+    assert isinstance(queue_time_ns, int) and queue_time_ns > 0
+
 
 @pytest.mark.parametrize(
     "header_value",


### PR DESCRIPTION
Occassionally Amazon will send the time string in hexidecimal format.
It's not parseable in the format, but they do indicate it will be 8
characters long. It should be reasonable that decimal format time strings
will be longer than that.