### PR TITLE
Ignore black updates for pre-commit.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,39 +1,43 @@
+ci:
+  # Ignore black updates because it stopped supported python2.7 with 22.1.0
+  skip: [black]
+
 repos:
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.1.0
-  hooks:
-  - id: check-added-large-files
-  - id: check-case-conflict
-  - id: check-json
-  - id: check-merge-conflict
-  - id: check-symlinks
-  - id: check-toml
-  - id: check-xml
-  - id: check-yaml
-  - id: end-of-file-fixer
-  - id: trailing-whitespace
-- repo: https://github.com/psf/black
-  rev: 21.12b0
-  hooks:
-  - id: black
-    language_version: python3
-- repo: https://github.com/pycqa/isort
-  rev: 5.10.1
-  hooks:
-  - id: isort
-- repo: https://github.com/PyCQA/flake8
-  rev: 4.0.1
-  hooks:
-  - id: flake8
-    additional_dependencies:
-    - flake8-2020
-    - flake8-bugbear
-    - flake8-coding
-    - flake8-comprehensions
-    - flake8-tidy-imports
-    - flake8-print
-- repo: https://github.com/mgedmin/check-manifest
-  rev: "0.47"
-  hooks:
-  - id: check-manifest
-    args: [--no-build-isolation]
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.1.0
+    hooks:
+    - id: check-added-large-files
+    - id: check-case-conflict
+    - id: check-json
+    - id: check-merge-conflict
+    - id: check-symlinks
+    - id: check-toml
+    - id: check-xml
+    - id: check-yaml
+    - id: end-of-file-fixer
+    - id: trailing-whitespace
+  - repo: https://github.com/psf/black
+    rev: 21.12b0
+    hooks:
+    - id: black
+      language_version: python3
+  - repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+    - id: isort
+  - repo: https://github.com/PyCQA/flake8
+    rev: 4.0.1
+    hooks:
+    - id: flake8
+      additional_dependencies:
+      - flake8-2020
+      - flake8-bugbear
+      - flake8-coding
+      - flake8-comprehensions
+      - flake8-tidy-imports
+      - flake8-print
+  - repo: https://github.com/mgedmin/check-manifest
+    rev: "0.47"
+    hooks:
+    - id: check-manifest
+      args: [--no-build-isolation]


### PR DESCRIPTION
As of 22.1.0 black stopped supported formating python 2.7 code.