### PR TITLE
Update elasticsearch testing for v8.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
 
     services:
       elasticsearch:
-        image: elasticsearch:7.10.1
+        image: elasticsearch:8.2.3
         ports:
         - 9200:9200
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,57 @@ on:
     - cron: '44 2 * * *'
 
 jobs:
+  tests-ubuntu-latest:
+    name: Python ${{ matrix.python-version }} Ubuntu Latest
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+        - "3.6"
+        - "3.7"
+        - "3.8"
+        - "3.9"
+        - "3.10"
+
+    services:
+      elasticsearch:
+        image: elasticsearch:8.2.3
+        ports:
+        - 9200:9200
+        env:
+          discovery.type: single-node
+
+      mongodb:
+        image: mongo:4
+        ports:
+        - 27017:27017
+
+      redis:
+        image: redis:6
+        ports:
+        - 6379:6379
+
+    env:
+      ELASTICSEARCH_URL: http://localhost:9200/
+      MONGODB_URL: mongodb://localhost:27017/
+      REDIS_URL: redis://localhost:6379/0
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Upgrade packaging tools
+      run: python -m pip install --upgrade pip setuptools virtualenv
+    - name: Install dependencies
+      run: python -m pip install --upgrade tox
+    - name: Run tox targets for ${{ matrix.python-version }}
+      run: |
+        ENV_PREFIX=$(tr -C -d "0-9" <<< "${{ matrix.python-version }}" | cut -c -3)
+        TOXENV=$(tox --listenvs | grep "^py$ENV_PREFIX" | tr '\n' ',') python -m tox
+
   tests-ubuntu-20:
     name: Python ${{ matrix.python-version }} Ubuntu 20
     runs-on: ubuntu-20.04
@@ -21,15 +72,10 @@ jobs:
         python-version:
         - "2.7"
         - "3.5"
-        - "3.6"
-        - "3.7"
-        - "3.8"
-        - "3.9"
-        - "3.10"
 
     services:
       elasticsearch:
-        image: elasticsearch:8.2.3
+        image: elasticsearch:7.10.1
         ports:
         - 9200:9200
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,7 @@ jobs:
         - 9200:9200
         env:
           discovery.type: single-node
+          xpack.security.enabled: false
 
       mongodb:
         image: mongo:4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 - Added Django 4.1 to the testing matrix.
+- Added support for Elasticsearch v8+.
+  ([Issue 725](https://github.com/scoutapp/scout_apm_python/issues/725))
 
 ### Fixed
 - Catch SIGQUIT and SIGTERM errors when running core agent. They will now

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -70,7 +70,7 @@ by environment variables. These are:
 
 * `ELASTICSEARCH_URL` - point to a running Elasticsearch instance, e.g.
   "http://localhost:9200/" . You can start it with:
-  `docker run --detach --name elasticsearch --publish 9200:9200 -e "discovery.type=single-node" elasticsearch:7.10.1` .
+  `docker run --detach --name elasticsearch --publish 9200:9200 -e "discovery.type=single-node" -e "xpack.security.enabled=false" elasticsearch:8.2.3` .
 * `MONGODB_URL` - point to a running MongoDB instance e.g.
   "mongodb://localhost:27017/" . You can start it with:
   `docker run --detach --name mongo --publish 27017:27017 mongo:4.0` .

--- a/src/scout_apm/instruments/elasticsearch.py
+++ b/src/scout_apm/instruments/elasticsearch.py
@@ -4,16 +4,25 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import logging
 from collections import namedtuple
 
+import elasticsearch
 import wrapt
 
 from scout_apm.compat import get_pos_args, unwrap_decorators
 from scout_apm.core.tracked_request import TrackedRequest
 
 try:
-    from elasticsearch import Elasticsearch, Transport
+    from elasticsearch import Elasticsearch
 except ImportError:  # pragma: no cover
     Elasticsearch = None
-    Transport = None
+
+try:
+    # Transport was moved to elastic_transport as of v8.0.0
+    from elastic_transport import Transport
+except ImportError:  # pragma: no cover
+    try:
+        from elasticsearch import Transport
+    except ImportError:  # pragma: no cover
+        Transport = None
 
 logger = logging.getLogger(__name__)
 
@@ -21,10 +30,17 @@ logger = logging.getLogger(__name__)
 def ensure_installed():
     logger.debug("Instrumenting elasticsearch.")
 
-    if Elasticsearch is None:
-        logger.debug(
-            "Couldn't import elasticsearch.Elasticsearch - probably not installed."
-        )
+    if Elasticsearch is None or Transport is None:
+        if Elasticsearch is None:
+            logger.debug(
+                "Couldn't import elasticsearch.Elasticsearch "
+                "- probably not installed."
+            )
+        if Transport is None:
+            logger.debug(
+                "Couldn't import elasticsearch.Transport or "
+                "elastic_transport.Transport - probably not installed."
+            )
     else:
         ensure_client_instrumented()
         ensure_transport_instrumented()
@@ -32,51 +48,60 @@ def ensure_installed():
 
 ClientMethod = namedtuple("ClientMethod", ["name", "takes_index_argument"])
 
-CLIENT_METHODS = [
-    ClientMethod("bulk", True),
-    ClientMethod("clear_scroll", False),
-    ClientMethod("close", False),
-    ClientMethod("close_point_in_time", False),
-    ClientMethod("count", True),
-    ClientMethod("create", True),
-    ClientMethod("delete", True),
-    ClientMethod("delete_by_query", True),
-    ClientMethod("delete_by_query_rethrottle", False),
-    ClientMethod("delete_script", False),
-    ClientMethod("exists", True),
-    ClientMethod("exists_source", True),
-    ClientMethod("explain", True),
-    ClientMethod("field_caps", True),
-    ClientMethod("get", True),
-    ClientMethod("get_script", False),
-    ClientMethod("get_script_context", False),
-    ClientMethod("get_script_languages", False),
-    ClientMethod("get_source", True),
-    ClientMethod("index", True),
-    ClientMethod("info", False),
-    ClientMethod("mget", True),
-    ClientMethod("msearch", True),
-    ClientMethod("msearch_template", True),
-    ClientMethod("mtermvectors", True),
-    ClientMethod("open_point_in_time", True),
-    ClientMethod("ping", False),
-    ClientMethod("put_script", False),
-    ClientMethod("rank_eval", True),
-    ClientMethod("reindex", False),
-    ClientMethod("reindex_rethrottle", False),
-    ClientMethod("render_search_template", False),
-    ClientMethod("scripts_painless_execute", False),
-    ClientMethod("scroll", False),
-    ClientMethod("search", True),
-    ClientMethod("search_mvt", True),
-    ClientMethod("search_shards", True),
-    ClientMethod("search_template", True),
-    ClientMethod("termvectors", True),
-    ClientMethod("terms_enum", True),
-    ClientMethod("update", True),
-    ClientMethod("update_by_query", True),
-    ClientMethod("update_by_query_rethrottle", False),
-]
+VERSIONED_CLIENT_METHODS = {
+    "v7": [
+        ClientMethod("bulk", True),
+        ClientMethod("clear_scroll", False),
+        ClientMethod("close", False),
+        ClientMethod("close_point_in_time", False),
+        ClientMethod("count", True),
+        ClientMethod("create", True),
+        ClientMethod("delete", True),
+        ClientMethod("delete_by_query", True),
+        ClientMethod("delete_by_query_rethrottle", False),
+        ClientMethod("delete_script", False),
+        ClientMethod("exists", True),
+        ClientMethod("exists_source", True),
+        ClientMethod("explain", True),
+        ClientMethod("field_caps", True),
+        ClientMethod("get", True),
+        ClientMethod("get_script", False),
+        ClientMethod("get_script_context", False),
+        ClientMethod("get_script_languages", False),
+        ClientMethod("get_source", True),
+        ClientMethod("index", True),
+        ClientMethod("info", False),
+        ClientMethod("mget", True),
+        ClientMethod("msearch", True),
+        ClientMethod("msearch_template", True),
+        ClientMethod("mtermvectors", True),
+        ClientMethod("open_point_in_time", True),
+        ClientMethod("ping", False),
+        ClientMethod("put_script", False),
+        ClientMethod("rank_eval", True),
+        ClientMethod("reindex", False),
+        ClientMethod("reindex_rethrottle", False),
+        ClientMethod("render_search_template", False),
+        ClientMethod("scripts_painless_execute", False),
+        ClientMethod("scroll", False),
+        ClientMethod("search", True),
+        ClientMethod("search_mvt", True),
+        ClientMethod("search_shards", True),
+        ClientMethod("search_template", True),
+        ClientMethod("termvectors", True),
+        ClientMethod("terms_enum", True),
+        ClientMethod("update", True),
+        ClientMethod("update_by_query", True),
+        ClientMethod("update_by_query_rethrottle", False),
+    ],
+    "v8": [
+        ClientMethod("knn_search", True),
+    ],
+}
+
+CLIENT_METHODS = VERSIONED_CLIENT_METHODS["v7"][:]
+if elasticsearch.VERSION > (8, 0, 0):
+    CLIENT_METHODS += VERSIONED_CLIENT_METHODS["v8"]
 
 
 have_patched_client = False
@@ -185,8 +210,11 @@ def _sanitize_name(name):
             "bench",
             "bulk",
             "count",
+            "delete_by_query",
+            "execute",
             "exists",
             "explain",
+            "field_caps",
             "field_stats",
             "health",
             "mget",
@@ -195,14 +223,21 @@ def _sanitize_name(name):
             "msearch",
             "mtermvectors",
             "percolate",
+            "pit",
             "query",
+            "rank_eval",
+            "reindex",
+            "script_context",
+            "script_language",
             "scroll",
             "search_shards",
             "source",
             "suggest",
             "template",
             "termvectors",
+            "terms_enum",
             "update",
+            "update_by_query",
             "search",
         )
         if op in known_names:

--- a/tests/integration/instruments/test_elasticsearch.py
+++ b/tests/integration/instruments/test_elasticsearch.py
@@ -13,6 +13,10 @@ from scout_apm.instruments.elasticsearch import CLIENT_METHODS, ensure_installed
 from tests.compat import mock
 from tests.tools import delete_attributes, skip_if_python_2
 
+skip_if_elasticsearch_v7 = pytest.mark.skipif(
+    elasticsearch.VERSION < (8, 0, 0), reason="Requires ElasticSearch 8"
+)
+
 
 @pytest.fixture(scope="module")
 def elasticsearch_client():
@@ -186,6 +190,7 @@ def test_search_v7_api(elasticsearch_client, tracked_request):
     assert span.operation == "Elasticsearch/Unknown/Search"
 
 
+@skip_if_elasticsearch_v7
 def test_search(elasticsearch_client, tracked_request):
     elasticsearch_client.options().search()
 
@@ -261,7 +266,7 @@ def test_perform_request_missing_url(elasticsearch_client, tracked_request):
 
 
 def test_perform_request_bad_url(elasticsearch_client, tracked_request):
-    with pytest.raises(AttributeError):
+    with pytest.raises((TypeError, AttributeError)):
         # Transport instrumentation doesn't crash if url has the wrong type.
         # This raises a TypeError when calling the original method.
         elasticsearch_client.transport.perform_request("GET", None, body=None)

--- a/tests/integration/instruments/test_elasticsearch.py
+++ b/tests/integration/instruments/test_elasticsearch.py
@@ -31,8 +31,9 @@ def test_all_client_attributes_accounted_for():
     public_attributes = {
         m for m in dir(elasticsearch.Elasticsearch) if not m.startswith("_")
     }
-    deliberately_ignored_attributes = set()
+    deliberately_ignored_attributes = {"perform_request", "options", "transport"}
     wrapped_methods = {m.name for m in CLIENT_METHODS}
+
     assert (
         public_attributes - deliberately_ignored_attributes - wrapped_methods
     ) == set()
@@ -71,10 +72,13 @@ def test_ensure_installed_twice(caplog):
 
 
 def test_ensure_installed_fail_no_client(caplog):
-    mock_no_client = mock.patch(
+    mock_no_elasticsearch = mock.patch(
         "scout_apm.instruments.elasticsearch.Elasticsearch", new=None
     )
-    with mock_no_client:
+    mock_no_transport = mock.patch(
+        "scout_apm.instruments.elasticsearch.Transport", new=None
+    )
+    with mock_no_elasticsearch, mock_no_transport:
         ensure_installed()
 
     assert caplog.record_tuples == [
@@ -87,6 +91,12 @@ def test_ensure_installed_fail_no_client(caplog):
             "scout_apm.instruments.elasticsearch",
             logging.DEBUG,
             "Couldn't import elasticsearch.Elasticsearch - probably not installed.",
+        ),
+        (
+            "scout_apm.instruments.elasticsearch",
+            logging.DEBUG,
+            "Couldn't import elasticsearch.Transport or elastic_transport.Transport "
+            "- probably not installed.",
         ),
     ]
 
@@ -168,8 +178,16 @@ def test_ping(elasticsearch_client, tracked_request):
     assert span.operation == "Elasticsearch/Ping"
 
 
-def test_search(elasticsearch_client, tracked_request):
+def test_search_v7_api(elasticsearch_client, tracked_request):
     elasticsearch_client.search()
+
+    assert len(tracked_request.complete_spans) == 1
+    span = tracked_request.complete_spans[0]
+    assert span.operation == "Elasticsearch/Unknown/Search"
+
+
+def test_search(elasticsearch_client, tracked_request):
+    elasticsearch_client.options().search()
 
     assert len(tracked_request.complete_spans) == 1
     span = tracked_request.complete_spans[0]
@@ -232,9 +250,10 @@ def test_search_kwarg_index_list(elasticsearch_client, tracked_request):
 
 def test_perform_request_missing_url(elasticsearch_client, tracked_request):
     # Check Transport instrumentation doesn't crash if url is missing.
-    # This raises a TypeError when calling the original method.
-    with pytest.raises(TypeError):
-        elasticsearch_client.transport.perform_request("GET", params={}, body=None)
+    # This raises a TypeError and AttributeError when calling the original
+    # method.
+    with pytest.raises((TypeError, AttributeError)):
+        elasticsearch_client.transport.perform_request("GET", body=None)
 
     assert len(tracked_request.complete_spans) == 1
     span = tracked_request.complete_spans[0]
@@ -242,12 +261,10 @@ def test_perform_request_missing_url(elasticsearch_client, tracked_request):
 
 
 def test_perform_request_bad_url(elasticsearch_client, tracked_request):
-    with pytest.raises(TypeError):
+    with pytest.raises(AttributeError):
         # Transport instrumentation doesn't crash if url has the wrong type.
         # This raises a TypeError when calling the original method.
-        elasticsearch_client.transport.perform_request(
-            "GET", None, params={}, body=None
-        )
+        elasticsearch_client.transport.perform_request("GET", None, body=None)
 
     assert len(tracked_request.complete_spans) == 1
     span = tracked_request.complete_spans[0]
@@ -256,9 +273,7 @@ def test_perform_request_bad_url(elasticsearch_client, tracked_request):
 
 def test_perform_request_unknown_url(elasticsearch_client, tracked_request):
     # Transport instrumentation doesn't crash if url is unknown.
-    elasticsearch_client.transport.perform_request(
-        "GET", "/_nodes", params={}, body=None
-    )
+    elasticsearch_client.transport.perform_request("GET", "/_nodes", body=None)
 
     assert len(tracked_request.complete_spans) == 1
     span = tracked_request.complete_spans[0]
@@ -267,9 +282,7 @@ def test_perform_request_unknown_url(elasticsearch_client, tracked_request):
 
 def test_perform_request_known_url(elasticsearch_client, tracked_request):
     # Transport instrumentation doesn't crash if url is unknown.
-    elasticsearch_client.transport.perform_request(
-        "GET", "/_count", params={}, body=None
-    )
+    elasticsearch_client.transport.perform_request("GET", "/_count", body=None)
 
     assert len(tracked_request.complete_spans) == 1
     span = tracked_request.complete_spans[0]

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,8 @@ deps =
     django41: Django>4.0,<4.2
     django41: djangorestframework
     dramatiq>=1.0.0 ; python_version >= "3.5"
-    elasticsearch<8.0.0
+    elasticsearch<8.0.0; python_version <= "3.5"
+    elasticsearch ; python_version > "3.5"
     falcon
     flask
     flask-sqlalchemy


### PR DESCRIPTION
Transport was moved to elastic_transport. Check there first
and fallback to elasticsearch if it's not there.

Updates the development docs to contain instructions on running
elasticsearch v8.

Closes #725