### PR TITLE
Stabilize build for Elasticsearch < 8.0.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -36,17 +36,16 @@ deps =
     django21: django-tastypie
     django22: Django>=2.2,<2.3
     django22: djangorestframework
-    django30: Django>=3.0a1,<3.1
+    django30: Django>=3.0,<3.1
     django30: djangorestframework
     django31: Django>=3.1,<3.2
     django31: djangorestframework
     django32: Django>=3.2,<3.3
     django32: djangorestframework
-    django40: Django>=4.0b1,<4.1
+    django40: Django>=4.0,<4.1
     django40: djangorestframework
     dramatiq>=1.0.0 ; python_version >= "3.5"
-    elasticsearch ; python_version >= "3.6"
-    elasticsearch<8.0.0 ; python_version < "3.6"
+    elasticsearch<8.0.0
     falcon
     flask
     flask-sqlalchemy


### PR DESCRIPTION
The current python agent doesn't support Elasticsearch 8+.
The issue to instrument that is #725