### PR TITLE
Fix socket resource leak in CoreAgentDownloader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 - Support hex timestamp in Amazon headers
   ([PR #598](https://github.com/scoutapp/scout_apm_python/pull/598))
+- Fix a socket resource leak when downloading the core agent.
+  ([PR #609](https://github.com/scoutapp/scout_apm_python/pull/609))
 
 ## [2.17.0] 2020-09-17
 

--- a/src/scout_apm/core/agent/manager.py
+++ b/src/scout_apm/core/agent/manager.py
@@ -216,6 +216,7 @@ class CoreAgentDownloader(object):
                     fp.write(chunk)
         finally:
             response.release_conn()
+            http.clear()
         return True
 
     def untar(self):


### PR DESCRIPTION
Detected by latest pytest feature of failing tests on "unraisable exceptions", from our warnings config that turns the `ResourceWarning` into an exception.