### PR TITLE
Fix the build for python3.5 and cherrypy usage.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,8 @@ deps =
     attrs ; python_version > "3.4"
     attrs<21.1.0 ; python_version <= "3.4"
     bottle
-    cherrypy
+    cherrypy ; python_version > "3.5"
+    cherrypy<18.6.1 ; python_version <= "3.5"
     celery!=4.4.4  # https://github.com/celery/celery/issues/6153
     cryptography ; python_version >= "3.6"
     cryptography<3.2 ; python_version < "3.6"
@@ -60,6 +61,7 @@ deps =
     ; alongside the latest celery.
     ; nameko<3
     mock ; python_version < "3.0"
+    more-itertools < 8.11.0 ; python_version <= "3.5"
     psutil
     pymongo
     pyramid


### PR DESCRIPTION
CherryPy dropped support for python 3.5 in 18.6.1
more-itertools started using non-compatible python 3.5 syntax
in 8.11.0 and is used by CherryPy.