### PR TITLE
Fallback to celery task_failure einfo param.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 ### Fixed
 - Avoid instrumenting PyMongo collection methods that were removed in v4.
   ([Issue 710](https://github.com/scoutapp/scout_apm_python/issues/710))
+- When Celery `task_failure` signal has a string type for the `traceback`
+  parameter, use the `einfo.tb` to fetch the traceback.
+  ([Issue 708](https://github.com/scoutapp/scout_apm_python/issues/708))
 
 ## [2.23.4] 2021-11-12
 

--- a/src/scout_apm/celery.py
+++ b/src/scout_apm/celery.py
@@ -23,7 +23,7 @@ except ImportError:
     get_safe_settings = None
 
 import scout_apm.core
-from scout_apm.compat import datetime_to_timestamp
+from scout_apm.compat import datetime_to_timestamp, string_type
 from scout_apm.core.config import scout_config
 from scout_apm.core.error import ErrorMonitor
 from scout_apm.core.tracked_request import TrackedRequest
@@ -79,6 +79,7 @@ def task_failure_callback(
     args=None,
     kwargs=None,
     traceback=None,
+    einfo=None,
     **remaining
 ):
     tracked_request = TrackedRequest.instance()
@@ -110,6 +111,12 @@ def task_failure_callback(
             )
             pass
 
+    # Celery occassionally will send the traceback as a string rather
+    # than a Stack trace object as the docs indicate. In that case,
+    # fall back to the billiard ExceptionInfo instance
+    traceback = (
+        traceback if traceback and not isinstance(traceback, string_type) else einfo.tb
+    )
     exc_info = (exception.__class__, exception, traceback)
     ErrorMonitor.send(
         exc_info,


### PR DESCRIPTION
Celery doesn't always send a stack trace object to the
task_failure handlers. In those cases, it sends a string.
Rather than parse the string, fallback to the einfo
instance to access the traceback.

Fixes #708