### PR TITLE
Always return a tuple from backtrace.filepaths.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Added
 
 ### Fixed
+- Always return a tuple from ``filepaths``.
+  ([Issue 737](https://github.com/scoutapp/scout_apm_python/issues/737))
 
 ## [2.25.0] 2022-05-04
 

--- a/src/scout_apm/core/__init__.py
+++ b/src/scout_apm/core/__init__.py
@@ -64,7 +64,7 @@ def shutdown():
 
     def apm_callback(queue_size):
         if scout_config.value("shutdown_message_enabled"):
-            print(  # noqa: T001
+            print(  # noqa: T001,T201
                 (
                     "Scout draining {queue_size} event{s} for up to"
                     + " {timeout_seconds} seconds"
@@ -78,7 +78,7 @@ def shutdown():
 
     def error_callback(queue_size):
         if scout_config.value("shutdown_message_enabled"):
-            print(  # noqa: T001
+            print(  # noqa: T001,T201
                 (
                     "Scout draining {queue_size} error{s} for up to"
                     + " {timeout_seconds} seconds"

--- a/src/scout_apm/core/backtrace.py
+++ b/src/scout_apm/core/backtrace.py
@@ -63,9 +63,7 @@ def filepaths(frame):
     if filepath.endswith(".pyc"):
         filepath = filepath[:-1]
 
-    if not module:
-        return filepath
-    return filepath, module_filepath(module, filepath)
+    return filepath, (module_filepath(module, filepath) if module else filepath)
 
 
 if sys.version_info >= (3, 5):

--- a/tests/unit/core/test_backtrace.py
+++ b/tests/unit/core/test_backtrace.py
@@ -140,3 +140,13 @@ def test_module_filepath_error_flows(error_module):
     full_path = backtrace.module_filepath(module, filepath)
     assert full_path != "/tests/unit/core/test_backtrace.py"
     assert full_path.endswith("/tests/unit/core/test_backtrace.py")
+
+
+def test_filepaths_no_module():
+    """When there is no module a tuple should still be returned"""
+    frame = get_tb().tb_frame
+    frame.f_globals["__name__"] = None
+    actual = backtrace.filepaths(frame)
+    assert len(actual) == 2
+    assert actual[0].endswith("tests/unit/core/test_backtrace.py")
+    assert actual[0].endswith("tests/unit/core/test_backtrace.py")


### PR DESCRIPTION
When a frame of the stack is from an eval call, there
is no module.