### PR TITLE
Deprecation notice about urllib3[secure]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,8 +65,6 @@ setup(
         'contextvars ; python_version >= "3.6" and python_version < "3.7"',
         'importlib-metadata ; python_version < "3.8"',
         "psutil>=5,<6",
-        'urllib3[secure] < 1.25 ; python_version < "3.5"',
-        'urllib3[secure] < 2 ; python_version >= "3.5"',
         "wrapt>=1.10,<2.0",
     ],
     keywords=["apm", "performance monitoring", "development"],

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
         'contextvars ; python_version >= "3.6" and python_version < "3.7"',
         'importlib-metadata ; python_version < "3.8"',
         "psutil>=5,<6",
-        'urllib3 < 1.25 ; python_version < "3.5"',
+        'urllib3[secure] < 1.25 ; python_version < "3.5"',
         'urllib3 < 2 ; python_version >= "3.5"',
         "wrapt>=1.10,<2.0",
     ],

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,8 @@ setup(
         'contextvars ; python_version >= "3.6" and python_version < "3.7"',
         'importlib-metadata ; python_version < "3.8"',
         "psutil>=5,<6",
+        'urllib3 < 1.25 ; python_version < "3.5"',
+        'urllib3 < 2 ; python_version >= "3.5"',
         "wrapt>=1.10,<2.0",
     ],
     keywords=["apm", "performance monitoring", "development"],


### PR DESCRIPTION
 ### Description

 pyOpenSSL and urllib3[secure] are deprecated in the upcoming release (1.26.12)
 https://github.com/urllib3/urllib3/issues/2680
 Removed 'urllib3[secure] < 1.25 ; python_version < "3.5"' and  'urllib3[secure] < 2 ; python_version >= "3.5"'

Closes #746