### PR TITLE
Reuse existing core agent process if it exists.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Pending
+- Reuse existing core agent process if it exists. This avoids spawning
+  multiple processes that can occur with custom instrumentation.
 - Removed parsing queue time from Amazon ALB header, X-Amzn-Trace-Id.
   The time portion of the header only has the truncated seconds which
   appears as about 500ms for queue time constantly.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -139,6 +139,13 @@ def core_agent_manager(core_agent_dir):
         scout_config.reset_all()
 
 
+def get_core_agent_pid():
+    for p in psutil.process_iter(["name"]):
+        if p.name() == "core-agent":
+            return p.pid
+    return None
+
+
 def core_agent_is_running():
     return any(p.name() == "core-agent" for p in psutil.process_iter(["name"]))
 


### PR DESCRIPTION
This avoids spawning multiple processes that can occur with custom
instrumentation.