### PR TITLE
Split CI test github actions into two jobs.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,22 +7,68 @@ on:
   pull_request:
 
 jobs:
-  tests:
-    name: Python ${{ matrix.python-version }}
-    runs-on: ubuntu-18.04
+  tests-ubuntu-20:
+    name: Python ${{ matrix.python-version }} Ubuntu 20
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false
       matrix:
         python-version:
         - "2.7"
-        - "3.4"
         - "3.5"
         - "3.6"
         - "3.7"
         - "3.8"
         - "3.9"
         - "3.10"
+
+    services:
+      elasticsearch:
+        image: elasticsearch:7.10.1
+        ports:
+        - 9200:9200
+        env:
+          discovery.type: single-node
+
+      mongodb:
+        image: mongo:4
+        ports:
+        - 27017:27017
+
+      redis:
+        image: redis:6
+        ports:
+        - 6379:6379
+
+    env:
+      ELASTICSEARCH_URL: http://localhost:9200/
+      MONGODB_URL: mongodb://localhost:27017/
+      REDIS_URL: redis://localhost:6379/0
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Upgrade packaging tools
+      run: python -m pip install --upgrade pip setuptools virtualenv
+    - name: Install dependencies
+      run: python -m pip install --upgrade tox
+    - name: Run tox targets for ${{ matrix.python-version }}
+      run: |
+        ENV_PREFIX=$(tr -C -d "0-9" <<< "${{ matrix.python-version }}" | cut -c -3)
+        TOXENV=$(tox --listenvs | grep "^py$ENV_PREFIX" | tr '\n' ',') python -m tox
+
+  tests-ubuntu-18:
+    name: Python ${{ matrix.python-version }} Ubuntu 18
+    runs-on: ubuntu-18.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+        - 3.4
 
     services:
       elasticsearch:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,10 @@ on:
     branches:
     - master
   pull_request:
+  schedule:
+    # Run daily. Avoid running at distinct hours to reduce load
+    # on GitHub.
+    - cron: '44 2 * * *'
 
 jobs:
   tests-ubuntu-20:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - Split CI tests GitHub actions into two jobs to support python 3.4 on
   Ubuntu 18 and modern versions with Ubuntu 20.
+- Run CI tests once per day to identify issues quicker.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Pending
 
 ### Added
+- Split CI tests GitHub actions into two jobs to support python 3.4 on
+  Ubuntu 18 and modern versions with Ubuntu 20.
 
 ### Fixed
 


### PR DESCRIPTION
We need to use Ubuntu 18 to support python3.4 and Ubuntu20 to support
modern versions.