### PR TITLE
Allow tests to pass by ignoring a deprecation warning.

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -49,6 +49,8 @@ filterwarnings =
     ; Deprecations in our libraries
     ignore:dns.hash module will be removed.*:DeprecationWarning:dns.hash
     ignore:Pipeline\.hmset\(\) is deprecated\. Use Pipeline\.hset\(\) instead\.:DeprecationWarning
+    ; importlib-metadata 3.9 raises deprecation for kombu compat code.
+    ignore:SelectableGroups dict interface is deprecated. Use select.:DeprecationWarning
     ; eventlet warning against use of Python 2.7
     ignore:Support for your Python version is deprecated and will be removed in the future:DeprecationWarning:eventlet
     ; Appears in both gettext and Django:


### PR DESCRIPTION
The warning is being emitted by kombu using deprecated logic of importlib-metadata.