### PR TITLE
Include Celery's priority and fix failing tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Pending
+- Added Celery's ``priority`` delivery info to the set of tags.
 - Removed parsing queue time from Amazon ALB header, X-Amzn-Trace-Id.
   The time portion of the header only has the truncated seconds which
   appears as about 500ms for queue time constantly.

--- a/src/scout_apm/celery.py
+++ b/src/scout_apm/celery.py
@@ -40,6 +40,7 @@ def task_prerun_callback(task=None, **kwargs):
     delivery_info = task.request.delivery_info
     tracked_request.tag("is_eager", delivery_info.get("is_eager", False))
     tracked_request.tag("exchange", delivery_info.get("exchange", "unknown"))
+    tracked_request.tag("priority", delivery_info.get("priority", "unknown"))
     tracked_request.tag("routing_key", delivery_info.get("routing_key", "unknown"))
     tracked_request.tag("queue", delivery_info.get("queue", "unknown"))
 

--- a/tests/integration/test_celery.py
+++ b/tests/integration/test_celery.py
@@ -77,8 +77,14 @@ def test_hello_eager(tracked_requests):
     tracked_request = tracked_requests[0]
     assert "task_id" in tracked_request.tags
     assert tracked_request.tags["is_eager"] is True
-    assert tracked_request.tags["exchange"] == "unknown"
-    assert tracked_request.tags["routing_key"] == "unknown"
+    if celery.VERSION < (5, 1):
+        assert tracked_request.tags["exchange"] == "unknown"
+        assert tracked_request.tags["priority"] == "unknown"
+        assert tracked_request.tags["routing_key"] == "unknown"
+    else:
+        assert tracked_request.tags["exchange"] is None
+        assert tracked_request.tags["priority"] is None
+        assert tracked_request.tags["routing_key"] is None
     assert tracked_request.tags["queue"] == "unknown"
     assert tracked_request.active_spans == []
     assert len(tracked_request.complete_spans) == 1
@@ -97,6 +103,7 @@ def test_hello_worker(celery_app, celery_worker, tracked_requests):
     assert "task_id" in tracked_request.tags
     assert tracked_request.tags["is_eager"] is False
     assert tracked_request.tags["exchange"] == ""
+    assert tracked_request.tags["priority"] == 0
     assert tracked_request.tags["routing_key"] == "celery"
     assert tracked_request.tags["queue"] == "unknown"
     assert (


### PR DESCRIPTION
As of Celery 5.1.0, the delivery info for tasks includes default
values of None rather than no key.