### PR TITLE
Drop unused test depednency pytest-travis-fold

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -53,7 +53,6 @@ deps =
     pymongo
     pyramid
     pytest
-    pytest-travis-fold
     pytest-cov
     pyyaml ; python_version != "3.4"
     pyyaml < 5.3 ; python_version == "3.4"


### PR DESCRIPTION
This isn't needed since the move from Travis to GitHub Actions.