### PR TITLE
764 update agent to fully support python 311

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -48,3 +48,4 @@ filterwarnings =
     ignore:open_text is deprecated\. Use files\(\) instead\.:DeprecationWarning
     ; ElasticSearch v8 will drop support for python < 3.6
     ignore:Support for Python 3\.5 and earlier is deprecated and will be removed in v8\.0\.0:DeprecationWarning
+    ignore:'cgi' is deprecated and slated for removal in Python 3.13

--- a/src/scout_apm/celery.py
+++ b/src/scout_apm/celery.py
@@ -8,14 +8,10 @@ from celery.signals import before_task_publish, task_failure, task_postrun, task
 
 try:
     import django
+    from django.views.debug import SafeExceptionReporterFilter
 
-    if django.VERSION < (3, 1):
-        from django.views.debug import get_safe_settings
-    else:
-        from django.views.debug import SafeExceptionReporterFilter
-
-        def get_safe_settings():
-            return SafeExceptionReporterFilter().get_safe_settings()
+    def get_safe_settings():
+        return SafeExceptionReporterFilter().get_safe_settings()
 
 except ImportError:
     # Django not installed

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import logging
 import os
+from functools import partial
 
 import celery
 import psutil
@@ -257,7 +258,7 @@ def error_monitor_errors(request):
             return wrapped(*args, **kwargs)
 
     orig = ErrorServiceThread.send
-    ErrorServiceThread.send = capture_error(orig)
+    ErrorServiceThread.send = partial(capture_error(orig))
     try:
         yield errors
     finally:

--- a/tests/unit/core/test_objtrace.py
+++ b/tests/unit/core/test_objtrace.py
@@ -54,20 +54,18 @@ def test_get_counts_allocations():
 
 
 @skip_if_objtrace_not_extension
-@pytest.mark.skipif(
-    sys.version_info < (3, 5), reason="Multiple allocations on Python 3.5+ only"
-)
 def test_get_counts_multiple_allocations():
     objtrace.enable()
     bytes(123)
+    bytes(456)
     counts = objtrace.get_counts()
     assert counts[1] > 0
 
 
 @skip_if_objtrace_not_extension
 @pytest.mark.skipif(
-    sys.version_info < (3, 5),
-    reason="For some reason can only force a realloc on Python 3.5+",
+    sys.version_info >= (3, 11),
+    reason="For some reason can only force a realloc on Python > 3.5 and < 3.11",
 )
 def test_get_counts_reallocations():
     text = "some text"

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,7 @@
 [tox]
 isolated_build = True
 envlist =
-    {py38,py39,py310}-django32
-    {py38,py39,py310}-django{40,41}
+    {py38,py39,py310,py311}-django{40,41,42}
 
 [testenv]
 passenv =
@@ -21,7 +20,8 @@ deps =
     django41: Django>4.0,<4.2
     django41: djangorestframework
     django41: django-tastypie
-    django42: Django>4.2,<4.3
+    django42: Django>=4.2,<4.3
+    django42: djangorestframework
     dramatiq>=1.0.0
     elasticsearch
     falcon
@@ -48,6 +48,6 @@ commands =
     pytest {posargs}
 
 # For newer versions of python use --asyncio-mode=auto usage.
-[testenv:py{38,39,310}-django{32,40,41}]
+[testenv:py{38,39,310,311}-django{32,40,41,42}]
 commands =
     pytest {posargs} --asyncio-mode=auto


### PR DESCRIPTION
This PR adds py311 to tox environments and fixes a couple small issues.
## Changes
- Test fixture to mock `ErrorServiceThread.send`. For some reason in 3.11, the return type of the wrapper wasn't callable, so invoking `ErrorServiceThread.send` threw `AttributeError: 'method' object has no attribute __get__`. This fix is backwards compatible and works with previous python versions.
- Similar to <py35, in py311 you can't force memory reallocations, so the conditional skip for that test was updated to skip >=3.11.