### PR TITLE
Build wheel on Python 3.9

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
         # Disable for platforms where pure Python wheels would be generated,
         # and Python 3.9 since it's pre-release
         CIBW_BUILD_VERBOSITY: 1
-        CIBW_SKIP: "cp27-* cp35-* cp39-* pp27-* pp36-* pp37-*"
+        CIBW_SKIP: "cp27-* pp27-* pp36-* pp37-*"
       run: cibuildwheel
     - name: Check packages
       run: twine check dist/* wheelhouse/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   `open_point_in_time()`.
   ([PR #602](https://github.com/scoutapp/scout_apm_python/pull/602))
 
+- The release now includes a wheel for Python 3.9.
+
 ### Fixed
 
 - Support hex timestamp in Amazon headers


### PR DESCRIPTION
Also undo removal from Python 3.5 which shouldn't be necessary.