### PR TITLE
Error monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Pending
 
 ### Added
+- Support Error Monitoring. See
+  [integration docs](https://scoutapm.com/docs/python/error-monitoring).
+  ([PR #651](https://github.com/scoutapp/scout_apm_python/pull/651))
 
 ### Fixed
 - Setup metadata keywords now contains an array of strings.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### Fixed
 - Setup metadata keywords now contains an array of strings.
+- Remove non-project paths from traces.
+  ([Issue #416](https://github.com/scoutapp/scout_apm_python/issues/416))
+
 
 ## [2.20.0] 2021-07-21
 - Removed parsing queue time from Amazon ALB header, X-Amzn-Trace-Id.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Support Error Monitoring. See
   [integration docs](https://scoutapm.com/docs/python/error-monitoring).
   ([PR #651](https://github.com/scoutapp/scout_apm_python/pull/651))
+- Deprecate `backtrace.capture` in favor of `backtrace.capture_backtrace`
 
 ### Fixed
 - Setup metadata keywords now contains an array of strings.

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ setup(
         'urllib3[secure] < 1.25 ; python_version < "3.5"',
         'urllib3[secure] < 2 ; python_version >= "3.5"',
         "wrapt>=1.10,<2.0",
+        "requests",
     ],
     keywords=["apm", "performance monitoring", "development"],
     classifiers=[

--- a/src/scout_apm/compat.py
+++ b/src/scout_apm/compat.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import datetime as dt
+import gzip
 import inspect
 import sys
 from functools import wraps
@@ -151,9 +152,27 @@ def urllib3_cert_pool_manager(**kwargs):
     return urllib3.PoolManager(cert_reqs=CERT_REQUIRED, ca_certs=certifi.where())
 
 
+if sys.version_info >= (3, 2):
+
+    def gzip_compress(data):
+        return gzip.compress(data)
+
+
+else:
+    import io
+
+    def gzip_compress(data):
+        """Reimplementation gzip.compress for python 2.7"""
+        buf = io.BytesIO()
+        with gzip.GzipFile(fileobj=buf, mode="wb") as f:
+            f.write(data)
+        return buf.getvalue()
+
+
 __all__ = [
     "ContextDecorator",
     "datetime_to_timestamp",
+    "gzip_compress",
     "kwargs_only",
     "parse_qsl",
     "queue",

--- a/src/scout_apm/core/config.py
+++ b/src/scout_apm/core/config.py
@@ -223,6 +223,10 @@ class Defaults(object):
             "core_agent_version": "v1.3.0",  # can be an exact tag name, or 'latest'
             "disabled_instruments": [],
             "download_url": "https://s3-us-west-1.amazonaws.com/scout-public-downloads/apm_core_agent/release",  # noqa: B950
+            "errors_batch_size": 5,
+            "errors_enabled": False,
+            "errors_ignored_exceptions": (),
+            "errors_host": "https://errors.scoutapm.com",
             "framework": "",
             "framework_version": "",
             "hostname": None,

--- a/src/scout_apm/core/config.py
+++ b/src/scout_apm/core/config.py
@@ -212,7 +212,7 @@ class Defaults(object):
     def __init__(self):
         self.defaults = {
             "app_server": "",
-            "application_root": "",
+            "application_root": os.getcwd(),
             "collect_remote_ip": True,
             "core_agent_dir": "/tmp/scout_apm_core",
             "core_agent_download": True,

--- a/src/scout_apm/core/error.py
+++ b/src/scout_apm/core/error.py
@@ -60,7 +60,10 @@ class ErrorMonitor(object):
             else None,
             "request_session": filter_element("", session) if session else None,
             "environment": filter_element("", environment) if environment else None,
-            "trace": capture(traceback.tb_frame, apply_filter=False),
+            "trace": [
+                "{file}:{line}:in {function}".format(**frame)
+                for frame in capture(traceback.tb_frame, apply_filter=False)
+            ],
             "request_components": {
                 "module": request_components.module,
                 "controller": request_components.controller,

--- a/src/scout_apm/core/error.py
+++ b/src/scout_apm/core/error.py
@@ -1,0 +1,76 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import sys
+
+from scout_apm.core.backtrace import capture
+from scout_apm.core.config import scout_config
+from scout_apm.core.error_service import ErrorServiceThread
+from scout_apm.core.tracked_request import TrackedRequest
+from scout_apm.core.web_requests import RequestComponents, filter_element
+
+text_type = str if sys.version_info[0] >= 3 else unicode  # noqa: F821
+
+
+class ErrorMonitor(object):
+    @classmethod
+    def send(
+        cls,
+        exc_info,
+        request_components=None,
+        request_path=None,
+        request_params=None,
+        session=None,
+        environment=None,
+        custom_controller=None,
+        custom_params=None,
+    ):
+        if not scout_config.value("errors_enabled"):
+            return
+
+        exc_class, exc_value, traceback = exc_info
+
+        ignore_exceptions = scout_config.value("errors_ignored_exceptions")
+        if ignore_exceptions and isinstance(exc_value, tuple(ignore_exceptions)):
+            return
+
+        tracked_request = TrackedRequest.instance()
+
+        context = {}
+        context.update(tracked_request.tags)
+
+        if custom_params:
+            context["custom_params"] = custom_params
+
+        if custom_controller:
+            if request_components:
+                request_components.controller = custom_controller
+            else:
+                request_components = RequestComponents(
+                    module=None, controller=custom_controller, action=None
+                )
+
+        error = {
+            "exception_class": exc_class.__name__,
+            "message": text_type(exc_value),
+            "request_id": tracked_request.request_id,
+            "request_uri": request_path,
+            "request_params": filter_element("", request_params)
+            if request_params
+            else None,
+            "request_session": filter_element("", session) if session else None,
+            "environment": filter_element("", environment) if environment else None,
+            "trace": capture(traceback.tb_frame, apply_filter=False),
+            "request_components": {
+                "module": request_components.module,
+                "controller": request_components.controller,
+                "action": request_components.action,
+            }
+            if request_components
+            else None,
+            "context": context,
+            "host": scout_config.value("hostname"),
+            "revision_sha": scout_config.value("revision_sha"),
+        }
+
+        ErrorServiceThread.send(error=error)

--- a/src/scout_apm/core/error.py
+++ b/src/scout_apm/core/error.py
@@ -50,7 +50,6 @@ class ErrorMonitor(object):
                     module=None, controller=custom_controller, action=None
                 )
 
-        app_root = scout_config.value("application_root")
         error = {
             "exception_class": exc_class.__name__,
             "message": text_type(exc_value),
@@ -63,9 +62,7 @@ class ErrorMonitor(object):
             "environment": filter_element("", environment) if environment else None,
             "trace": [
                 "{file}:{line}:in {function}".format(
-                    file=frame["file"].split(app_root, maxsplit=1)[-1]
-                    if app_root
-                    else frame["file"],
+                    file=frame["file"],
                     line=frame["line"],
                     function=frame["function"],
                 )

--- a/src/scout_apm/core/error_service.py
+++ b/src/scout_apm/core/error_service.py
@@ -1,0 +1,152 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import json
+import logging
+import os
+import threading
+import time
+
+try:
+    from html import escape
+except ImportError:
+    from cgi import escape
+
+try:
+    from urllib.parse import urljoin
+except ImportError:
+    from urlparse import urljoin
+
+import requests
+
+from scout_apm.compat import gzip_compress, queue
+from scout_apm.core.config import scout_config
+from scout_apm.core.threading import SingletonThread
+
+# Time unit - monkey-patched in tests to make them run faster
+SECOND = 1
+
+logger = logging.getLogger(__name__)
+
+
+class ErrorServiceThread(SingletonThread):
+    _instance_lock = threading.Lock()
+    _stop_event = threading.Event()
+    _queue = queue.Queue(maxsize=500)
+
+    @classmethod
+    def _on_stop(cls):
+        super(ErrorServiceThread, cls)._on_stop()
+        # Unblock _queue.get()
+        try:
+            cls._queue.put(None, False)
+        except queue.Full as exc:
+            logger.debug("ErrorServiceThread full for stop: %r", exc, exc_info=exc)
+            pass
+
+    @classmethod
+    def send(cls, error):
+        try:
+            cls._queue.put(error, False)
+        except queue.Full as exc:
+            logger.debug("ErrorServiceThread full for send: %r", exc, exc_info=exc)
+
+        cls.ensure_started()
+
+    @classmethod
+    def wait_until_drained(cls, timeout_seconds=2.0, callback=None):
+        interval_seconds = min(timeout_seconds, 0.05)
+        start = time.time()
+        while True:
+            queue_size = cls._queue.qsize()
+            queue_empty = queue_size == 0
+            elapsed = time.time() - start
+            if queue_empty or elapsed >= timeout_seconds:
+                break
+
+            if callback is not None:
+                callback(queue_size)
+                callback = None
+
+            cls.ensure_started()
+
+            time.sleep(interval_seconds)
+        return queue_empty
+
+    def run(self):
+        batch_size = scout_config.value("errors_batch_size") or 1
+        try:
+            while True:
+                errors = []
+                try:
+                    # Attempt to fetch the batch size off of the queue.
+                    for _ in range(batch_size):
+                        error = self._queue.get(block=True, timeout=1 * SECOND)
+                        if error:
+                            errors.append(error)
+                except queue.Empty:
+                    pass
+
+                if errors and self._send(errors):
+                    for _ in range(len(errors)):
+                        self._queue.task_done()
+
+                # Check for stop event after each read. This allows opening,
+                # sending, and then immediately stopping.
+                if self._stop_event.is_set():
+                    logger.debug("ErrorServiceThread stopping.")
+                    break
+        except Exception as exc:
+            logger.debug("ErrorServiceThread exception: %r", exc, exc_info=exc)
+        finally:
+            logger.debug("ErrorServiceThread stopped.")
+
+    def _send(self, errors):
+        try:
+            data = json.dumps(
+                {
+                    "notifier": "scout_apm_python",
+                    "environment": scout_config.value("environment"),
+                    "root": scout_config.value("application_root"),
+                    "problems": errors,
+                }
+            )
+        except (ValueError, TypeError) as exc:
+            logger.debug(
+                "Exception when serializing error message: %r", exc, exc_info=exc
+            )
+            return False
+
+        params = {
+            "key": scout_config.value("key"),
+            "name": escape(scout_config.value("name"), quote=False),
+        }
+        headers = {
+            "Agent-Hostname": scout_config.value("hostname"),
+            "Content-Encoding": "gzip",
+            "Content-Type": "application/json",
+            "X-Error-Count": "{}".format(len(errors)),
+        }
+
+        try:
+            response = requests.post(
+                urljoin(scout_config.value("errors_host"), "apps/error.scout"),
+                params=params,
+                data=gzip_compress(data.encode("utf-8")),
+                headers=headers,
+            )
+            response.raise_for_status()
+        except requests.HTTPError as exc:
+            logger.debug(
+                (
+                    "ErrorServiceThread exception on _send:"
+                    + " %r on PID: %s on thread: %s"
+                ),
+                exc,
+                os.getpid(),
+                threading.current_thread(),
+                exc_info=exc,
+            )
+            return False
+
+        return True

--- a/src/scout_apm/core/tracked_request.py
+++ b/src/scout_apm/core/tracked_request.py
@@ -285,4 +285,4 @@ class Span(object):
         self.tag("stop_allocations", end_allocs)
 
     def capture_backtrace(self):
-        self.tag("stack", backtrace.capture())
+        self.tag("stack", backtrace.capture_backtrace())

--- a/src/scout_apm/django/request.py
+++ b/src/scout_apm/django/request.py
@@ -1,0 +1,149 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import sys
+
+from scout_apm.compat import string_types
+from scout_apm.core.web_requests import RequestComponents
+
+
+def get_controller_name(request):
+    view_func = request.resolver_match.func
+    view_name = request.resolver_match._func_path
+
+    django_admin_components = _get_django_admin_components(view_func)
+    if django_admin_components:
+        view_name = "{}.{}.{}".format(
+            django_admin_components.module,
+            django_admin_components.controller,
+            django_admin_components.action,
+        )
+
+    django_rest_framework_components = _get_django_rest_framework_components(
+        request, view_func
+    )
+    if django_rest_framework_components is not None:
+        view_name = "{}.{}.{}".format(
+            django_rest_framework_components.module,
+            django_rest_framework_components.controller,
+            django_rest_framework_components.action,
+        )
+
+    # Seems to be a Tastypie Resource. Need to resort to some stack inspection
+    # to find a better name since its decorators don't wrap very well
+    if view_name == "tastypie.resources.wrapper":
+        tastypie_components = _get_tastypie_components(request, view_func)
+        if tastypie_components is not None:
+            view_name = "{}.{}.{}".format(
+                tastypie_components.module,
+                tastypie_components.controller,
+                tastypie_components.action,
+            )
+
+    return "Controller/{}".format(view_name)
+
+
+def get_request_components(request):
+    if not request.resolver_match:
+        return None
+    view_func = request.resolver_match.func
+    view_name = request.resolver_match._func_path
+    request_components = RequestComponents(
+        module=view_func.__module__,
+        controller=view_func.__name__,
+        action=request.method,
+    )
+
+    django_admin_components = _get_django_admin_components(view_func)
+    if django_admin_components:
+        request_components = django_admin_components
+
+    django_rest_framework_components = _get_django_rest_framework_components(
+        request, view_func
+    )
+    if django_rest_framework_components is not None:
+        request_components = django_rest_framework_components
+
+    # Seems to be a Tastypie Resource. Need to resort to some stack inspection
+    # to find a better name since its decorators don't wrap very well
+    if view_name == "tastypie.resources.wrapper":
+        tastypie_components = _get_tastypie_components(request, view_func)
+        if tastypie_components is not None:
+            request_components = tastypie_components
+    return request_components
+
+
+def _get_django_admin_components(view_func):
+    if hasattr(view_func, "model_admin"):
+        # Seems to comes from Django admin (attribute only set on Django 1.9+)
+        admin_class = view_func.model_admin.__class__
+        return RequestComponents(
+            module=admin_class.__module__,
+            controller=admin_class.__name__,
+            action=view_func.__name__,
+        )
+    return None
+
+
+def _get_django_rest_framework_components(request, view_func):
+    try:
+        from rest_framework.viewsets import ViewSetMixin
+    except ImportError:
+        return None
+
+    kls = getattr(view_func, "cls", None)
+    if isinstance(kls, type) and not issubclass(kls, ViewSetMixin):
+        return None
+
+    # Get 'actions' set in ViewSetMixin.as_view
+    actions = getattr(view_func, "actions", None)
+    if not actions or not isinstance(actions, dict):
+        return None
+
+    method_lower = request.method.lower()
+    if method_lower not in actions:
+        return None
+
+    return RequestComponents(
+        module=view_func.__module__,
+        controller=view_func.__name__,
+        action=actions[method_lower],
+    )
+
+
+def _get_tastypie_components(request, view_func):
+    try:
+        from tastypie.resources import Resource
+    except ImportError:
+        return None
+
+    if sys.version_info[0] == 2:  # pragma: no cover
+        try:
+            wrapper = view_func.__closure__[0].cell_contents
+        except (AttributeError, IndexError):
+            return None
+    else:
+        try:
+            wrapper = view_func.__wrapped__
+        except AttributeError:
+            return None
+
+    if not hasattr(wrapper, "__closure__") or len(wrapper.__closure__) != 2:
+        return None
+
+    instance = wrapper.__closure__[0].cell_contents
+    if not isinstance(instance, Resource):  # pragma: no cover
+        return None
+
+    method_name = wrapper.__closure__[1].cell_contents
+    if not isinstance(method_name, string_types):  # pragma: no cover
+        return None
+
+    if method_name.startswith("dispatch_"):  # pragma: no cover
+        method_name = request.method.lower() + method_name.split("dispatch", 1)[1]
+
+    return RequestComponents(
+        module=instance.__module__,
+        controller=instance.__class__.__name__,
+        action=method_name,
+    )

--- a/src/scout_apm/instruments/urllib3.py
+++ b/src/scout_apm/instruments/urllib3.py
@@ -6,6 +6,7 @@ import logging
 import wrapt
 
 from scout_apm.compat import text_type
+from scout_apm.core.config import scout_config
 from scout_apm.core.tracked_request import TrackedRequest
 
 try:
@@ -56,6 +57,10 @@ def wrapped_urlopen(wrapped, instance, args, kwargs):
     except Exception:
         logger.exception("Could not get URL for HTTPConnectionPool")
         url = "Unknown"
+
+    # Don't instrument ErrorMonitor calls
+    if text_type(url).startswith(scout_config.value("errors_host")):
+        return wrapped(*args, **kwargs)
 
     tracked_request = TrackedRequest.instance()
     with tracked_request.span(operation="HTTP/{}".format(method)) as span:

--- a/tests/compat.py
+++ b/tests/compat.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import gzip
 import sys
 
 if sys.version_info >= (3, 0):
@@ -57,4 +58,19 @@ else:
             pass
 
 
-__all__ = ["mock", "nullcontext", "suppress", "TemporaryDirectory"]
+if sys.version_info >= (3, 2):
+
+    def gzip_decompress(data):
+        return gzip.decompress(data)
+
+
+else:
+    import io
+
+    def gzip_decompress(data):
+        """Reimplementation gzip.compress for python 2.7"""
+        with gzip.GzipFile(fileobj=io.BytesIO(data), mode="rb") as f:
+            return f.read()
+
+
+__all__ = ["gzip_decompress", "mock", "nullcontext", "suppress", "TemporaryDirectory"]

--- a/tests/integration/core/agent/test_socket.py
+++ b/tests/integration/core/agent/test_socket.py
@@ -37,7 +37,7 @@ def socket(running_agent):
     time.sleep(0.01)
 
     yield socket
-    # ensure_stopped() already called by global auto_stop_core_agent_socket
+    # ensure_stopped() already called by global stop_and_empty_core_error_service
 
 
 class Command(object):

--- a/tests/integration/core/test_error_service.py
+++ b/tests/integration/core/test_error_service.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
+import os
 from datetime import datetime
 from time import sleep
 
@@ -11,6 +12,8 @@ import pytest
 from scout_apm.core.config import scout_config
 from scout_apm.core.error_service import ErrorServiceThread
 from tests.compat import gzip_decompress
+
+WORKING_DIRECTORY = os.getcwd().encode("utf-8")
 
 
 @pytest.fixture
@@ -41,7 +44,7 @@ def error_service_thread():
         (
             {},
             b'{"notifier": "scout_apm_python", "environment": null, '
-            b'"root": "", "problems": [{"foo": "bar"}]}',
+            b'"root": "' + WORKING_DIRECTORY + b'", "problems": [{"foo": "bar"}]}',
             {"Agent-Hostname": None, "X-Error-Count": "1"},
             "https://errors.scoutapm.com/apps/error.scout" "?name=Python+App",
         ),
@@ -76,7 +79,9 @@ def test_send_batch(error_service_thread):
     def request_callback(request, uri, response_headers):
         decompressed_body = (
             b'{"notifier": "scout_apm_python", "environment": null, '
-            b'"root": "", "problems": [{"foo": 0}, {"foo": 1}, '
+            b'"root": "'
+            + WORKING_DIRECTORY
+            + b'", "problems": [{"foo": 0}, {"foo": 1}, '
             b'{"foo": 2}, {"foo": 3}, {"foo": 4}]}'
         )
         assert gzip_decompress(request.body) == decompressed_body

--- a/tests/integration/core/test_error_service.py
+++ b/tests/integration/core/test_error_service.py
@@ -1,0 +1,134 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import logging
+from datetime import datetime
+from time import sleep
+
+import httpretty
+import pytest
+
+from scout_apm.core.config import scout_config
+from scout_apm.core.error_service import ErrorServiceThread
+from tests.compat import gzip_decompress
+
+
+@pytest.fixture
+def error_service_thread():
+    service_thread = ErrorServiceThread.ensure_started()
+    yield service_thread
+    # ensure_stopped() already called by global stop_and_empty_core_agent_socket
+
+
+@pytest.mark.parametrize(
+    "config, decompressed_body, expected_headers, expected_uri",
+    [
+        (
+            {
+                "key": "scout-app-key",
+                "app": "scout test app",
+                "hostname": "example.com",
+                "environment": "scout-test",
+                "application_root": "/tmp/",
+                "errors_host": "https://testserver",
+            },
+            b'{"notifier": "scout_apm_python", "environment": "scout-test", '
+            b'"root": "/tmp/", "problems": [{"foo": "bar"}]}',
+            {"Agent-Hostname": "example.com", "X-Error-Count": "1"},
+            "https://testserver/apps/error.scout?key=scout-app-key"
+            "&name=scout+test+app",
+        ),
+        (
+            {},
+            b'{"notifier": "scout_apm_python", "environment": null, '
+            b'"root": "", "problems": [{"foo": "bar"}]}',
+            {"Agent-Hostname": None, "X-Error-Count": "1"},
+            "https://errors.scoutapm.com/apps/error.scout" "?name=Python+App",
+        ),
+    ],
+)
+def test_send(
+    config, decompressed_body, expected_headers, expected_uri, error_service_thread
+):
+    scout_config.set(**config)
+
+    def request_callback(request, uri, response_headers):
+        assert uri == expected_uri
+        for key, value in expected_headers.items():
+            assert request.headers.get(key) == value
+        assert gzip_decompress(request.body) == decompressed_body
+        return [200, response_headers, "Hello world!"]
+
+    try:
+        with httpretty.enabled(allow_net_connect=False):
+            httpretty.register_uri(
+                httpretty.POST,
+                "https://errors.scoutapm.com/apps/error.scout",
+                body=request_callback,
+            )
+            ErrorServiceThread.send({"foo": "bar"})
+            ErrorServiceThread.wait_until_drained()
+    finally:
+        scout_config.reset_all()
+
+
+def test_send_batch(error_service_thread):
+    def request_callback(request, uri, response_headers):
+        decompressed_body = (
+            b'{"notifier": "scout_apm_python", "environment": null, '
+            b'"root": "", "problems": [{"foo": 0}, {"foo": 1}, '
+            b'{"foo": 2}, {"foo": 3}, {"foo": 4}]}'
+        )
+        assert gzip_decompress(request.body) == decompressed_body
+        assert request.headers.get("X-Error-Count") == "5"
+        return [200, response_headers, "Hello world!"]
+
+    try:
+        with httpretty.enabled(allow_net_connect=False):
+            httpretty.register_uri(
+                httpretty.POST,
+                "https://errors.scoutapm.com/apps/error.scout",
+                body=request_callback,
+            )
+            for i in range(5):
+                ErrorServiceThread.send({"foo": i})
+            ErrorServiceThread.wait_until_drained()
+    finally:
+        scout_config.reset_all()
+
+
+def test_send_api_error(error_service_thread, caplog):
+    try:
+        with httpretty.enabled(allow_net_connect=False):
+            httpretty.register_uri(
+                httpretty.POST,
+                "https://errors.scoutapm.com/apps/error.scout",
+                body="Unexpected Error",
+                status=500,
+            )
+            ErrorServiceThread.send({"foo": "bar"})
+            ErrorServiceThread.wait_until_drained()
+    finally:
+        scout_config.reset_all()
+    assert caplog.record_tuples[-1][0] == "scout_apm.core.error_service"
+    assert caplog.record_tuples[-1][1] == logging.DEBUG
+    assert caplog.record_tuples[-1][2].startswith(
+        "ErrorServiceThread exception on _send:"
+    )
+
+
+def test_send_unserializable_data(error_service_thread, caplog):
+    with httpretty.enabled(allow_net_connect=False):
+        ErrorServiceThread.send({"value": datetime.now()})
+        ErrorServiceThread.wait_until_drained()
+
+    if ErrorServiceThread._queue.empty() and not caplog.record_tuples:
+        # py38-django20 and py36-django11 tend to fail
+        # here by indicating the log never occurred despite
+        # the message being pushed down.
+        sleep(2)
+    assert caplog.record_tuples[-1][0] == "scout_apm.core.error_service"
+    assert caplog.record_tuples[-1][1] == logging.DEBUG
+    assert caplog.record_tuples[-1][2].startswith(
+        "Exception when serializing error message:"
+    )

--- a/tests/integration/django_app.py
+++ b/tests/integration/django_app.py
@@ -182,8 +182,16 @@ def drf_router():
         queryset = User.objects.all()
         serializer_class = UserSerializer
 
+    class ErrorViewSet(viewsets.ModelViewSet):
+        queryset = User.objects.all()
+
+        def get_queryset(self, *args, **kwargs):
+            raise ValueError("BØØM!")
+
     router = routers.SimpleRouter()
     router.register(r"users", UserViewSet)
+    router.register(r"crash", ErrorViewSet)
+
     return router
 
 
@@ -206,8 +214,17 @@ def tastypie_api():
             queryset = User.objects.all()
             allowed_methods = ["get"]
 
+    class CrashResource(TastypieModelResource):
+        class Meta:
+            queryset = User.objects.all()
+            allowed_methods = ["get"]
+
+        def build_filters(self, *args, **kwargs):
+            raise ValueError("BØØM!")
+
     api = TastypieApi(api_name="v1")
     api.register(UserResource())
+    api.register(CrashResource())
     return api
 
 

--- a/tests/integration/instruments/test_urllib3.py
+++ b/tests/integration/instruments/test_urllib3.py
@@ -121,3 +121,18 @@ def test_request_no_absolute_url(caplog, tracked_request):
     span = tracked_request.complete_spans[0]
     assert span.operation == "HTTP/GET"
     assert span.tags["url"] == "Unknown"
+
+
+def test_request_ignore_errors_host(tracked_request):
+    ensure_installed()
+    with httpretty.enabled(allow_net_connect=False):
+        httpretty.register_uri(
+            httpretty.POST, "https://errors.scoutapm.com", body="Hello World!"
+        )
+
+        http = urllib3_cert_pool_manager()
+        response = http.request("POST", "https://errors.scoutapm.com")
+
+    assert response.status == 200
+    assert response.data == b"Hello World!"
+    assert len(tracked_request.complete_spans) == 0

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -346,7 +346,11 @@ def test_error_capture(error_monitor_errors, tracked_request):
 
     assert len(error_monitor_errors) == 1
     error = error_monitor_errors[0]
-    assert error["trace"][0]["function"] == "test_error_capture"
+    filepath, line, func_str = error["trace"][0].split(":")
+    assert filepath.endswith("tests/integration/test_api.py")
+    # The line number changes between python versions. Make sure it's not empty.
+    assert line
+    assert func_str == "in test_error_capture"
     assert error["exception_class"] == "ZeroDivisionError"
     assert error["message"] == "division by zero"
     assert error["context"] == {

--- a/tests/integration/test_django.py
+++ b/tests/integration/test_django.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import datetime as dt
+import os
 import sys
 from contextlib import contextmanager
 
@@ -117,7 +118,7 @@ def test_instruments_idempotent(func):
 def test_on_setting_changed_application_root():
     with app_with_scout(BASE_DIR="/tmp/foobar"):
         assert scout_config.value("application_root") == "/tmp/foobar"
-    assert scout_config.value("application_root") == ""
+    assert scout_config.value("application_root") == os.getcwd()
 
 
 @skip_if_python_2
@@ -126,7 +127,7 @@ def test_on_setting_changed_application_root_pathlib():
         value = scout_config.value("application_root")
         assert isinstance(value, str)
         assert value == "/tmp/foobar"
-    assert scout_config.value("application_root") == ""
+    assert scout_config.value("application_root") == os.getcwd()
 
 
 def test_on_setting_changed_monitor():

--- a/tests/unit/core/test_backtrace.py
+++ b/tests/unit/core/test_backtrace.py
@@ -41,6 +41,30 @@ def test_capture_limit():
     assert len(stack) == backtrace.LIMIT
 
 
+def test_capture_with_frame():
+    def error():
+        # Python 2 compatible way of getting the current frame.
+        try:
+            raise ZeroDivisionError
+        except ZeroDivisionError:
+            # Get the current frame
+            return sys.exc_info()[2].tb_frame
+
+    stack = backtrace.capture(error(), apply_filter=False)
+
+    assert len(stack) >= 1
+    for frame in stack:
+        assert isinstance(frame, dict)
+        assert set(frame.keys()) == {"file", "line", "function"}
+        assert isinstance(frame["file"], str)
+        assert isinstance(frame["line"], int)
+        assert isinstance(frame["function"], str)
+
+    assert stack[0]["file"] == format_py_filename(__file__)
+    assert stack[0]["function"] == "error"
+    assert stack[1]["function"] == "test_capture_with_frame"
+
+
 def test_filter_frames():
     """Verify the frames from the library paths are excluded."""
     paths = sysconfig.get_paths()

--- a/tests/unit/core/test_backtrace.py
+++ b/tests/unit/core/test_backtrace.py
@@ -20,14 +20,12 @@ def test_capture_backtrace():
         assert isinstance(frame["line"], int)
         assert isinstance(frame["function"], str)
 
-    assert stack[0]["file"] == format_py_filename(__file__)
-
-
-def format_py_filename(filename):
-    if sys.version_info[0] == 2 and filename.endswith(".pyc"):
-        # Python 2 will include .pyc filename if it's used, so strip that
-        return filename[:-1]
-    return filename
+    assert stack[0]["file"] == "scout_apm/core/backtrace.py"
+    assert stack[0]["function"] == "filter_frames"
+    assert stack[1]["file"] == "scout_apm/core/backtrace.py"
+    assert stack[1]["function"] == "capture_backtrace"
+    assert stack[2]["file"] == "tests/unit/core/test_backtrace.py"
+    assert stack[2]["function"] == "test_capture_backtrace"
 
 
 def test_capture_backtrace_limit():
@@ -74,5 +72,5 @@ def test_capture_stacktrace():
         assert isinstance(frame["line"], int)
         assert isinstance(frame["function"], str)
 
-    assert stack[0]["file"] == format_py_filename(__file__)
+    assert stack[0]["file"] == "tests/unit/core/test_backtrace.py"
     assert stack[0]["function"] == "error"

--- a/tests/unit/core/test_backtrace.py
+++ b/tests/unit/core/test_backtrace.py
@@ -8,8 +8,8 @@ import sysconfig
 from scout_apm.core import backtrace
 
 
-def test_capture():
-    stack = backtrace.capture()
+def test_capture_backtrace():
+    stack = backtrace.capture_backtrace()
 
     assert isinstance(stack, list)
     assert len(stack) >= 1
@@ -30,39 +30,15 @@ def format_py_filename(filename):
     return filename
 
 
-def test_capture_limit():
+def test_capture_backtrace_limit():
     def capture_recursive_bottom(limit):
         if limit <= 1:
-            return backtrace.capture()
+            return backtrace.capture_backtrace()
         else:
             return capture_recursive_bottom(limit - 1)
 
     stack = capture_recursive_bottom(backtrace.LIMIT * 2)
     assert len(stack) == backtrace.LIMIT
-
-
-def test_capture_with_frame():
-    def error():
-        # Python 2 compatible way of getting the current frame.
-        try:
-            raise ZeroDivisionError
-        except ZeroDivisionError:
-            # Get the current frame
-            return sys.exc_info()[2].tb_frame
-
-    stack = backtrace.capture(error(), apply_filter=False)
-
-    assert len(stack) >= 1
-    for frame in stack:
-        assert isinstance(frame, dict)
-        assert set(frame.keys()) == {"file", "line", "function"}
-        assert isinstance(frame["file"], str)
-        assert isinstance(frame["line"], int)
-        assert isinstance(frame["function"], str)
-
-    assert stack[0]["file"] == format_py_filename(__file__)
-    assert stack[0]["function"] == "error"
-    assert stack[1]["function"] == "test_capture_with_frame"
 
 
 def test_filter_frames():
@@ -77,3 +53,26 @@ def test_filter_frames():
     actual = list(backtrace.filter_frames(frames))
     assert len(actual) == 1
     assert actual[0]["file"] == "/valid/path"
+
+
+def test_capture_stacktrace():
+    def error():
+        # Python 2 compatible way of getting the current frame.
+        try:
+            raise ZeroDivisionError
+        except ZeroDivisionError:
+            # Get the current frame
+            return sys.exc_info()[2]
+
+    stack = backtrace.capture_stacktrace(error())
+
+    assert len(stack) == 1
+    for frame in stack:
+        assert isinstance(frame, dict)
+        assert set(frame.keys()) == {"file", "line", "function"}
+        assert isinstance(frame["file"], str)
+        assert isinstance(frame["line"], int)
+        assert isinstance(frame["function"], str)
+
+    assert stack[0]["file"] == format_py_filename(__file__)
+    assert stack[0]["function"] == "error"

--- a/tests/unit/core/test_error.py
+++ b/tests/unit/core/test_error.py
@@ -1,0 +1,196 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import sys
+from contextlib import contextmanager
+
+import pytest
+
+from scout_apm.api import Config
+from scout_apm.compat import kwargs_only
+from scout_apm.core.error import ErrorMonitor
+from scout_apm.core.web_requests import RequestComponents
+
+
+@contextmanager
+@kwargs_only
+def app_with_scout(scout_config=None):
+    """
+    Context manager that configures and installs the Scout plugin.
+    """
+    # Enable Scout by default in tests.
+    if scout_config is None:
+        scout_config = {}
+
+    scout_config.setdefault("monitor", True)
+    scout_config.setdefault("errors_enabled", True)
+    Config.set(**scout_config)
+
+    try:
+        yield
+    finally:
+        # Reset Scout configuration.
+        Config.reset_all()
+
+
+def test_monitor_not_configured(error_monitor_errors):
+    with app_with_scout(scout_config={"errors_enabled": False}):
+        ErrorMonitor.send(None)
+    assert len(error_monitor_errors) == 0
+
+
+def test_monitor_ignore_exceptions(error_monitor_errors):
+    with app_with_scout(
+        scout_config={"errors_ignored_exceptions": [ZeroDivisionError]}
+    ):
+        try:
+            1 / 0
+        except ZeroDivisionError:
+            exc_info = sys.exc_info()
+        ErrorMonitor.send(exc_info, request_path="")
+    assert len(error_monitor_errors) == 0
+
+
+@pytest.mark.parametrize(
+    "path, params, session, environment, request_components, "
+    "custom_controller, custom_params, expected_error",
+    [
+        (
+            "/test/",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            {
+                "exception_class": "ZeroDivisionError",
+                "message": "division by zero",
+                "request_id": "sample_id",
+                "request_uri": "/test/",
+                "request_params": None,
+                "request_session": None,
+                "environment": None,
+                "request_components": None,
+                "context": {"spam": "foo"},
+                "host": None,
+                "revision_sha": "",
+            },
+        ),
+        (
+            "/test/",
+            None,
+            None,
+            None,
+            None,
+            "test-controller",
+            None,
+            {
+                "exception_class": "ZeroDivisionError",
+                "message": "division by zero",
+                "request_id": "sample_id",
+                "request_uri": "/test/",
+                "request_params": None,
+                "request_session": None,
+                "environment": None,
+                "request_components": {
+                    "module": None,
+                    "controller": "test-controller",
+                    "action": None,
+                },
+                "context": {"spam": "foo"},
+                "host": None,
+                "revision_sha": "",
+            },
+        ),
+        (
+            "/test/",
+            [("foo", "bar")],
+            {"spam": "eggs"},
+            {"PASSWORD": "hunter2"},
+            RequestComponents("sample.app", "DataView", "detail"),
+            None,
+            None,
+            {
+                "exception_class": "ZeroDivisionError",
+                "message": "division by zero",
+                "request_id": "sample_id",
+                "request_uri": "/test/",
+                "request_params": [("foo", "bar")],
+                "request_session": {"spam": "eggs"},
+                "environment": {"PASSWORD": "[FILTERED]"},
+                "request_components": {
+                    "module": "sample.app",
+                    "controller": "DataView",
+                    "action": "detail",
+                },
+                "context": {"spam": "foo"},
+                "host": None,
+                "revision_sha": "",
+            },
+        ),
+        (
+            "/test/",
+            [("foo", "bar")],
+            {"spam": "eggs"},
+            {"PASSWORD": "hunter2"},
+            RequestComponents("sample.app", "DataView", "detail"),
+            "test-controller",
+            {"baz": 3},
+            {
+                "exception_class": "ZeroDivisionError",
+                "message": "division by zero",
+                "request_id": "sample_id",
+                "request_uri": "/test/",
+                "request_params": [("foo", "bar")],
+                "request_session": {"spam": "eggs"},
+                "environment": {"PASSWORD": "[FILTERED]"},
+                "request_components": {
+                    "module": "sample.app",
+                    "controller": "test-controller",
+                    "action": "detail",
+                },
+                "context": {"spam": "foo", "custom_params": {"baz": 3}},
+                "host": None,
+                "revision_sha": "",
+            },
+        ),
+    ],
+)
+def test_monitor(
+    path,
+    params,
+    session,
+    environment,
+    request_components,
+    custom_controller,
+    custom_params,
+    expected_error,
+    tracked_request,
+    error_monitor_errors,
+):
+    with app_with_scout():
+        tracked_request.request_id = "sample_id"
+        tracked_request.tags["spam"] = "foo"
+        exc_info = 0
+        try:
+            1 / 0
+        except ZeroDivisionError:
+            exc_info = sys.exc_info()
+        ErrorMonitor.send(
+            exc_info,
+            request_components=request_components,
+            request_path=path,
+            request_params=params,
+            session=session,
+            environment=environment,
+            custom_controller=custom_controller,
+            custom_params=custom_params,
+        )
+
+    assert len(error_monitor_errors) == 1
+    error = error_monitor_errors[0]
+    # Remove the trace from the error as it bloats the test.
+    trace = error.pop("trace")
+    assert trace[0]["function"] == "test_monitor"
+    assert error == expected_error

--- a/tests/unit/core/test_error.py
+++ b/tests/unit/core/test_error.py
@@ -191,6 +191,9 @@ def test_monitor(
     assert len(error_monitor_errors) == 1
     error = error_monitor_errors[0]
     # Remove the trace from the error as it bloats the test.
-    trace = error.pop("trace")
-    assert trace[0]["function"] == "test_monitor"
+    filepath, line, func_str = error.pop("trace")[0].split(":")
+    assert filepath.endswith("tests/unit/core/test_error.py")
+    # The line number changes between python versions. Make sure it's not empty.
+    assert line
+    assert func_str == "in test_monitor"
     assert error == expected_error

--- a/tests/unit/core/test_web_requests.py
+++ b/tests/unit/core/test_web_requests.py
@@ -12,6 +12,7 @@ from scout_apm.core.web_requests import (
     CUTOFF_EPOCH_S,
     convert_ambiguous_timestamp_to_ns,
     create_filtered_path,
+    filter_element,
     ignore_path,
     track_request_queue_time,
 )
@@ -42,6 +43,26 @@ from scout_apm.core.web_requests import (
 )
 def test_create_filtered_path(path, params, expected):
     assert create_filtered_path(path, params) == expected
+
+
+@pytest.mark.parametrize(
+    "key, value, expected",
+    [
+        ("bar", "baz", "baz"),
+        ("password", "baz", "[FILTERED]"),
+        ("bar", {"password": "hunter2"}, {"password": "[FILTERED]"}),
+        ("bar", [{"password": "hunter2"}], [{"password": "[FILTERED]"}]),
+        ("bar", {"baz"}, {"baz"}),
+        (
+            "bar",
+            ({"password": "hunter2"}, "baz"),
+            ({"password": "[FILTERED]"}, "baz"),
+        ),
+        ("", None, None),
+    ],
+)
+def test_filter_element(key, value, expected):
+    assert filter_element(key, value) == expected
 
 
 @pytest.mark.parametrize("path, params", [("/", []), ("/", [("foo", "ignored")])])


### PR DESCRIPTION
Monitor errors via got_request_exception signal.

The middleware process_exception would only allow us to track
exceptions thrown in views, that weren't picked up by an
earlier middleware that returned a result. This solution allows
us to track exceptions that occur anywhere in the application.

The downside to this is that it's possible if another receiver
of got_request_exception throws a new exception, our handler
may get the wrong exception with sys.exc_info().

We could limit the scope of that issue by injecting a middleware
that's as far down the list as possible to wrap the view
and catch exceptions there. Then rely on the signal handler
for catching exceptions in the middleware.

Create ErrorServiceThread to buffer error messages.


TODO:

- [x] Django instrumentation unit tests
- [x] ErrorMonitor core unit tests
- [x] Documentation of new settings and error monitoring feature.
- [x] Batch errors together and send on separate thread from the requests thread.
- [x] API for manually tracking errors