### PR TITLE
Fix timing rounding bug in tests.

### DIFF
--- a/tests/unit/core/test_web_requests.py
+++ b/tests/unit/core/test_web_requests.py
@@ -160,7 +160,7 @@ def test_track_amazon_request_queue_time_valid(header_value, tracked_request):
 def test_track_amazon_request_queue_time_hexidecimal_valid(
     header_value, tracked_request
 ):
-    start_time = format(int(datetime_to_timestamp(dt.datetime.utcnow())), "x")
+    start_time = format(int(datetime_to_timestamp(dt.datetime.utcnow())) - 2, "x")
 
     result = track_amazon_request_queue_time(
         "Root=1-{start_time}-12456789abcdef012345678".format(start_time=start_time),


### PR DESCRIPTION
There's some floating point rounding errors here. Subtracting
some time to ensure the header time is before the tracked
request start time seems to fix it.

Related to #328

Reproduced using pytest-repeat plugin and a count of 1000.