### PR TITLE
Supply a list of keywords rather than a string.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Pending
 
+### Added
+
+### Fixed
+- Setup metadata keywords now contains an array of strings.
 
 ## [2.20.0] 2021-07-21
 - Removed parsing queue time from Amazon ALB header, X-Amzn-Trace-Id.

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
         'urllib3[secure] < 2 ; python_version >= "3.5"',
         "wrapt>=1.10,<2.0",
     ],
-    keywords="apm performance monitoring development",
+    keywords=["apm", "performance monitoring", "development"],
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Framework :: Bottle",


### PR DESCRIPTION
PyPI treats the string as an array and is making each
character a keyword.