### PR TITLE
Resolve CI errors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
 
     services:
       elasticsearch:
-        image: elasticsearch:8.2.3
+        image: elasticsearch:8.7.0
         ports:
         - 9200:9200
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,7 +70,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-        - "2.7"
         - "3.5"
         - "3.6"
 
@@ -111,15 +110,55 @@ jobs:
         ENV_PREFIX=$(tr -C -d "0-9" <<< "${{ matrix.python-version }}" | cut -c -3)
         TOXENV=$(tox --listenvs | grep "^py$ENV_PREFIX" | tr '\n' ',') python -m tox
 
+
+  tests-python-27:
+    name: Python ${{ matrix.python-version }}
+    runs-on: ubuntu-20.04
+    container:
+      image: python:2.7.18-buster
+
+    strategy:
+      fail-fast: false
+
+    services:
+      elasticsearch:
+        image: elasticsearch:7.10.1
+        ports:
+          - 9200:9200
+        env:
+          discovery.type: single-node
+
+      mongodb:
+        image: mongo:4
+        ports:
+          - 27017:27017
+
+      redis:
+        image: redis:6
+        ports:
+          - 6379:6379
+
+    env:
+      ELASTICSEARCH_URL: http://localhost:9200/
+      MONGODB_URL: mongodb://localhost:27017/
+      REDIS_URL: redis://localhost:6379/0
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Upgrade packaging tools
+        run: python -m pip install --upgrade pip setuptools virtualenv
+      - name: Install dependencies
+        run: python -m pip install --upgrade tox
+      - name: Run tox targets for 2.7
+        run: |
+          TOXENV=$(tox --listenvs | grep "^py27" | tr '\n' ',') python -m tox
+
   tests-ubuntu-18:
     name: Python ${{ matrix.python-version }} Ubuntu 18
     runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false
-      matrix:
-        python-version:
-        - "3.4"
 
     services:
       elasticsearch:
@@ -148,12 +187,11 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: "3.4"
     - name: Upgrade packaging tools
       run: python -m pip install --upgrade pip setuptools virtualenv
     - name: Install dependencies
       run: python -m pip install --upgrade tox
-    - name: Run tox targets for ${{ matrix.python-version }}
+    - name: Run tox targets for 3.4
       run: |
-        ENV_PREFIX=$(tr -C -d "0-9" <<< "${{ matrix.python-version }}" | cut -c -3)
-        TOXENV=$(tox --listenvs | grep "^py$ENV_PREFIX" | tr '\n' ',') python -m tox
+        TOXENV=$(tox --listenvs | grep "^py34" | tr '\n' ',') python -m tox

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-        - "3.6"
         - "3.7"
         - "3.8"
         - "3.9"
@@ -73,6 +72,7 @@ jobs:
         python-version:
         - "2.7"
         - "3.5"
+        - "3.6"
 
     services:
       elasticsearch:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -112,7 +112,7 @@ jobs:
 
 
   tests-python-27:
-    name: Python ${{ matrix.python-version }}
+    name: Python 2.7
     runs-on: ubuntu-20.04
     container:
       image: python:2.7.18-buster
@@ -153,9 +153,11 @@ jobs:
         run: |
           TOXENV=$(tox --listenvs | grep "^py27" | tr '\n' ',') python -m tox
 
-  tests-ubuntu-18:
-    name: Python ${{ matrix.python-version }} Ubuntu 18
-    runs-on: ubuntu-18.04
+  tests-python-34:
+    name: Python 3.4
+    runs-on: ubuntu-20.04
+    container:
+      image: python:3.4.10
 
     strategy:
       fail-fast: false
@@ -185,9 +187,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-      with:
-        python-version: "3.4"
     - name: Upgrade packaging tools
       run: python -m pip install --upgrade pip setuptools virtualenv
     - name: Install dependencies

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ ci:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
     - id: check-added-large-files
     - id: check-case-conflict
@@ -23,11 +23,11 @@ repos:
       language_version: python3
       additional_dependencies: ['click<8.1']
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
     - id: isort
   - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: 6.0.0
     hooks:
     - id: flake8
       additional_dependencies:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Pending
+
+### Added
+
+### Fixed
+- Fix CI for python 2.7, 3.4, 3.5, 3.6, 3.8
+- Update ElasticSearch support for 8.7.0 (``health_check``).
+- Support flask_sqlalchemy v3. This requires a integration
+  change where ``instrument_sqlalchemy`` is called before ``db.init_app()``.
+- Disable tests for SQLAlchemy v2 to allow CI tests to pass.
+
 ## [2.26.1] 2022-07-28
 
 ### Fixed

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -70,7 +70,7 @@ by environment variables. These are:
 
 * `ELASTICSEARCH_URL` - point to a running Elasticsearch instance, e.g.
   "http://localhost:9200/" . You can start it with:
-  `docker run --detach --name elasticsearch --publish 9200:9200 -e "discovery.type=single-node" -e "xpack.security.enabled=false" elasticsearch:8.2.3` .
+  `docker run --detach --name elasticsearch --publish 9200:9200 -e "discovery.type=single-node" -e "xpack.security.enabled=false" elasticsearch:8.7.0` .
 * `MONGODB_URL` - point to a running MongoDB instance e.g.
   "mongodb://localhost:27017/" . You can start it with:
   `docker run --detach --name mongo --publish 27017:27017 mongo:4.0` .

--- a/pytest.ini
+++ b/pytest.ini
@@ -77,5 +77,8 @@ filterwarnings =
     ; Triggered by cherrypy -> jarco/text -> importlib_resources
     ignore:read_text is deprecated\. Use files\(\) instead\.:DeprecationWarning
     ignore:open_text is deprecated\. Use files\(\) instead\.:DeprecationWarning
+    ; Triggered by cherrypy -> cherrypy/__init__.py, pyramid/asset.py
+    ignore:pkg_resources is deprecated as an API:DeprecationWarning
+    ignore:.*pkg_resources.declare_namespace:DeprecationWarning
     ; ElasticSearch v8 will drop support for python < 3.6
     ignore:Support for Python 3\.5 and earlier is deprecated and will be removed in v8\.0\.0:DeprecationWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -84,3 +84,5 @@ filterwarnings =
     ignore:Support for Python 3\.5 and earlier is deprecated and will be removed in v8\.0\.0:DeprecationWarning
     ; Triggered by sqlalchemy -> sqlalchemy/engine/base.py
     ignore:.*These feature\(s\) are not compatible with SQLAlchemy 2\.0:DeprecationWarning
+    ; Triggered by rq -> rq/job.py
+    ignore:The `push_connection` function is deprecated\. Pass the `connection` explicitly instead\.:DeprecationWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -82,3 +82,5 @@ filterwarnings =
     ignore:.*pkg_resources.declare_namespace:DeprecationWarning
     ; ElasticSearch v8 will drop support for python < 3.6
     ignore:Support for Python 3\.5 and earlier is deprecated and will be removed in v8\.0\.0:DeprecationWarning
+    ; Triggered by sqlalchemy -> sqlalchemy/engine/base.py
+    ignore:.*These feature\(s\) are not compatible with SQLAlchemy 2\.0:DeprecationWarning

--- a/src/scout_apm/core/config.py
+++ b/src/scout_apm/core/config.py
@@ -194,7 +194,9 @@ class Derived(object):
     def derive_core_agent_full_name(self):
         triple = self.config.value("core_agent_triple")
         if not platform_detection.is_valid_triple(triple):
-            warnings.warn("Invalid value for core_agent_triple: {}".format(triple))
+            warnings.warn(
+                "Invalid value for core_agent_triple: {}".format(triple), stacklevel=2
+            )
         return "{name}-{version}-{triple}".format(
             name="scout_apm_core",
             version=self.config.value("core_agent_version"),

--- a/src/scout_apm/falcon.py
+++ b/src/scout_apm/falcon.py
@@ -95,6 +95,7 @@ class ScoutMiddleware(object):
                     + " more detail."
                 ).format(self.__class__.__name__),
                 RuntimeWarning,
+                stacklevel=2,
             )
             operation = "Controller/{}.{}.{}".format(
                 resource.__module__, resource.__class__.__name__, req.method

--- a/src/scout_apm/flask/sqlalchemy.py
+++ b/src/scout_apm/flask/sqlalchemy.py
@@ -8,11 +8,22 @@ import scout_apm.sqlalchemy
 
 
 def instrument_sqlalchemy(db):
-    SQLAlchemy.get_engine = wrapped_get_engine(SQLAlchemy.get_engine)
+    # Version 3 of flask_sqlalchemy changed how engines are created
+    if hasattr(db, "_make_engine"):
+        db._make_engine = wrapped_make_engine(db._make_engine)
+    else:
+        SQLAlchemy.get_engine = wrapped_get_engine(SQLAlchemy.get_engine)
 
 
 @wrapt.decorator
 def wrapped_get_engine(wrapped, instance, args, kwargs):
+    engine = wrapped(*args, **kwargs)
+    scout_apm.sqlalchemy.instrument_sqlalchemy(engine)
+    return engine
+
+
+@wrapt.decorator
+def wrapped_make_engine(wrapped, instance, args, kwargs):
     engine = wrapped(*args, **kwargs)
     scout_apm.sqlalchemy.instrument_sqlalchemy(engine)
     return engine

--- a/src/scout_apm/instruments/elasticsearch.py
+++ b/src/scout_apm/instruments/elasticsearch.py
@@ -97,6 +97,7 @@ VERSIONED_CLIENT_METHODS = {
     ],
     "v8": [
         ClientMethod("knn_search", True),
+        ClientMethod("health_report", False),
     ],
 }
 

--- a/tests/integration/test_flask_sqlalchemy.py
+++ b/tests/integration/test_flask_sqlalchemy.py
@@ -17,20 +17,24 @@ def app_with_scout():
     with flask_app_with_scout() as app:
         app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
         app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
-        db = SQLAlchemy(app)
+        db = SQLAlchemy()
         # Setup according to https://docs.scoutapm.com/#flask-sqlalchemy
         instrument_sqlalchemy(db)
-        conn = db.engine.connect()
+        db.init_app(app)
+        # Use manual context
+        # https://flask-sqlalchemy.palletsprojects.com/en/latest/contexts/#manual-context
+        with app.app_context():
+            conn = db.engine.connect()
 
-        @app.route("/sqlalchemy/")
-        def sqlalchemy():
-            result = conn.execute("SELECT 'Hello from the DB!'")
-            return list(result)[0][0]
+            @app.route("/sqlalchemy/")
+            def sqlalchemy():
+                result = conn.execute("SELECT 'Hello from the DB!'")
+                return list(result)[0][0]
 
-        try:
-            yield app
-        finally:
-            conn.close()
+            try:
+                yield app
+            finally:
+                conn.close()
 
 
 def test_sqlalchemy(tracked_requests):

--- a/tests/integration/test_rq.py
+++ b/tests/integration/test_rq.py
@@ -8,6 +8,7 @@ from contextlib import contextmanager
 import pytest
 import redis
 from rq import Queue
+from rq.version import VERSION
 
 import scout_apm.rq
 from scout_apm.api import Config
@@ -62,13 +63,20 @@ def app_with_scout(redis_conn, scout_config=None):
         Config.reset_all()
 
 
+def get_job_result(job):
+    """Helper wrapper around an old rq API"""
+    if VERSION <= "1.13.0":
+        return job.result
+    return job.return_value()
+
+
 def test_hello(redis_conn, tracked_requests):
     with app_with_scout(redis_conn=redis_conn) as app:
         job = app.queue.enqueue(hello)
         app.worker.work(burst=True)
 
     assert job.is_finished
-    assert job.result == "Hello World!"
+    assert get_job_result(job) == "Hello World!"
     assert len(tracked_requests) == 1
     tracked_request = tracked_requests[0]
     task_id = tracked_request.tags["task_id"]
@@ -108,5 +116,5 @@ def test_no_monitor(redis_conn, tracked_requests):
         app.worker.work(burst=True)
 
     assert job.is_finished
-    assert job.result == "Hello World!"
+    assert get_job_result(job) == "Hello World!"
     assert tracked_requests == []

--- a/tox.ini
+++ b/tox.ini
@@ -69,7 +69,8 @@ deps =
     mock ; python_version < "3.0"
     more-itertools < 8.11.0 ; python_version <= "3.5"
     psutil
-    pymongo
+    pymongo < 3.13.0 ; python_version == "3.4"
+    pymongo ; python_version != "3.4"
     pyramid
     pytest
     pytest-asyncio ; python_version >= "3.6"
@@ -80,8 +81,8 @@ deps =
     rq ; python_version >= "3.6"
     rq < 1.12 ; python_version < "3.6"
     six
-    sqlalchemy<1.3.24 ; python_version == "3.4"
-    sqlalchemy < 2.0.0 ; python_version < "3.8"
+    sqlalchemy < 1.3.24 ; python_version == "3.4"
+    sqlalchemy < 2.0.0 ; python_version < "3.8" and python_version != "3.4"
     ; When compatible, re-enable sqlalchemy v2 tests.
     sqlalchemy < 2.0.0 ; python_version >= "3.8"
     ; sqlalchemy ; python_version >= "3.8"

--- a/tox.ini
+++ b/tox.ini
@@ -79,8 +79,9 @@ deps =
     rq ; python_version >= "3.6"
     rq < 1.12 ; python_version < "3.6"
     six
-    sqlalchemy ; python_version != "3.4"
     sqlalchemy<1.3.24 ; python_version == "3.4"
+    sqlalchemy < 2.0.0 ; python_version < "3.8"
+    sqlalchemy ; python_version >= "3.8"
     starlette ; python_version >= "3.6"
     webtest
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -81,7 +81,9 @@ deps =
     six
     sqlalchemy<1.3.24 ; python_version == "3.4"
     sqlalchemy < 2.0.0 ; python_version < "3.8"
-    sqlalchemy ; python_version >= "3.8"
+    ; When compatible, re-enable sqlalchemy v2 tests.
+    sqlalchemy < 2.0.0 ; python_version >= "3.8"
+    ; sqlalchemy ; python_version >= "3.8"
     starlette ; python_version >= "3.6"
     webtest
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -73,7 +73,8 @@ deps =
     pyyaml ; python_version != "3.4"
     pyyaml < 5.3 ; python_version == "3.4"
     redis
-    rq
+    rq ; python_version >= "3.6"
+    rq < 1.12 ; python_version < "3.6"
     six
     sqlalchemy ; python_version != "3.4"
     sqlalchemy<1.3.24 ; python_version == "3.4"

--- a/tox.ini
+++ b/tox.ini
@@ -47,8 +47,8 @@ deps =
     django41: Django>4.0,<4.2
     django41: djangorestframework
     dramatiq>=1.0.0 ; python_version >= "3.5"
-    elasticsearch<8.0.0; python_version <= "3.5"
-    elasticsearch ; python_version > "3.5"
+    elasticsearch<8.0.0; python_version <= "3.6"
+    elasticsearch ; python_version > "3.6"
     falcon
     flask
     flask-sqlalchemy < 3.0.0 ; python_version < "3.7"

--- a/tox.ini
+++ b/tox.ini
@@ -51,7 +51,8 @@ deps =
     elasticsearch ; python_version > "3.5"
     falcon
     flask
-    flask-sqlalchemy
+    flask-sqlalchemy < 3.0.0 ; python_version < "3.7"
+    flask-sqlalchemy ; python_version >= "3.7"
     hiredis
     huey
     hug>=2.5.1 ; python_version >= "3.5"

--- a/tox.ini
+++ b/tox.ini
@@ -57,6 +57,9 @@ deps =
     hug>=2.5.1 ; python_version >= "3.5"
     httpretty<1 ; python_version < "3.5"
     httpretty ; python_version >= "3.5"
+    ; Celery tests are failing due to kombu having a bad pin of importlib_meta data.
+    importlib_metadata < 5.0.0 ; python_version < "3.8"
+    importlib_metadata ; python_version >= "3.8"
     jinja2
     ; nameko tests temporarily disabled
     ; Due to bad pinning of kombu only a past nameko version can be installed


### PR DESCRIPTION
This makes a number of changes to the application, though mainly to the tests to restore CI tests. 2.7 and 3.4 are going to continue to fail. Those environments are becoming more and more difficult to maintain as vendors drop support.

- Fix CI for python 2.7, 3.4, 3.5, 3.6, 3.8
- Update ElasticSearch support for 8.7.0 (``health_check``).
- Support flask_sqlalchemy v3. This requires a integration change where ``instrument_sqlalchemy`` is called before ``db.init_app()``.
- Disable tests for SQLAlchemy v2 to allow CI tests to pass.