### PR TITLE
Improved debug logging for requests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Pending
+- Improved debug logging for requests. It now includes some summary
+  information about the request.
+  ([Issue #654](https://github.com/scoutapp/scout_apm_python/issues/654))
 - Added Celery's ``priority`` delivery info to the set of tags.
 - Removed parsing queue time from Amazon ALB header, X-Amzn-Trace-Id.
   The time portion of the header only has the truncated seconds which

--- a/src/scout_apm/core/tracked_request.py
+++ b/src/scout_apm/core/tracked_request.py
@@ -149,6 +149,21 @@ class TrackedRequest(object):
                 CoreAgentSocketThread.send(batch_command)
             SamplersThread.ensure_started()
 
+        details = " ".join(
+            "{}={}".format(key, value)
+            for key, value in [
+                ("start_time", self.start_time),
+                ("end_time", self.end_time),
+                ("duration", (self.end_time - self.start_time).total_seconds()),
+                ("active_spans", len(self.active_spans)),
+                ("complete_spans", len(self.complete_spans)),
+                ("tags", len(self.tags)),
+                ("hit_max", self.hit_max),
+                ("is_real_request", self.is_real_request),
+            ]
+        )
+        logger.debug("Request %s %s", self.request_id, details)
+
         from scout_apm.core.context import context
 
         context.clear_tracked_request(self)

--- a/tests/unit/core/test_tracked_request.py
+++ b/tests/unit/core/test_tracked_request.py
@@ -185,6 +185,37 @@ def test_finish_does_captures_memory_on_real_requests(tracked_request):
     assert "mem_delta" in tracked_request.tags
 
 
+def test_finish_log_request_info(tracked_request, caplog):
+    tracked_request.start_span(operation="Something")
+    tracked_request.stop_span()
+    tracked_request.is_real_request = True
+    tracked_request.finish()
+
+    assert (
+        "scout_apm.core.tracked_request",
+        logging.DEBUG,
+        "Stopping request: {}".format(tracked_request.request_id),
+    ) in caplog.record_tuples
+
+    assert (
+        "scout_apm.core.tracked_request",
+        logging.DEBUG,
+        (
+            "Request {} ".format(tracked_request.request_id)
+            + "start_time={} ".format(tracked_request.start_time)
+            + "end_time={} ".format(tracked_request.end_time)
+            + "duration={} ".format(
+                (tracked_request.end_time - tracked_request.start_time).total_seconds()
+            )
+            + "active_spans=0 "
+            + "complete_spans=1 "
+            + "tags=1 "
+            + "hit_max=False "
+            + "is_real_request=True"
+        ),
+    ) in caplog.record_tuples
+
+
 def test_is_ignored_default_false(tracked_request):
     assert not tracked_request.is_ignored()
 


### PR DESCRIPTION
It now contains summary information for the request that is
logged after the request has been sent.

Closes #654