### PR TITLE
Remove tracking queue time from amazon trace id header.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## Pending
+- Removed parsing queue time from Amazon ALB header, X-Amzn-Trace-Id.
+  The time portion of the header only has the truncated seconds which
+  appears as about 500ms for queue time constantly.
+  ([Issue #631](https://github.com/scoutapp/scout_apm_python/issues/631))
 
 ## [2.19.0] 2021-05-04
 

--- a/src/scout_apm/bottle.py
+++ b/src/scout_apm/bottle.py
@@ -10,7 +10,6 @@ from scout_apm.core.tracked_request import TrackedRequest
 from scout_apm.core.web_requests import (
     create_filtered_path,
     ignore_path,
-    track_amazon_request_queue_time,
     track_request_queue_time,
 )
 
@@ -72,14 +71,10 @@ def wrap_callback(wrapped, instance, args, kwargs):
         )
         tracked_request.tag("user_ip", user_ip)
 
-    tracked_queue_time = False
     queue_time = request.headers.get("x-queue-start", "") or request.headers.get(
         "x-request-start", ""
     )
-    tracked_queue_time = track_request_queue_time(queue_time, tracked_request)
-    if not tracked_queue_time:
-        amazon_queue_time = request.headers.get("x-amzn-trace-id", "")
-        track_amazon_request_queue_time(amazon_queue_time, tracked_request)
+    track_request_queue_time(queue_time, tracked_request)
 
     with tracked_request.span(
         operation="Controller{}".format(controller_name), should_capture_backtrace=False

--- a/src/scout_apm/cherrypy.py
+++ b/src/scout_apm/cherrypy.py
@@ -12,7 +12,6 @@ from scout_apm.core.tracked_request import TrackedRequest
 from scout_apm.core.web_requests import (
     create_filtered_path,
     ignore_path,
-    track_amazon_request_queue_time,
     track_request_queue_time,
 )
 
@@ -72,10 +71,7 @@ class ScoutPlugin(plugins.SimplePlugin):
         queue_time = request.headers.get("x-queue-start", "") or request.headers.get(
             "x-request-start", ""
         )
-        tracked_queue_time = track_request_queue_time(queue_time, tracked_request)
-        if not tracked_queue_time:
-            amazon_queue_time = request.headers.get("x-amzn-trace-id", "")
-            track_amazon_request_queue_time(amazon_queue_time, tracked_request)
+        track_request_queue_time(queue_time, tracked_request)
 
         response = cherrypy.response
         status = response.status

--- a/src/scout_apm/django/middleware.py
+++ b/src/scout_apm/django/middleware.py
@@ -12,7 +12,6 @@ from scout_apm.core.tracked_request import TrackedRequest
 from scout_apm.core.web_requests import (
     create_filtered_path,
     ignore_path,
-    track_amazon_request_queue_time,
     track_request_queue_time,
 )
 
@@ -168,11 +167,7 @@ class MiddlewareTimingMiddleware(object):
         queue_time = request.META.get("HTTP_X_QUEUE_START") or request.META.get(
             "HTTP_X_REQUEST_START", ""
         )
-        queue_time_tracked = track_request_queue_time(queue_time, tracked_request)
-        if not queue_time_tracked:
-            track_amazon_request_queue_time(
-                request.META.get("HTTP_X_AMZN_TRACE_ID", ""), tracked_request
-            )
+        track_request_queue_time(queue_time, tracked_request)
 
         with tracked_request.span(
             operation="Middleware",
@@ -254,11 +249,7 @@ class OldStyleMiddlewareTimingMiddleware(object):
         queue_time = request.META.get("HTTP_X_QUEUE_START") or request.META.get(
             "HTTP_X_REQUEST_START", ""
         )
-        queue_time_tracked = track_request_queue_time(queue_time, tracked_request)
-        if not queue_time_tracked:
-            track_amazon_request_queue_time(
-                request.META.get("HTTP_X_AMZN_TRACE_ID", ""), tracked_request
-            )
+        track_request_queue_time(queue_time, tracked_request)
 
         tracked_request.start_span(
             operation="Middleware", should_capture_backtrace=False

--- a/src/scout_apm/falcon.py
+++ b/src/scout_apm/falcon.py
@@ -12,7 +12,6 @@ from scout_apm.core.tracked_request import TrackedRequest
 from scout_apm.core.web_requests import (
     create_filtered_path,
     ignore_path,
-    track_amazon_request_queue_time,
     track_request_queue_time,
 )
 
@@ -75,10 +74,7 @@ class ScoutMiddleware(object):
         queue_time = req.get_header("x-queue-start", default="") or req.get_header(
             "x-request-start", default=""
         )
-        tracked_queue_time = track_request_queue_time(queue_time, tracked_request)
-        if not tracked_queue_time:
-            amazon_queue_time = req.get_header("x-amzn-trace-id", default="")
-            track_amazon_request_queue_time(amazon_queue_time, tracked_request)
+        track_request_queue_time(queue_time, tracked_request)
 
     def process_resource(self, req, resp, resource, params):
         if self._do_nothing:

--- a/src/scout_apm/pyramid.py
+++ b/src/scout_apm/pyramid.py
@@ -7,7 +7,6 @@ from scout_apm.core.tracked_request import TrackedRequest
 from scout_apm.core.web_requests import (
     create_filtered_path,
     ignore_path,
-    track_amazon_request_queue_time,
     track_request_queue_time,
 )
 
@@ -53,14 +52,10 @@ def instruments(handler, registry):
                 )
                 tracked_request.tag("user_ip", user_ip)
 
-            tracked_queue_time = False
             queue_time = request.headers.get(
                 "x-queue-start", default=""
             ) or request.headers.get("x-request-start", default="")
-            tracked_queue_time = track_request_queue_time(queue_time, tracked_request)
-            if not tracked_queue_time:
-                amazon_queue_time = request.headers.get("x-amzn-trace-id", default="")
-                track_amazon_request_queue_time(amazon_queue_time, tracked_request)
+            track_request_queue_time(queue_time, tracked_request)
 
             try:
                 try:

--- a/tests/integration/test_bottle.py
+++ b/tests/integration/test_bottle.py
@@ -148,24 +148,6 @@ def test_queue_time(header_name, tracked_requests):
     assert isinstance(queue_time_ns, int) and queue_time_ns > 0
 
 
-def test_amazon_queue_time(tracked_requests):
-    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow())) - 2
-    with app_with_scout() as app:
-        response = TestApp(app).get(
-            "/",
-            headers={
-                "X-Amzn-Trace-Id": str(
-                    "Self=1-{}-12456789abcdef012345678".format(queue_start)
-                )
-            },
-        )
-
-    assert response.status_int == 200
-    assert len(tracked_requests) == 1
-    queue_time_ns = tracked_requests[0].tags["scout.queue_time_ns"]
-    assert isinstance(queue_time_ns, int) and queue_time_ns > 0
-
-
 def test_home_ignored(tracked_requests):
     with app_with_scout(config={"scout.ignore": ["/"]}) as app:
         response = TestApp(app).get("/")

--- a/tests/integration/test_cherrypy.py
+++ b/tests/integration/test_cherrypy.py
@@ -138,24 +138,6 @@ def test_queue_time(header_name, tracked_requests):
     assert isinstance(queue_time_ns, int) and queue_time_ns > 0
 
 
-def test_amazon_queue_time(tracked_requests):
-    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow())) - 2
-    with app_with_scout() as app:
-        response = TestApp(app).get(
-            "/",
-            headers={
-                "X-Amzn-Trace-Id": str(
-                    "Self=1-{}-12456789abcdef012345678".format(queue_start)
-                )
-            },
-        )
-
-    assert response.status_int == 200
-    assert len(tracked_requests) == 1
-    queue_time_ns = tracked_requests[0].tags["scout.queue_time_ns"]
-    assert queue_time_ns >= 2000000000 and queue_time_ns < 4000000000
-
-
 def test_hello(tracked_requests):
     with app_with_scout() as app:
         response = TestApp(app).get("/hello/")

--- a/tests/integration/test_django.py
+++ b/tests/integration/test_django.py
@@ -674,24 +674,6 @@ def test_queue_time(header_name, tracked_requests):
     assert isinstance(queue_time_ns, int) and queue_time_ns > 0
 
 
-def test_amazon_queue_time(tracked_requests):
-    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow())) - 2
-    with app_with_scout() as app:
-        response = TestApp(app).get(
-            "/",
-            headers={
-                "X-Amzn-Trace-Id": str(
-                    "Self=1-{}-12456789abcdef012345678".format(queue_start)
-                )
-            },
-        )
-
-    assert response.status_int == 200
-    assert len(tracked_requests) == 1
-    queue_time_ns = tracked_requests[0].tags["scout.queue_time_ns"]
-    assert isinstance(queue_time_ns, int) and queue_time_ns > 0
-
-
 @skip_unless_old_style_middleware
 @pytest.mark.parametrize("list_or_tuple", [list, tuple])
 @pytest.mark.parametrize("preinstalled", [True, False])

--- a/tests/integration/test_falcon.py
+++ b/tests/integration/test_falcon.py
@@ -232,24 +232,6 @@ def test_queue_time(header_name, tracked_requests):
     assert isinstance(queue_time_ns, int) and queue_time_ns > 0
 
 
-def test_amazon_queue_time(tracked_requests):
-    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow())) - 2
-    with app_with_scout() as app:
-        response = TestApp(app).get(
-            "/",
-            headers={
-                "X-Amzn-Trace-Id": str(
-                    "Self=1-{}-12456789abcdef012345678".format(queue_start)
-                )
-            },
-        )
-
-    assert response.status_int == 200
-    assert len(tracked_requests) == 1
-    queue_time_ns = tracked_requests[0].tags["scout.queue_time_ns"]
-    assert isinstance(queue_time_ns, int) and queue_time_ns > 0
-
-
 def test_middleware_returning_early_from_process_request(tracked_requests):
     class ShortcutMiddleware(object):
         def process_request(self, req, resp):

--- a/tests/integration/test_flask.py
+++ b/tests/integration/test_flask.py
@@ -137,24 +137,6 @@ def test_queue_time(header_name, tracked_requests):
     assert isinstance(queue_time_ns, int) and queue_time_ns > 0
 
 
-def test_amazon_queue_time(tracked_requests):
-    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow())) - 2
-    with app_with_scout() as app:
-        response = TestApp(app).get(
-            "/",
-            headers={
-                "X-Amzn-Trace-Id": str(
-                    "Self=1-{}-12456789abcdef012345678".format(queue_start)
-                )
-            },
-        )
-
-    assert response.status_int == 200
-    assert len(tracked_requests) == 1
-    queue_time_ns = tracked_requests[0].tags["scout.queue_time_ns"]
-    assert isinstance(queue_time_ns, int) and queue_time_ns > 0
-
-
 def test_hello(tracked_requests):
     with app_with_scout() as app:
         response = TestApp(app).get("/hello/")

--- a/tests/integration/test_nameko.py
+++ b/tests/integration/test_nameko.py
@@ -168,24 +168,6 @@ def test_queue_time(header_name, tracked_requests):
     assert isinstance(queue_time_ns, int) and queue_time_ns > 0
 
 
-def test_amazon_queue_time(tracked_requests):
-    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow())) - 2
-    with app_with_scout() as app:
-        response = TestApp(app).get(
-            "/",
-            headers={
-                "X-Amzn-Trace-Id": str(
-                    "Self=1-{}-12456789abcdef012345678".format(queue_start)
-                )
-            },
-        )
-
-    assert response.status_int == 200
-    assert len(tracked_requests) == 1
-    queue_time_ns = tracked_requests[0].tags["scout.queue_time_ns"]
-    assert isinstance(queue_time_ns, int) and queue_time_ns > 0
-
-
 def test_server_error(tracked_requests):
     with app_with_scout() as app:
         response = TestApp(app).get("/crash/", expect_errors=True)

--- a/tests/integration/test_pyramid.py
+++ b/tests/integration/test_pyramid.py
@@ -133,24 +133,6 @@ def test_queue_time(header_name, tracked_requests):
     assert isinstance(queue_time_ns, int) and queue_time_ns > 0
 
 
-def test_amazon_queue_time(tracked_requests):
-    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow())) - 2
-    with app_with_scout() as app:
-        response = TestApp(app).get(
-            "/",
-            headers={
-                "X-Amzn-Trace-Id": str(
-                    "Self=1-{}-12456789abcdef012345678".format(queue_start)
-                )
-            },
-        )
-
-    assert response.status_int == 200
-    assert len(tracked_requests) == 1
-    queue_time_ns = tracked_requests[0].tags["scout.queue_time_ns"]
-    assert isinstance(queue_time_ns, int) and queue_time_ns > 0
-
-
 def test_home_ignored(tracked_requests):
     with app_with_scout(config={"SCOUT_IGNORE": ["/"]}) as app:
         response = TestApp(app).get("/")

--- a/tests/integration/test_starlette_py36plus.py
+++ b/tests/integration/test_starlette_py36plus.py
@@ -312,31 +312,6 @@ async def test_queue_time(header_name, tracked_requests):
 
 
 @async_test
-async def test_amazon_queue_time(tracked_requests):
-    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow())) - 2
-    with app_with_scout() as app:
-        communicator = ApplicationCommunicator(
-            app,
-            asgi_http_scope(
-                path="/",
-                headers={
-                    "X-Amzn-Trace-Id": "Self=1-{}-12456789abcdef012345678".format(
-                        queue_start
-                    )
-                },
-            ),
-        )
-        await communicator.send_input({"type": "http.request"})
-        response_start = await communicator.receive_output()
-        await communicator.receive_output()
-
-    assert response_start["type"] == "http.response.start"
-    assert response_start["status"] == 200
-    queue_time_ns = tracked_requests[0].tags["scout.queue_time_ns"]
-    assert isinstance(queue_time_ns, int) and queue_time_ns > 0
-
-
-@async_test
 async def test_server_error(tracked_requests):
     with app_with_scout() as app:
         communicator = ApplicationCommunicator(app, asgi_http_scope(path="/crash/"))

--- a/tests/unit/core/test_web_requests.py
+++ b/tests/unit/core/test_web_requests.py
@@ -13,7 +13,6 @@ from scout_apm.core.web_requests import (
     convert_ambiguous_timestamp_to_ns,
     create_filtered_path,
     ignore_path,
-    track_amazon_request_queue_time,
     track_request_queue_time,
 )
 
@@ -120,79 +119,6 @@ def test_track_request_queue_time_valid(with_t, tracked_request):
 )
 def test_track_request_queue_time_invalid(header_value, tracked_request):
     result = track_request_queue_time(header_value, tracked_request)
-
-    assert result is False
-    assert "scout.queue_time_ns" not in tracked_request.tags
-
-
-@pytest.mark.parametrize(
-    "header_value",
-    [
-        "Root=1-{start_time}-12456789abcdef012345678",
-        "Root=1-{start_time}-12456789abcdef012345678;CalledFrom=app",
-        "Self=1-{start_time}-12456789abcdef012345678",
-        "Self=1-{start_time}-12456789abcdef012345678;Root=1-123-abcdef012345678912345678",  # noqa: B950
-        "Self=1-{start_time}-12456789abcdef012345678;Root=1-123-abcdef012345678912345678;CalledFrom=app",  # noqa: B950
-    ],
-)
-def test_track_amazon_request_queue_time_valid(header_value, tracked_request):
-    start_time = int(datetime_to_timestamp(dt.datetime.utcnow())) - 2
-
-    result = track_amazon_request_queue_time(
-        header_value.format(start_time=start_time), tracked_request
-    )
-
-    assert result is True
-    queue_time_ns = tracked_request.tags["scout.queue_time_ns"]
-    assert isinstance(queue_time_ns, int) and queue_time_ns > 0
-
-
-@pytest.mark.parametrize(
-    "header_value",
-    [
-        "Root=1-{start_time}-12456789abcdef012345678",
-        "Root=1-{start_time}-12456789abcdef012345678;CalledFrom=app",
-        "Self=1-{start_time}-12456789abcdef012345678",
-        "Self=1-{start_time}-12456789abcdef012345678;Root=1-123-abcdef012345678912345678",  # noqa: B950
-        "Self=1-{start_time}-12456789abcdef012345678;Root=1-123-abcdef012345678912345678;CalledFrom=app",  # noqa: B950
-    ],
-)
-def test_track_amazon_request_queue_time_hexidecimal_valid(
-    header_value, tracked_request
-):
-    start_time = format(int(datetime_to_timestamp(dt.datetime.utcnow())) - 2, "x")
-
-    result = track_amazon_request_queue_time(
-        "Root=1-{start_time}-12456789abcdef012345678".format(start_time=start_time),
-        tracked_request,
-    )
-
-    assert result is True
-    queue_time_ns = tracked_request.tags["scout.queue_time_ns"]
-    assert isinstance(queue_time_ns, int) and queue_time_ns > 0
-
-
-@pytest.mark.parametrize(
-    "header_value",
-    [
-        str(""),
-        str("!"),  # unaprseable value
-        str("CalledFrom=app"),  # ignorable custom value
-        str("Root=1"),  # missing split
-        str("Root=1;Self=1"),  # two missing split
-        str("Root=1-"),  # empty second value
-        str("Root=whatever;Self=1-"),  # two empty second value
-        str("Root=1--abc"),  # invalid int
-        str("Root=1-abc-abc"),  # invalid int
-        str("Root=1-nan-abc"),  # not a digit
-        str("Root=1-0.3-abc"),  # raises value error on int conversion
-        str("Root=1-0-abc"),  # not a real timestamp
-        str("Root=1-10000000000000000000-abc"),  # far into the future
-        str("CalledFrom=app;Root=1-10000000000000000000-abc"),  # far into the future
-    ],
-)
-def test_track_amazon_request_queue_time_invalid(header_value, tracked_request):
-    result = track_amazon_request_queue_time(header_value, tracked_request)
 
     assert result is False
     assert "scout.queue_time_ns" not in tracked_request.tags


### PR DESCRIPTION
The header's time value is in seconds which isn't enough precision
for us to provide quality data to users. With seconds precision, the
queue time hovers about 0.5s due to the truncation.

It may be possible to pull the millisecond precision data from the
AWS logs themselves and avoid the python agent altogether.

Closes #631