### PR TITLE
Build wheels for all versions of python.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,15 +153,16 @@ jobs:
           path: dist
 
       - name: Publish distributions to Test PyPI
-        uses: pypa/gh-action-pypi-publish@v1.4.2
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.TEST_TWINE_PASSWORD }}
           repository_url: https://test.pypi.org/legacy/
+          skip_existing: true
 
       - name: Publish distributiosn to PyPI
         if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
-        uses: pypa/gh-action-pypi-publish@v1.4.2
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.TWINE_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,63 +9,159 @@ on:
   pull_request:
 
 jobs:
-  release:
-    name: Build release
-    runs-on: ubuntu-18.04
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - uses: actions/setup-python@v2
-      with:
-        python-version: 3.9
-
-    - uses: actions/setup-python@v2
-      with:
-        python-version: 2.7
-
-    - name: Set up QEMU
-      # For cross-architecture builds
-      # https://cibuildwheel.readthedocs.io/en/stable/faq/#emulation
-      if: runner.os == 'Linux'
-      uses: docker/setup-qemu-action@v1
-      with:
-        platforms: all
-
-    - name: Install packaging tools
-      run: |
-        python2.7 -m pip install --upgrade pip setuptools wheel
-        python3.9 -m pip install --upgrade "cibuildwheel<2.0.0" pip setuptools twine wheel
-
-    - name: Build sdist
-      run: python3.9 setup.py sdist
-
-    - name: Build Python 2 pure Python wheel
-      run: python2.7 setup.py bdist_wheel
-
-    - name: Build Python 3 pure Python wheel
-      env:
-        SCOUT_DISABLE_EXTENSIONS: "1"
-      run: python3.9 setup.py bdist_wheel
-
-    - name: Build binary wheels
-      env:
+  cibuildwheel_py37plus:
+    name: Build python 3.7+ ${{ matrix.manylinux_image }} wheels
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-20.04 ]
+        python: [ '3.10' ]
+        manylinux_image: [ manylinux2010, manylinux2014, manylinux_2_24 ]
         # Disable for platforms where pure Python wheels would be generated
-        CIBW_ARCHS_LINUX: "auto aarch64"
-        CIBW_BUILD_VERBOSITY: 1
-        CIBW_SKIP: "cp27-* pp27-* pp36-* pp37-*"
-      run: cibuildwheel
+        cibw_skip: [ "pp37-* pp38-* pp39-* pp310-*" ]
+        include:
+          # Exclude building 3.10 wheel for manylinux1.
+          - os: ubuntu-20.04
+            python: 3.9
+            manylinux_image: manylinux1
+            cibw_skip: "pp37-* pp38-* pp39-* pp310-* cp310-*"
+    steps:
+      - uses: actions/checkout@v2
 
-    - name: Check packages
-      run: twine check dist/* wheelhouse/*
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: ${{ matrix.python }}
 
-    - name: List files
-      run: ls -al dist wheelhouse
+      - name: Install cibuildwheel
+        run: |
+          python -m pip install --upgrade pip cibuildwheel
 
-    - name: Release
-      if: startsWith(github.event.ref, 'refs/tags')
-      env:
-        TWINE_NON_INTERACTIVE: 1
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-      run: twine upload --skip-existing dist/* wheelhouse/*
+      - name: Set up QEMU
+        # For cross-architecture builds
+        # https://cibuildwheel.readthedocs.io/en/stable/faq/#emulation
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+      - name: Set AArch64 env if needed
+        if: matrix.manylinux_image != 'manylinux1' && matrix.manylinux_image != 'manylinux2010'
+        env:
+          CIBW_MANYLINUX_AARCH64_IMAGE: ${{ matrix.manylinux_image }}
+          CIBW_ARCHS_LINUX: "auto aarch64"
+        run: echo "set CIBW_MANYLINUX_AARCH64_IMAGE=${{ env.CIBW_MANYLINUX_AARCH64_IMAGE }}"
+      - name: Build binary wheels
+        env:
+          CIBW_SKIP: ${{ matrix.cibw_skip }}
+          CIBW_BUILD_VERBOSITY: 1
+          CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.manylinux_image }}
+          CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.manylinux_image }}
+        run: python -m cibuildwheel
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl
+
+  cibuildwheel_py35py36:
+    name: Build python 3.5, 3.6 platform wheels
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-18.04 ]
+        python: [ 3.9 ]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Install cibuildwheel
+        run: |
+          python -m pip install --upgrade pip "cibuildwheel==1.12.0"
+
+      - name: Set up QEMU
+        # For cross-architecture builds
+        # https://cibuildwheel.readthedocs.io/en/stable/faq/#emulation
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+      - name: Build binary wheels
+        env:
+          CIBW_BUILD_VERBOSITY: 1
+          CIBW_BUILD: "cp35-* cp36-*"
+          CIBW_ARCHS_LINUX: "auto aarch64"
+        run: python -m cibuildwheel
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl
+
+  build_pure_wheels:
+    name: Build pure python wheels
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python: [3.9, 2.7]
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install packaging tools
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+
+      - name: Build Python pure Python wheel
+        env:
+          SCOUT_DISABLE_EXTENSIONS: "1"
+        run: python setup.py bdist_wheel
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: dist/*.whl
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: 3.9
+
+      - name: Build sdist
+        run: python setup.py sdist
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: dist/*.tar.gz
+
+  upload_pypi:
+    needs: [cibuildwheel_py37plus, cibuildwheel_py35py36, build_pure_wheels, build_sdist]
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Download distributions for publishing.
+        uses: actions/download-artifact@v2
+        with:
+          name: artifact
+          path: dist
+
+      - name: Publish distributions to Test PyPI
+        uses: pypa/gh-action-pypi-publish@v1.4.2
+        with:
+          user: __token__
+          password: ${{ secrets.TEST_TWINE_PASSWORD }}
+          repository_url: https://test.pypi.org/legacy/
+
+      - name: Publish distributiosn to PyPI
+        if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
+        uses: pypa/gh-action-pypi-publish@v1.4.2
+        with:
+          user: __token__
+          password: ${{ secrets.TWINE_PASSWORD }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   the debug level. This avoids flooding logs when clients use an older
   version of ElasticSearch.
   ([Issue 713](https://github.com/scoutapp/scout_apm_python/issues/713))
+- Restore building wheels for python 3.4 and 3.5.
+  ([Issue 584](https://github.com/scoutapp/scout_apm_python/issues/584))
 
 ## [2.23.5] 2021-12-09
 


### PR DESCRIPTION
* Upload all builds to Test PyPI
* Rework release Github action to utilize newer versions of cibuildwheel when available.
* Avoid supplying earlier versions of python to cibuildwheel > 2.
* Supply the various manylinux images.
* Break the two cibuildwheel configurations into two via a matrix, except py3.10 for manylinux1
* Specify AArch64 manylinux image.
* Only build aarch64 wheels when using a viable manylinux image.

For some reason, a manylinux2014 image is still used even when manylinux_2_24 is specified