### PR TITLE
Use urllib3 to post error messages to Scout Error API. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   ([Issue 708](https://github.com/scoutapp/scout_apm_python/issues/708))
 - Use urllib3 to post errors to Scout Errors API. Removes dependency on
   requests library.
+- Switch to a dict for the `request_params` away from a list of tuples.
 
 ## [2.23.4] 2021-11-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - When Celery `task_failure` signal has a string type for the `traceback`
   parameter, use the `einfo.tb` to fetch the traceback.
   ([Issue 708](https://github.com/scoutapp/scout_apm_python/issues/708))
+- Use urllib3 to post errors to Scout Errors API. Removes dependency on
+  requests library.
 
 ## [2.23.4] 2021-11-12
 

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,6 @@ setup(
         'urllib3[secure] < 1.25 ; python_version < "3.5"',
         'urllib3[secure] < 2 ; python_version >= "3.5"',
         "wrapt>=1.10,<2.0",
-        "requests",
     ],
     keywords=["apm", "performance monitoring", "development"],
     classifiers=[

--- a/src/scout_apm/compat.py
+++ b/src/scout_apm/compat.py
@@ -79,11 +79,13 @@ def text(value, encoding="utf-8", errors="strict"):
 
 
 if sys.version_info >= (3, 0):
-    from urllib.parse import parse_qsl, urlencode
+    from html import escape
+    from urllib.parse import parse_qsl, urlencode, urljoin
 else:
+    from cgi import escape
     from urllib import urlencode
 
-    from urlparse import parse_qsl
+    from urlparse import parse_qsl, urljoin
 
 
 if sys.version_info >= (3, 0):
@@ -160,7 +162,7 @@ else:
     def gzip_compress(data):
         """Reimplementation gzip.compress for python 2.7"""
         buf = io.BytesIO()
-        with gzip.GzipFile(fileobj=buf, mode="wb") as f:
+        with gzip.GzipFile(fileobj=buf, mode="w") as f:
             f.write(data)
         return buf.getvalue()
 
@@ -168,6 +170,7 @@ else:
 __all__ = [
     "ContextDecorator",
     "datetime_to_timestamp",
+    "escape",
     "gzip_compress",
     "kwargs_only",
     "parse_qsl",
@@ -176,4 +179,5 @@ __all__ = [
     "text",
     "text_type",
     "urlencode",
+    "urljoin",
 ]

--- a/src/scout_apm/django/apps.py
+++ b/src/scout_apm/django/apps.py
@@ -63,7 +63,7 @@ class ScoutApmDjangoConfig(AppConfig):
             sys.exc_info(),
             request_components=get_request_components(request),
             request_path=request.path,
-            request_params=[(k, v) for k, vs in request.GET.lists() for v in vs],
+            request_params=dict(request.GET.lists()),
             session=dict(request.session.items())
             if hasattr(request, "session")
             else None,

--- a/src/scout_apm/flask/__init__.py
+++ b/src/scout_apm/flask/__init__.py
@@ -66,9 +66,7 @@ class ScoutApm(object):
                         sys.exc_info(),
                         request_components=get_request_components(self.app, request),
                         request_path=request.path,
-                        request_params=[
-                            (k, v) for k, vs in request.args.lists() for v in vs
-                        ],
+                        request_params=dict(request.args.lists()),
                         session=dict(session.items()),
                         environment=self.app.config,
                     )

--- a/tests/compat.py
+++ b/tests/compat.py
@@ -64,11 +64,11 @@ if sys.version_info >= (3, 2):
         return gzip.decompress(data)
 
 else:
-    import io
+    import StringIO
 
     def gzip_decompress(data):
         """Reimplementation gzip.compress for python 2.7"""
-        with gzip.GzipFile(fileobj=io.BytesIO(data), mode="rb") as f:
+        with gzip.GzipFile(fileobj=StringIO.StringIO(data), mode="rb") as f:
             return f.read()
 
 

--- a/tests/integration/core/test_error_service.py
+++ b/tests/integration/core/test_error_service.py
@@ -40,7 +40,7 @@ def error_service_thread():
                 "notifier": "scout_apm_python",
                 "environment": "scout-test",
                 "root": "/tmp/",
-                "problems": [{"foo": "bar"}],
+                "problems": [{"foo": "BØØM!"}],
             },
             {"Agent-Hostname": "example.com", "X-Error-Count": "1"},
             "https://testserver/apps/error.scout?key=scout-app-key"
@@ -52,10 +52,10 @@ def error_service_thread():
                 "notifier": "scout_apm_python",
                 "environment": None,
                 "root": WORKING_DIRECTORY,
-                "problems": [{"foo": "bar"}],
+                "problems": [{"foo": "BØØM!"}],
             },
             {"Agent-Hostname": None, "X-Error-Count": "1"},
-            "https://errors.scoutapm.com/apps/error.scout" "?name=Python+App",
+            "https://errors.scoutapm.com/apps/error.scout?name=Python+App",
         ),
     ],
 )
@@ -68,10 +68,10 @@ def test_send(
         with httpretty.enabled(allow_net_connect=False):
             httpretty.register_uri(
                 httpretty.POST,
-                "{}/apps/error.scout".format(scout_config.value("errors_host")),
+                expected_uri,
                 body="Hello World!",
             )
-            ErrorServiceThread.send({"foo": "bar"})
+            ErrorServiceThread.send({"foo": "BØØM!"})
             ErrorServiceThread.wait_until_drained()
 
             request = httpretty.last_request()
@@ -121,14 +121,14 @@ def test_send_api_error(error_service_thread, caplog):
                 body="Unexpected Error",
                 status=500,
             )
-            ErrorServiceThread.send({"foo": "bar"})
+            ErrorServiceThread.send({"foo": "BØØM!"})
             ErrorServiceThread.wait_until_drained()
     finally:
         scout_config.reset_all()
     assert caplog.record_tuples[-1][0] == "scout_apm.core.error_service"
     assert caplog.record_tuples[-1][1] == logging.DEBUG
     assert caplog.record_tuples[-1][2].startswith(
-        "ErrorServiceThread exception on _send:"
+        "ErrorServiceThread 500 response error on _send:"
     )
 
 

--- a/tests/integration/test_django.py
+++ b/tests/integration/test_django.py
@@ -284,7 +284,7 @@ def test_server_error_error_monitor_with_params(tracked_requests, error_monitor_
 
     assert len(error_monitor_errors) == 1
     error = error_monitor_errors[0]
-    assert error["request_params"] == [("spam[]", "eggs"), ("spam[]", "false")]
+    assert error["request_params"] == {"spam[]": ["eggs", "false"]}
 
 
 def test_return_error(tracked_requests):

--- a/tests/integration/test_flask.py
+++ b/tests/integration/test_flask.py
@@ -285,7 +285,7 @@ def test_server_error_error_monitor_with_params(tracked_requests, error_monitor_
 
     assert len(error_monitor_errors) == 1
     error = error_monitor_errors[0]
-    assert error["request_params"] == [("spam[]", "eggs"), ("spam[]", "false")]
+    assert error["request_params"] == {"spam[]": ["eggs", "false"]}
 
 
 def test_return_error_error_monitor(tracked_requests, error_monitor_errors):

--- a/tests/unit/core/test_error.py
+++ b/tests/unit/core/test_error.py
@@ -105,7 +105,7 @@ def test_monitor_ignore_exceptions(error_monitor_errors):
         ),
         (
             "/test/",
-            [("foo", "bar")],
+            {"foo": ["bar"]},
             {"spam": "eggs"},
             {"PASSWORD": "hunter2"},
             RequestComponents("sample.app", "DataView", "detail"),
@@ -116,7 +116,7 @@ def test_monitor_ignore_exceptions(error_monitor_errors):
                 "message": "division by zero",
                 "request_id": "sample_id",
                 "request_uri": "/test/",
-                "request_params": [("foo", "bar")],
+                "request_params": {"foo": ["bar"]},
                 "request_session": {"spam": "eggs"},
                 "environment": {"PASSWORD": "[FILTERED]"},
                 "request_components": {
@@ -131,7 +131,7 @@ def test_monitor_ignore_exceptions(error_monitor_errors):
         ),
         (
             "/test/",
-            [("foo", "bar")],
+            {"foo": ["bar"]},
             {"spam": "eggs"},
             {"PASSWORD": "hunter2"},
             RequestComponents("sample.app", "DataView", "detail"),
@@ -142,7 +142,7 @@ def test_monitor_ignore_exceptions(error_monitor_errors):
                 "message": "division by zero",
                 "request_id": "sample_id",
                 "request_uri": "/test/",
-                "request_params": [("foo", "bar")],
+                "request_params": {"foo": ["bar"]},
                 "request_session": {"spam": "eggs"},
                 "environment": {"PASSWORD": "[FILTERED]"},
                 "request_components": {

--- a/tox.ini
+++ b/tox.ini
@@ -56,7 +56,7 @@ deps =
     huey
     hug>=2.5.1 ; python_version >= "3.5"
     httpretty<1 ; python_version < "3.5"
-    httpretty!=1.1.1 ; python_version >= "3.5"
+    httpretty ; python_version >= "3.5"
     jinja2
     ; nameko tests temporarily disabled
     ; Due to bad pinning of kombu only a past nameko version can be installed

--- a/tox.ini
+++ b/tox.ini
@@ -73,7 +73,6 @@ deps =
     pyyaml ; python_version != "3.4"
     pyyaml < 5.3 ; python_version == "3.4"
     redis
-    requests
     rq
     six
     sqlalchemy ; python_version != "3.4"


### PR DESCRIPTION
Removes requests from packages dependencies


Requires integration testing to confirm error logging still works properly.