### PR TITLE
Make module_filepath more robust for unexpected results.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Added support for Django 4.0 and Python 3.10.
 
 ### Fixed
+- Make `module_filepath` more robust avoiding throwing exceptions.
+  ([Issue 691](https://github.com/scoutapp/scout_apm_python/issues/691))
 
 ## [2.23.2] 2021-10-04
 

--- a/src/scout_apm/core/backtrace.py
+++ b/src/scout_apm/core/backtrace.py
@@ -32,22 +32,27 @@ def module_filepath(module, filepath):
     if root_module_name == module:
         return os.path.basename(filepath)
 
+    module_dir = None
     root_module = sys.modules[root_module_name]
-    if root_module.__file__:
-        module_dir = root_module.__file__.rsplit(os.sep, 2)[0]
-    elif root_module.__path__:
-        # Default to using the first path specified for the module.
-        module_dir = root_module.__path__[0].rsplit(os.sep, 1)[0]
-        if len(root_module.__path__) > 1:
-            logger.debug(
-                "{} has {} paths. Use the first and ignore the rest.".format(
-                    root_module, len(root_module.__path__)
+    try:
+        if root_module.__file__:
+            module_dir = root_module.__file__.rsplit(os.sep, 2)[0]
+        elif root_module.__path__ and isinstance(root_module.__path__, (list, tuple)):
+            # Default to using the first path specified for the module.
+            module_dir = root_module.__path__[0].rsplit(os.sep, 1)[0]
+            if len(root_module.__path__) > 1:
+                logger.debug(
+                    "{} has {} paths. Use the first and ignore the rest.".format(
+                        root_module, len(root_module.__path__)
+                    )
                 )
-            )
-    else:
-        # If the file path don't exist, then return the full path.
-        return filepath
-    return filepath.split(module_dir, 1)[-1].lstrip(os.sep)
+    except Exception as exc:
+        logger.debug(
+            "Error processing module {} and filepath {}".format(root_module, filepath),
+            exc_info=exc,
+        )
+
+    return filepath.split(module_dir, 1)[-1].lstrip(os.sep) if module_dir else filepath
 
 
 def filepath(frame):

--- a/tests/unit/core/test_backtrace.py
+++ b/tests/unit/core/test_backtrace.py
@@ -107,58 +107,27 @@ def test_module_filepath_with_namespace(test_package_as_namespace_package):
     )
 
 
-@pytest.fixture
-def test_package_invalid_path():
+@pytest.fixture(
+    params=[
+        # Invalid path case
+        [None, "invalid"],
+        # Raise an error case
+        [None, [None]],
+        # No file or path case.
+        [None, None],
+    ]
+)
+def error_module(request):
     orig_file = sys.modules["tests"].__file__
     orig_path = sys.modules["tests"].__path__
-    sys.modules["tests"].__file__ = None
-    sys.modules["tests"].__path__ = "invalid"
+    sys.modules["tests"].__file__ = request.param[0]
+    sys.modules["tests"].__path__ = request.param[1]
     yield
     sys.modules["tests"].__file__ = orig_file
     sys.modules["tests"].__path__ = orig_path
 
 
-@pytest.fixture
-def test_package_error():
-    orig_file = sys.modules["tests"].__file__
-    orig_path = sys.modules["tests"].__path__
-    sys.modules["tests"].__file__ = None
-    sys.modules["tests"].__path__ = [None]
-    yield
-    sys.modules["tests"].__file__ = orig_file
-    sys.modules["tests"].__path__ = orig_path
-
-
-@pytest.fixture
-def test_package_no_file_or_path():
-    orig_file = sys.modules["tests"].__file__
-    orig_path = sys.modules["tests"].__path__
-    sys.modules["tests"].__file__ = None
-    sys.modules["tests"].__path__ = None
-    yield
-    sys.modules["tests"].__file__ = orig_file
-    sys.modules["tests"].__path__ = orig_path
-
-
-def test_module_filepath_with_invalid_path(test_package_invalid_path):
-    frame = get_tb().tb_frame
-    module = frame.f_globals["__name__"]
-    filepath = frame.f_code.co_filename
-    full_path = backtrace.module_filepath(module, filepath)
-    assert full_path != "tests/unit/core/test_backtrace.py"
-    assert full_path.endswith("tests/unit/core/test_backtrace.py")
-
-
-def test_module_filepath_error(test_package_error):
-    frame = get_tb().tb_frame
-    module = frame.f_globals["__name__"]
-    filepath = frame.f_code.co_filename
-    full_path = backtrace.module_filepath(module, filepath)
-    assert full_path != "tests/unit/core/test_backtrace.py"
-    assert full_path.endswith("tests/unit/core/test_backtrace.py")
-
-
-def test_module_filepath_without_file_or_path(test_package_no_file_or_path):
+def test_module_filepath_error_flows(error_module):
     frame = get_tb().tb_frame
     module = frame.f_globals["__name__"]
     filepath = frame.f_code.co_filename

--- a/tests/unit/core/test_backtrace.py
+++ b/tests/unit/core/test_backtrace.py
@@ -108,6 +108,28 @@ def test_module_filepath_with_namespace(test_package_as_namespace_package):
 
 
 @pytest.fixture
+def test_package_invalid_path():
+    orig_file = sys.modules["tests"].__file__
+    orig_path = sys.modules["tests"].__path__
+    sys.modules["tests"].__file__ = None
+    sys.modules["tests"].__path__ = "invalid"
+    yield
+    sys.modules["tests"].__file__ = orig_file
+    sys.modules["tests"].__path__ = orig_path
+
+
+@pytest.fixture
+def test_package_error():
+    orig_file = sys.modules["tests"].__file__
+    orig_path = sys.modules["tests"].__path__
+    sys.modules["tests"].__file__ = None
+    sys.modules["tests"].__path__ = [None]
+    yield
+    sys.modules["tests"].__file__ = orig_file
+    sys.modules["tests"].__path__ = orig_path
+
+
+@pytest.fixture
 def test_package_no_file_or_path():
     orig_file = sys.modules["tests"].__file__
     orig_path = sys.modules["tests"].__path__
@@ -116,6 +138,24 @@ def test_package_no_file_or_path():
     yield
     sys.modules["tests"].__file__ = orig_file
     sys.modules["tests"].__path__ = orig_path
+
+
+def test_module_filepath_with_invalid_path(test_package_invalid_path):
+    frame = get_tb().tb_frame
+    module = frame.f_globals["__name__"]
+    filepath = frame.f_code.co_filename
+    full_path = backtrace.module_filepath(module, filepath)
+    assert full_path != "tests/unit/core/test_backtrace.py"
+    assert full_path.endswith("tests/unit/core/test_backtrace.py")
+
+
+def test_module_filepath_error(test_package_error):
+    frame = get_tb().tb_frame
+    module = frame.f_globals["__name__"]
+    filepath = frame.f_code.co_filename
+    full_path = backtrace.module_filepath(module, filepath)
+    assert full_path != "tests/unit/core/test_backtrace.py"
+    assert full_path.endswith("tests/unit/core/test_backtrace.py")
 
 
 def test_module_filepath_without_file_or_path(test_package_no_file_or_path):


### PR DESCRIPTION
Skip handling _NamespacePath for now as it's an inner class for importlib.

Closes #691 