### PR TITLE
Improve ignoring of eventlet warning

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -49,6 +49,8 @@ filterwarnings =
     ; Deprecations in our libraries
     ignore:dns.hash module will be removed.*:DeprecationWarning:dns.hash
     ignore:Pipeline\.hmset\(\) is deprecated\. Use Pipeline\.hset\(\) instead\.:DeprecationWarning
+    ; eventlet warning against use of Python 2.7
+    ignore:Support for your Python version is deprecated and will be removed in the future:DeprecationWarning:eventlet
     ; Appears in both gettext and Django:
     ignore:parameter codeset is deprecated:DeprecationWarning
     ignore:"errors" is deprecated. Use "encoding_errors" instead:DeprecationWarning:redis.client
@@ -64,5 +66,3 @@ filterwarnings =
     ; Django 3.1 warnings
     ; RemovedInDjango40Warning to be fixed in https://github.com/encode/django-rest-framework/issues/7406
     ignore:django\.conf\.urls\.url\(\) is deprecated.*:PendingDeprecationWarning:rest_framework.routers
-    ; Django 2.7 Support deprecation warning
-    ignore:Support for your Python version is deprecated and will be removed in the future:DeprecationWarning


### PR DESCRIPTION
Update the ignore from 30d0854f4732fe361be3f0fcf0469f94626532da to target the triggering module, and correct the comment since it's nothing to do with Django.