### PR TITLE
Move to vanilla pre-commit

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,22 @@
+name: pre-commit
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - uses: actions/setup-python@v2
+
+    - uses: pre-commit/action@v2.0.0
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v3.2.0
+  rev: v3.4.0
   hooks:
   - id: check-added-large-files
   - id: check-case-conflict
@@ -12,20 +12,28 @@ repos:
   - id: check-yaml
   - id: end-of-file-fixer
   - id: trailing-whitespace
-- repo: local
+- repo: https://github.com/psf/black
+  rev: 20.8b1
   hooks:
   - id: black
-    name: black
-    entry: .tox/py38-codestyle/bin/black
-    language: system
-    types: [python]
-  - id: flake8
-    name: flake8
-    entry: .tox/py38-codestyle/bin/flake8 --config=setup.cfg
-    language: system
-    types: [python]
+    language_version: python3
+- repo: https://github.com/pycqa/isort
+  rev: 5.7.0
+  hooks:
   - id: isort
-    name: isort
-    entry: .tox/py38-codestyle/bin/isort
-    language: system
-    types: [python]
+- repo: https://gitlab.com/pycqa/flake8
+  rev: 3.8.4
+  hooks:
+  - id: flake8
+    additional_dependencies:
+    - flake8-2020
+    - flake8-bugbear
+    - flake8-coding
+    - flake8-comprehensions
+    - flake8-tidy-imports
+    - flake8-print
+- repo: https://github.com/mgedmin/check-manifest
+  rev: "0.46"
+  hooks:
+  - id: check-manifest
+    args: [--no-build-isolation]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 global-exclude *.py[cod]
 prune __pycache__
 prune tests
+recursive-include src *.c
 include CHANGELOG.md
 include DEVELOPMENT.md
 include LICENSE

--- a/src/scout_apm/core/config.py
+++ b/src/scout_apm/core/config.py
@@ -222,7 +222,7 @@ class Defaults(object):
             "core_agent_socket_path": "tcp://127.0.0.1:6590",
             "core_agent_version": "v1.3.0",  # can be an exact tag name, or 'latest'
             "disabled_instruments": [],
-            "download_url": "https://s3-us-west-1.amazonaws.com/scout-public-downloads/apm_core_agent/release",  # noqa: E501
+            "download_url": "https://s3-us-west-1.amazonaws.com/scout-public-downloads/apm_core_agent/release",  # noqa: B950
             "framework": "",
             "framework_version": "",
             "hostname": None,

--- a/tests/unit/core/test_web_requests.py
+++ b/tests/unit/core/test_web_requests.py
@@ -131,8 +131,8 @@ def test_track_request_queue_time_invalid(header_value, tracked_request):
         "Root=1-{start_time}-12456789abcdef012345678",
         "Root=1-{start_time}-12456789abcdef012345678;CalledFrom=app",
         "Self=1-{start_time}-12456789abcdef012345678",
-        "Self=1-{start_time}-12456789abcdef012345678;Root=1-123-abcdef012345678912345678",  # noqa: E501
-        "Self=1-{start_time}-12456789abcdef012345678;Root=1-123-abcdef012345678912345678;CalledFrom=app",  # noqa: E501
+        "Self=1-{start_time}-12456789abcdef012345678;Root=1-123-abcdef012345678912345678",  # noqa: B950
+        "Self=1-{start_time}-12456789abcdef012345678;Root=1-123-abcdef012345678912345678;CalledFrom=app",  # noqa: B950
     ],
 )
 def test_track_amazon_request_queue_time_valid(header_value, tracked_request):
@@ -146,21 +146,25 @@ def test_track_amazon_request_queue_time_valid(header_value, tracked_request):
     queue_time_ns = tracked_request.tags["scout.queue_time_ns"]
     assert isinstance(queue_time_ns, int) and queue_time_ns > 0
 
+
 @pytest.mark.parametrize(
     "header_value",
     [
         "Root=1-{start_time}-12456789abcdef012345678",
         "Root=1-{start_time}-12456789abcdef012345678;CalledFrom=app",
         "Self=1-{start_time}-12456789abcdef012345678",
-        "Self=1-{start_time}-12456789abcdef012345678;Root=1-123-abcdef012345678912345678",  # noqa: E501
-        "Self=1-{start_time}-12456789abcdef012345678;Root=1-123-abcdef012345678912345678;CalledFrom=app",  # noqa: E501
+        "Self=1-{start_time}-12456789abcdef012345678;Root=1-123-abcdef012345678912345678",  # noqa: B950
+        "Self=1-{start_time}-12456789abcdef012345678;Root=1-123-abcdef012345678912345678;CalledFrom=app",  # noqa: B950
     ],
 )
-def test_track_amazon_request_queue_time_hexidecimal_valid(header_value, tracked_request):
-    start_time = format(int(datetime_to_timestamp(dt.datetime.utcnow())), 'x')
+def test_track_amazon_request_queue_time_hexidecimal_valid(
+    header_value, tracked_request
+):
+    start_time = format(int(datetime_to_timestamp(dt.datetime.utcnow())), "x")
 
     result = track_amazon_request_queue_time(
-        "Root=1-{start_time}-12456789abcdef012345678".format(start_time=start_time), tracked_request
+        "Root=1-{start_time}-12456789abcdef012345678".format(start_time=start_time),
+        tracked_request,
     )
 
     assert result is True

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 isolated_build = True
 envlist =
-    py38-codestyle
     {py27,py34,py35}-django18
     {py27,py34,py35,py36}-django111
     {py34,py35,py36,py37,py38}-django20
@@ -68,22 +67,3 @@ deps =
     webtest
 commands =
     pytest {posargs}
-
-[testenv:py38-codestyle]
-deps =
-    check-manifest
-    black
-    flake8
-    flake8-2020
-    flake8-bugbear
-    flake8-coding
-    flake8-comprehensions
-    flake8-tidy-imports
-    flake8-print
-    isort
-    pre-commit
-    twine
-commands =
-    check-manifest
-    pre-commit run --all-files
-    twine check {distdir}/*


### PR DESCRIPTION
This is easier to manage and `pre-commit autoupdate` can keep dependencies up to date.