### PR TITLE
Build wheels for ARM on Linux

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,35 +15,53 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+
     - uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.9
+
     - uses: actions/setup-python@v2
       with:
         python-version: 2.7
+
+    - name: Set up QEMU
+      # For cross-architecture builds
+      # https://cibuildwheel.readthedocs.io/en/stable/faq/#emulation
+      if: runner.os == 'Linux'
+      uses: docker/setup-qemu-action@v1
+      with:
+        platforms: all
+
     - name: Install packaging tools
       run: |
         python2.7 -m pip install --upgrade pip setuptools wheel
-        python3.8 -m pip install --upgrade cibuildwheel pip setuptools twine wheel
+        python3.9 -m pip install --upgrade cibuildwheel pip setuptools twine wheel
+
     - name: Build sdist
-      run: python3.8 setup.py sdist
-    - name: Build Python 2 wheel
+      run: python3.9 setup.py sdist
+
+    - name: Build Python 2 pure Python wheel
       run: python2.7 setup.py bdist_wheel
-    - name: Build Python 3 wheel
+
+    - name: Build Python 3 pure Python wheel
       env:
         SCOUT_DISABLE_EXTENSIONS: "1"
-      run: python3.8 setup.py bdist_wheel
+      run: python3.9 setup.py bdist_wheel
+
     - name: Build binary wheels
       env:
-        # Disable for platforms where pure Python wheels would be generated,
-        # and Python 3.9 since it's pre-release
+        # Disable for platforms where pure Python wheels would be generated
+        CIBW_ARCHS_LINUX: "auto aarch64"
         CIBW_BUILD_VERBOSITY: 1
         CIBW_SKIP: "cp27-* pp27-* pp36-* pp37-*"
       run: cibuildwheel
+
     - name: Check packages
       run: twine check dist/* wheelhouse/*
+
     - name: List files
       run: ls -al dist wheelhouse
+
     - name: Release
       if: startsWith(github.event.ref, 'refs/tags')
       env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
   `open_point_in_time()`.
   ([PR #602](https://github.com/scoutapp/scout_apm_python/pull/602))
 
-- The release now includes a wheel for Python 3.9.
+- The release now includes binary wheels for Linux ARM and Python 3.9.
 
 ### Fixed
 


### PR DESCRIPTION
Also run cibuildwheel with Python 3.9 since it's now stable.