### PR TITLE
Pin cibuildwheels to < 2 to support building binaries for python3.5.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Install packaging tools
       run: |
         python2.7 -m pip install --upgrade pip setuptools wheel
-        python3.9 -m pip install --upgrade cibuildwheel pip setuptools twine wheel
+        python3.9 -m pip install --upgrade "cibuildwheel<2.0.0" pip setuptools twine wheel
 
     - name: Build sdist
       run: python3.9 setup.py sdist


### PR DESCRIPTION
I suspect we'll need to break up the release process to use both versions
of cibuildwheels to build binaries for all versions of python.

References #584