### PR TITLE
celery: Skip tagging `delivery_info` if missing from request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Added
 
 ### Fixed
+- Avoid assuming Celery tasks will have a truth-y `delivery_info` property.
+  ([Issue 731](https://github.com/scoutapp/scout_apm_python/issues/731))
 
 ## [2.24.1] 2022-02-16
 

--- a/src/scout_apm/celery.py
+++ b/src/scout_apm/celery.py
@@ -56,12 +56,13 @@ def task_prerun_callback(task=None, **kwargs):
     if parent_task_id:
         tracked_request.tag("parent_task_id", parent_task_id)
 
-    delivery_info = task.request.delivery_info
-    tracked_request.tag("is_eager", delivery_info.get("is_eager", False))
-    tracked_request.tag("exchange", delivery_info.get("exchange", "unknown"))
-    tracked_request.tag("priority", delivery_info.get("priority", "unknown"))
-    tracked_request.tag("routing_key", delivery_info.get("routing_key", "unknown"))
-    tracked_request.tag("queue", delivery_info.get("queue", "unknown"))
+    delivery_info = getattr(task.request, "delivery_info", None)
+    if delivery_info:
+        tracked_request.tag("is_eager", delivery_info.get("is_eager", False))
+        tracked_request.tag("exchange", delivery_info.get("exchange", "unknown"))
+        tracked_request.tag("priority", delivery_info.get("priority", "unknown"))
+        tracked_request.tag("routing_key", delivery_info.get("routing_key", "unknown"))
+        tracked_request.tag("queue", delivery_info.get("queue", "unknown"))
 
     tracked_request.start_span(operation=("Job/" + task.name))
 


### PR DESCRIPTION
I think finding the underlying issue (it's possible it's not from `scout_apm_python` but one in my control) is important, but I think that the instrumentation itself shouldn't raise.

Find to close this if you have a better solution / idea for handling this.

Resolves #731