### PR TITLE
Set pytest asyncio mode to auto.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,7 +72,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-        - 3.4
+        - "3.4"
 
     services:
       elasticsearch:

--- a/tox.ini
+++ b/tox.ini
@@ -6,9 +6,7 @@ envlist =
     {py34,py35,py36,py37,py38}-django20
     {py35,py36,py37,py38}-django21
     {py35,py36,py37,py38,py39,py310}-django22
-    {py36,py37,py38,py39,py310}-django30
-    {py36,py37,py38,py39,py310}-django31
-    {py36,py37,py38,py39,py310}-django32
+    {py36,py37,py38,py39,py310}-django{30,31,32}
     {py38,py39,py310}-django40
 
 [testenv]
@@ -81,3 +79,8 @@ deps =
     webtest
 commands =
     pytest {posargs}
+
+# For newer versions of python use --asyncio-mode=auto usage.
+[testenv:py{37,38,39,310}-django{20,21,22,30,31,32,40}]
+commands =
+    pytest {posargs} --asyncio-mode=auto


### PR DESCRIPTION
Auto is the library's recommended default. When the scout agent
needs to support Trio, we'll need to switch to strict.