### PR TITLE
Log elasticsearch client method instrumentation problems at DEBUG.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 ### Added
 
 ### Fixed
+- Only log warnings for ElasticSearch client method instrumentation
+  if no client methods were instrumented. Otherwise, log the issues at
+  the debug level. This avoids flooding logs when clients use an older
+  version of ElasticSearch.
+  ([Issue 713](https://github.com/scoutapp/scout_apm_python/issues/713))
 
 ## [2.23.5] 2021-12-09
 

--- a/src/scout_apm/instruments/elasticsearch.py
+++ b/src/scout_apm/instruments/elasticsearch.py
@@ -86,6 +86,7 @@ def ensure_client_instrumented():
     global have_patched_client
 
     if not have_patched_client:
+        instrumented_count = 0
         for name, takes_index_argument in CLIENT_METHODS:
             try:
                 method = getattr(Elasticsearch, name)
@@ -94,13 +95,19 @@ def ensure_client_instrumented():
                 else:
                     wrapped = wrap_client_method(method)
                 setattr(Elasticsearch, name, wrapped)
+                instrumented_count += 1
             except Exception as exc:
-                logger.warning(
+                logger.debug(
                     "Failed to instrument elasticsearch.Elasticsearch.%s: %r",
                     name,
                     exc,
                     exc_info=exc,
                 )
+        if instrumented_count == 0:
+            logger.warning(
+                "Failed to instrument any elasticsearch.Elasticsearch methods."
+                " Enable debug logs to view root causes."
+            )
 
         have_patched_client = True
 

--- a/tests/integration/instruments/test_elasticsearch.py
+++ b/tests/integration/instruments/test_elasticsearch.py
@@ -107,9 +107,32 @@ def test_ensure_installed_fail_no_client_bulk(caplog):
     )
     logger, level, message = caplog.record_tuples[1]
     assert logger == "scout_apm.instruments.elasticsearch"
-    assert level == logging.WARNING
+    assert level == logging.DEBUG
     assert message.startswith(
         "Failed to instrument elasticsearch.Elasticsearch.bulk: AttributeError"
+    )
+
+
+def test_ensure_installed_fail_no_client_methods(caplog):
+    mock_not_patched = mock.patch(
+        "scout_apm.instruments.elasticsearch.have_patched_client", new=False
+    )
+    # Change the wrap methods to a boolean to cause an exception
+    # and fail to wrap any of the client methods.
+    mock_wrap_client_index_method = mock.patch(
+        "scout_apm.instruments.elasticsearch.wrap_client_index_method", new=False
+    )
+    mock_wrap_client_method = mock.patch(
+        "scout_apm.instruments.elasticsearch.wrap_client_method", new=False
+    )
+    with mock_not_patched, mock_wrap_client_index_method, mock_wrap_client_method:
+        ensure_installed()
+
+    logger, level, message = caplog.record_tuples[-1]
+    assert logger == "scout_apm.instruments.elasticsearch"
+    assert level == logging.WARNING
+    assert message.startswith(
+        "Failed to instrument any elasticsearch.Elasticsearch methods."
     )
 
 


### PR DESCRIPTION
Only log warnings for ElasticSearch client method instrumentation
if no client methods were instrumented. Otherwise, log the issues at
the debug level. This avoids flooding logs when clients use an older
version of ElasticSearch.

Fixes #713