### PR TITLE
Pin jinja2 support to v2.x temporarily. 

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ deps =
     huey
     hug>=2.5.1 ; python_version >= "3.5"
     httpretty<1 ; python_version < "3.5"
-    httpretty ; python_version >= "3.5"
+    httpretty!=1.1.1 ; python_version >= "3.5"
     jinja2<3.0.0
     ; nameko tests temporarily disabled
     ; Due to bad pinning of kombu only a past nameko version can be installed

--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,7 @@ deps =
     hug>=2.5.1 ; python_version >= "3.5"
     httpretty<1 ; python_version < "3.5"
     httpretty ; python_version >= "3.5"
-    jinja2
+    jinja2<3.0.0
     ; nameko tests temporarily disabled
     ; Due to bad pinning of kombu only a past nameko version can be installed
     ; alongside the latest celery.

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,8 @@ passenv =
     MONGODB_URL
     REDIS_URL
 deps =
+    attrs ; python_version > "3.4"
+    attrs<21.1.0 ; python_version <= "3.4"
     bottle
     cherrypy
     celery!=4.4.4  # https://github.com/celery/celery/issues/6153


### PR DESCRIPTION
jinja2 v3 introduced changes for async_render which impacts render.
These will take more effort than we have available at the moment.

This will be addressed as a part of #646.