### PR TITLE
Add support for django 3.2.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Pending
+
+### Added
+
+- Tested with Django 3.2. Only define ``default_app_config`` when using
+  a version of Django earlier than 3.2.
+
 ## [2.18.0] 2021-02-09
 
 ### Added

--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,7 @@ setup(
         "Framework :: Django :: 2.2",
         "Framework :: Django :: 3.0",
         "Framework :: Django :: 3.1",
+        "Framework :: Django :: 3.2",
         "Framework :: Flask",
         "Framework :: Pyramid",
         "Intended Audience :: Developers",

--- a/src/scout_apm/django/__init__.py
+++ b/src/scout_apm/django/__init__.py
@@ -1,4 +1,8 @@
 # coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-default_app_config = "scout_apm.django.apps.ScoutApmDjangoConfig"
+import django
+
+if django.VERSION < (3, 2, 0):
+    # Only define default_app_config when using a version earlier than 3.2
+    default_app_config = "scout_apm.django.apps.ScoutApmDjangoConfig"

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ envlist =
     {py35,py36,py37,py38,py39}-django22
     {py36,py37,py38,py39}-django30
     {py36,py37,py38,py39}-django31
+    {py36,py37,py38,py39}-django32
 
 [testenv]
 passenv =
@@ -37,6 +38,8 @@ deps =
     django30: djangorestframework
     django31: Django>=3.1,<3.2
     django31: djangorestframework
+    django32: Django>=3.2,<3.3
+    django32: djangorestframework
     dramatiq>=1.0.0 ; python_version >= "3.5"
     elasticsearch
     falcon


### PR DESCRIPTION
Requires cleanup of removing >=3.2rc1 in tox after 3.2 is released.