### PR TITLE
Add hiredis parser for tests.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -51,6 +51,7 @@ deps =
     falcon
     flask
     flask-sqlalchemy
+    hiredis
     huey
     hug>=2.5.1 ; python_version >= "3.5"
     httpretty<1 ; python_version < "3.5"


### PR DESCRIPTION
Added to silence the following warning from redis-py:
UserWarning: redis-py works best with hiredis. Please consider installing