### PR TITLE
Remove 'usedevelop' from tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,6 @@ passenv =
     ELASTICSEARCH_URL
     MONGODB_URL
     REDIS_URL
-usedevelop = false
 deps =
     bottle
     cherrypy


### PR DESCRIPTION
'false' is the default so no need to specify: https://tox.readthedocs.io/en/latest/config.html#conf-usedevelop