### PR TITLE
Handle case of namespace packages when capturing backtraces.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Added
 
 ### Fixed
+- Handle case of namespace packages when capturing backtraces.
+  ([Issue #667](https://github.com/scoutapp/scout_apm_python/issues/667))
 
 ## [2.21.0] 2021-07-23
 


### PR DESCRIPTION
A namespace package does not have a file property. Instead utilize
the __path__ attribute and use the first element in the list. While
this may not capture the dynamic cases, it should capture the
necessary data for most cases.

Fixes #667