### PR TITLE
remove in-code python version checks

### DIFF
--- a/src/scout_apm/celery.py
+++ b/src/scout_apm/celery.py
@@ -18,7 +18,7 @@ except ImportError:
     get_safe_settings = None
 
 import scout_apm.core
-from scout_apm.compat import datetime_to_timestamp, string_type
+from scout_apm.compat import datetime_to_timestamp
 from scout_apm.core.config import scout_config
 from scout_apm.core.error import ErrorMonitor
 from scout_apm.core.tracked_request import TrackedRequest
@@ -110,9 +110,7 @@ def task_failure_callback(
     # Celery occassionally will send the traceback as a string rather
     # than a Stack trace object as the docs indicate. In that case,
     # fall back to the billiard ExceptionInfo instance
-    traceback = (
-        traceback if traceback and not isinstance(traceback, string_type) else einfo.tb
-    )
+    traceback = traceback if traceback and not isinstance(traceback, str) else einfo.tb
     exc_info = (exception.__class__, exception, traceback)
     ErrorMonitor.send(
         exc_info,

--- a/src/scout_apm/compat.py
+++ b/src/scout_apm/compat.py
@@ -4,99 +4,39 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import datetime as dt
 import gzip
 import inspect
-import sys
+import queue
+from contextlib import ContextDecorator
 from functools import wraps
+from html import escape
+from urllib.parse import parse_qsl, urlencode, urljoin
 
 import certifi
 import urllib3
 
-string_type = str if sys.version_info[0] >= 3 else basestring  # noqa: F821
-text_type = str if sys.version_info[0] >= 3 else unicode  # noqa: F821
-string_types = tuple({string_type, text_type})
 
-if sys.version_info >= (3,):
+def iteritems(dictionary):
+    return dictionary.items()
 
-    def iteritems(dictionary):
-        return dictionary.items()
-
-else:
-
-    def iteritems(dictionary):
-        return dictionary.iteritems()  # noqa: B301
-
-
-# open() raises OSError, or a specific subclass, on Python 3+
-if sys.version_info >= (3, 3):
-    CouldNotOpenFile = OSError
-else:
-    CouldNotOpenFile = IOError
-
-if sys.version_info >= (3, 2):
-    from contextlib import ContextDecorator
-else:
-
-    class ContextDecorator(object):
-        def _recreate_cm(self):
-            return self
-
-        def __call__(self, f):
-            @wraps(f)
-            def decorated(*args, **kwds):
-                with self._recreate_cm():
-                    return f(*args, **kwds)
-
-            return decorated
-
-
-if sys.version_info >= (3, 0):
-    import queue
-else:
-    import Queue as queue
 
 # datetime_to_timestamp converts a naive UTC datetime to a unix timestamp
-if sys.version_info >= (3, 3):
-
-    def datetime_to_timestamp(datetime_obj):
-        return datetime_obj.replace(tzinfo=dt.timezone.utc).timestamp()
-
-else:
-    _EPOCH = dt.datetime(1970, 1, 1)
-
-    def datetime_to_timestamp(datetime_obj):
-        return (datetime_obj - _EPOCH).total_seconds()
+def datetime_to_timestamp(datetime_obj):
+    return datetime_obj.replace(tzinfo=dt.timezone.utc).timestamp()
 
 
 def text(value, encoding="utf-8", errors="strict"):
     """
     Convert a value to str on Python 3 and unicode on Python 2.
     """
-    if isinstance(value, text_type):
+    if isinstance(value, str):
         return value
     elif isinstance(value, bytes):
-        return text_type(value, encoding, errors)
+        return str(value, encoding, errors)
     else:
-        return text_type(value)
+        return str(value)
 
 
-if sys.version_info >= (3, 0):
-    from html import escape
-    from urllib.parse import parse_qsl, urlencode, urljoin
-else:
-    from cgi import escape
-    from urllib import urlencode
-
-    from urlparse import parse_qsl, urljoin
-
-
-if sys.version_info >= (3, 0):
-
-    def get_pos_args(func):
-        return inspect.getfullargspec(func).args
-
-else:
-
-    def get_pos_args(func):
-        return inspect.getargspec(func).args
+def get_pos_args(func):
+    return inspect.getfullargspec(func).args
 
 
 def unwrap_decorators(func):
@@ -144,27 +84,11 @@ def kwargs_only(func):
 
 
 def urllib3_cert_pool_manager(**kwargs):
-    if sys.version_info >= (3, 0):
-        CERT_REQUIRED = "CERT_REQUIRED"
-    else:
-        CERT_REQUIRED = b"CERT_REQUIRED"
-    return urllib3.PoolManager(cert_reqs=CERT_REQUIRED, ca_certs=certifi.where())
+    return urllib3.PoolManager(cert_reqs="CERT_REQUIRED", ca_certs=certifi.where())
 
 
-if sys.version_info >= (3, 2):
-
-    def gzip_compress(data):
-        return gzip.compress(data)
-
-else:
-    import io
-
-    def gzip_compress(data):
-        """Reimplementation gzip.compress for python 2.7"""
-        buf = io.BytesIO()
-        with gzip.GzipFile(fileobj=buf, mode="w") as f:
-            f.write(data)
-        return buf.getvalue()
+def gzip_compress(data):
+    return gzip.compress(data)
 
 
 __all__ = [
@@ -175,9 +99,7 @@ __all__ = [
     "kwargs_only",
     "parse_qsl",
     "queue",
-    "string_type",
     "text",
-    "text_type",
     "urlencode",
     "urljoin",
 ]

--- a/src/scout_apm/core/agent/manager.py
+++ b/src/scout_apm/core/agent/manager.py
@@ -13,7 +13,7 @@ import time
 
 from urllib3.exceptions import HTTPError
 
-from scout_apm.compat import CouldNotOpenFile, text_type, urllib3_cert_pool_manager
+from scout_apm.compat import urllib3_cert_pool_manager
 from scout_apm.core.config import scout_config
 
 logger = logging.getLogger(__name__)
@@ -242,7 +242,7 @@ class CoreAgentDownloader(object):
 def parse_manifest(path):
     try:
         manifest_file = open(path)
-    except CouldNotOpenFile as exc:
+    except OSError as exc:
         if exc.errno == errno.ENOENT:
             logger.debug("Core Agent Manifest does not exist at %s", path)
         else:
@@ -255,13 +255,13 @@ def parse_manifest(path):
             logger.debug("Core Agent manifest json: %s", data)
 
             bin_name = data["core_agent_binary"]
-            if not isinstance(bin_name, text_type):
+            if not isinstance(bin_name, str):
                 raise TypeError("core_agent_binary should be a string.")
             bin_version = data["core_agent_version"]
-            if not isinstance(bin_version, text_type):
+            if not isinstance(bin_version, str):
                 raise TypeError("core_agent_version should be a string.")
             sha256 = data["core_agent_binary_sha256"]
-            if not isinstance(sha256, text_type):
+            if not isinstance(sha256, str):
                 raise TypeError("core_agent_binary_sha256 should be a string.")
 
             return CoreAgentManifest(
@@ -297,7 +297,7 @@ def sha256_digest(filename, block_size=65536):
         return None
 
 
-class SocketPath(text_type):
+class SocketPath(str):
     @property
     def is_tcp(self):
         return self.startswith("tcp://")

--- a/src/scout_apm/core/agent/socket.py
+++ b/src/scout_apm/core/agent/socket.py
@@ -6,7 +6,6 @@ import logging
 import os
 import socket
 import struct
-import sys
 import threading
 import time
 
@@ -209,7 +208,5 @@ class CoreAgentSocketThread(SingletonThread):
     def get_socket_address(self):
         if self.socket_path.is_tcp:
             host, _, port = self.socket_path.tcp_address.partition(":")
-            if sys.version_info[0] == 2:
-                host = bytes(host)
             return host, int(port)
         return self.socket_path

--- a/src/scout_apm/core/backtrace.py
+++ b/src/scout_apm/core/backtrace.py
@@ -66,77 +66,36 @@ def filepaths(frame):
     return filepath, (module_filepath(module, filepath) if module else filepath)
 
 
-if sys.version_info >= (3, 5):
+def stacktrace_walker(tb):
+    """Iterate over each frame of the stack downards for exceptions."""
+    for frame, lineno in traceback.walk_tb(tb):
+        name = frame.f_code.co_name
+        full_path, relative_path = filepaths(frame)
+        yield {
+            "file": relative_path,
+            "full_path": full_path,
+            "line": lineno,
+            "function": name,
+        }
 
-    def stacktrace_walker(tb):
-        """Iterate over each frame of the stack downards for exceptions."""
-        for frame, lineno in traceback.walk_tb(tb):
-            name = frame.f_code.co_name
-            full_path, relative_path = filepaths(frame)
-            yield {
-                "file": relative_path,
-                "full_path": full_path,
-                "line": lineno,
-                "function": name,
-            }
 
-    def backtrace_walker():
-        """Iterate over each frame of the stack upwards.
+def backtrace_walker():
+    """Iterate over each frame of the stack upwards.
 
-        Taken from python3/traceback.ExtractSummary.extract to support
-        iterating over the entire stack, but without creating a large
-        data structure.
-        """
-        start_frame = sys._getframe().f_back
-        for frame, lineno in traceback.walk_stack(start_frame):
-            name = frame.f_code.co_name
-            full_path, relative_path = filepaths(frame)
-            yield {
-                "file": relative_path,
-                "full_path": full_path,
-                "line": lineno,
-                "function": name,
-            }
-
-else:
-
-    def stacktrace_walker(tb):
-        """Iterate over each frame of the stack downards for exceptions."""
-        while tb is not None:
-            lineno = tb.tb_lineno
-            name = tb.tb_frame.f_code.co_name
-            full_path, relative_path = filepaths(tb.tb_frame)
-            yield {
-                "file": relative_path,
-                "full_path": full_path,
-                "line": lineno,
-                "function": name,
-            }
-            tb = tb.tb_next
-
-    def backtrace_walker():
-        """Iterate over each frame of the stack upwards.
-
-        Taken from python2.7/traceback.extract_stack to support iterating
-        over the entire stack, but without creating a large data structure.
-        """
-        try:
-            raise ZeroDivisionError
-        except ZeroDivisionError:
-            # Get the current frame
-            frame = sys.exc_info()[2].tb_frame.f_back
-
-        while frame is not None:
-            lineno = frame.f_lineno
-            name = frame.f_code.co_name
-            full_path, relative_path = filepaths(frame)
-            yield {
-                "file": relative_path,
-                "full_path": full_path,
-                "line": lineno,
-                "function": name,
-            }
-            frame = frame.f_back
+    Taken from python3/traceback.ExtractSummary.extract to support
+    iterating over the entire stack, but without creating a large
+    data structure.
+    """
+    start_frame = sys._getframe().f_back
+    for frame, lineno in traceback.walk_stack(start_frame):
+        name = frame.f_code.co_name
+        full_path, relative_path = filepaths(frame)
+        yield {
+            "file": relative_path,
+            "full_path": full_path,
+            "line": lineno,
+            "function": name,
+        }
 
 
 def capture_backtrace():

--- a/src/scout_apm/core/config.py
+++ b/src/scout_apm/core/config.py
@@ -6,7 +6,6 @@ import os
 import re
 import warnings
 
-from scout_apm.compat import string_type
 from scout_apm.core import platform_detection
 
 logger = logging.getLogger(__name__)
@@ -273,7 +272,7 @@ class Null(object):
 def convert_to_bool(value):
     if isinstance(value, bool):
         return value
-    if isinstance(value, string_type):
+    if isinstance(value, str):
         return value.lower() in ("yes", "true", "t", "1")
     # Unknown type - default to false?
     return False
@@ -291,7 +290,7 @@ def convert_to_list(value):
         return value
     if isinstance(value, tuple):
         return list(value)
-    if isinstance(value, string_type):
+    if isinstance(value, str):
         # Split on commas
         return [item.strip() for item in value.split(",") if item]
     # Unknown type - default to empty?

--- a/src/scout_apm/core/error.py
+++ b/src/scout_apm/core/error.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import logging
 import os
-import sys
 
 from scout_apm.core.backtrace import capture_stacktrace
 from scout_apm.core.config import scout_config
@@ -12,7 +11,6 @@ from scout_apm.core.tracked_request import TrackedRequest
 from scout_apm.core.web_requests import RequestComponents, filter_element
 
 logger = logging.getLogger(__name__)
-text_type = str if sys.version_info[0] >= 3 else unicode  # noqa: F821
 
 
 class ErrorMonitor(object):
@@ -56,7 +54,7 @@ class ErrorMonitor(object):
         scm_subdirectory = scout_config.value("scm_subdirectory")
         error = {
             "exception_class": exc_class.__name__,
-            "message": text_type(exc_value),
+            "message": str(exc_value),
             "request_id": tracked_request.request_id,
             "request_uri": request_path,
             "request_params": filter_element("", request_params)

--- a/src/scout_apm/core/metadata.py
+++ b/src/scout_apm/core/metadata.py
@@ -47,10 +47,7 @@ def get_metadata():
 
 def get_python_packages_versions():
     try:
-        if sys.version_info >= (3, 8):
-            from importlib.metadata import distributions
-        else:
-            from importlib_metadata import distributions
+        from importlib.metadata import distributions
     except ImportError:
         # For some reason it is unavailable
         return []

--- a/src/scout_apm/core/web_requests.py
+++ b/src/scout_apm/core/web_requests.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import datetime as dt
 import time
 
-from scout_apm.compat import datetime_to_timestamp, parse_qsl, text_type, urlencode
+from scout_apm.compat import datetime_to_timestamp, parse_qsl, urlencode
 from scout_apm.core.config import scout_config
 
 # Originally derived from:
@@ -47,9 +47,9 @@ def create_filtered_path(path, query_params):
     filtered_params = sorted(
         [
             (
-                text_type(key).encode("utf-8"),
-                # Apply text_type again to cover the None case.
-                text_type(filter_element(key, value)).encode("utf-8"),
+                str(key).encode("utf-8"),
+                # Apply str again to cover the None case.
+                str(filter_element(key, value)).encode("utf-8"),
             )
             for key, value in query_params
         ]
@@ -68,7 +68,7 @@ def filter_element(key, value):
 
         filter_element('', {"foo": "bar"})
     """
-    is_sensitive = text_type(key).lower() in FILTER_PARAMETERS
+    is_sensitive = str(key).lower() in FILTER_PARAMETERS
 
     if is_sensitive:
         filtered = "[FILTERED]"
@@ -81,7 +81,7 @@ def filter_element(key, value):
         # different collection, so we have to cautiously make everything a string
         # again. Ignoring the possibilities of bytes or objects with bad __str__
         # methods because they seem very unlikely.
-        filtered = {text_type(k): filter_element(k, v) for k, v in value.items()}
+        filtered = {str(k): filter_element(k, v) for k, v in value.items()}
     elif isinstance(value, list):
         filtered = [filter_element("", v) for v in value]
     elif isinstance(value, set):
@@ -91,7 +91,7 @@ def filter_element(key, value):
     elif value is None:
         filtered = value
     else:
-        filtered = text_type(value)
+        filtered = str(value)
 
     return filtered
 

--- a/src/scout_apm/django/request.py
+++ b/src/scout_apm/django/request.py
@@ -1,7 +1,6 @@
 # coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from scout_apm.compat import string_types
 from scout_apm.core.web_requests import RequestComponents
 
 
@@ -133,7 +132,7 @@ def _get_tastypie_components(request, view_func):
         return None
 
     method_name = wrapper.__closure__[1].cell_contents
-    if not isinstance(method_name, string_types):  # pragma: no cover
+    if not isinstance(method_name, str):  # pragma: no cover
         return None
 
     if method_name.startswith("dispatch_"):  # pragma: no cover

--- a/src/scout_apm/django/request.py
+++ b/src/scout_apm/django/request.py
@@ -1,8 +1,6 @@
 # coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import sys
-
 from scout_apm.compat import string_types
 from scout_apm.core.web_requests import RequestComponents
 
@@ -122,16 +120,10 @@ def _get_tastypie_components(request, view_func):
     except ImportError:
         return None
 
-    if sys.version_info[0] == 2:  # pragma: no cover
-        try:
-            wrapper = view_func.__closure__[0].cell_contents
-        except (AttributeError, IndexError):
-            return None
-    else:
-        try:
-            wrapper = view_func.__wrapped__
-        except AttributeError:
-            return None
+    try:
+        wrapper = view_func.__wrapped__
+    except AttributeError:
+        return None
 
     if not hasattr(wrapper, "__closure__") or len(wrapper.__closure__) != 2:
         return None

--- a/src/scout_apm/instruments/urllib3.py
+++ b/src/scout_apm/instruments/urllib3.py
@@ -5,7 +5,6 @@ import logging
 
 import wrapt
 
-from scout_apm.compat import text_type
 from scout_apm.core.config import scout_config
 from scout_apm.core.tracked_request import TrackedRequest
 
@@ -53,16 +52,16 @@ def wrapped_urlopen(wrapped, instance, args, kwargs):
         method = "Unknown"
 
     try:
-        url = text_type(instance._absolute_url("/"))
+        url = str(instance._absolute_url("/"))
     except Exception:
         logger.exception("Could not get URL for HTTPConnectionPool")
         url = "Unknown"
 
     # Don't instrument ErrorMonitor calls
-    if text_type(url).startswith(scout_config.value("errors_host")):
+    if str(url).startswith(scout_config.value("errors_host")):
         return wrapped(*args, **kwargs)
 
     tracked_request = TrackedRequest.instance()
     with tracked_request.span(operation="HTTP/{}".format(method)) as span:
-        span.tag("url", text_type(url))
+        span.tag("url", str(url))
         return wrapped(*args, **kwargs)

--- a/tests/compat.py
+++ b/tests/compat.py
@@ -2,74 +2,13 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import gzip
-import sys
-
-if sys.version_info >= (3, 0):
-    from types import SimpleNamespace
-else:
-
-    class SimpleNamespace(object):
-        def __init__(self, **kwargs):
-            for key, value in kwargs.items():
-                setattr(self, key, value)
+from contextlib import nullcontext, suppress
+from tempfile import TemporaryDirectory
+from unittest import mock
 
 
-if sys.version_info >= (3, 0):
-    from unittest import mock
-else:
-    import mock
-
-if sys.version_info >= (3, 2):
-    from tempfile import TemporaryDirectory
-else:
-    from contextlib import contextmanager
-    from shutil import rmtree
-    from tempfile import mkdtemp
-
-    @contextmanager
-    def TemporaryDirectory(*args, **kwargs):
-        tempdir = mkdtemp(*args, **kwargs)
-        try:
-            yield tempdir
-        finally:
-            rmtree(tempdir)
-
-
-if sys.version_info >= (3, 7):
-    from contextlib import nullcontext
-else:
-    from contextlib import contextmanager
-
-    @contextmanager
-    def nullcontext(obj):
-        yield obj
-
-
-if sys.version_info >= (3, 4):
-    from contextlib import suppress
-else:
-    from contextlib import contextmanager
-
-    @contextmanager
-    def suppress(*exceptions):
-        try:
-            yield
-        except exceptions:
-            pass
-
-
-if sys.version_info >= (3, 2):
-
-    def gzip_decompress(data):
-        return gzip.decompress(data)
-
-else:
-    import StringIO
-
-    def gzip_decompress(data):
-        """Reimplementation gzip.compress for python 2.7"""
-        with gzip.GzipFile(fileobj=StringIO.StringIO(data), mode="rb") as f:
-            return f.read()
+def gzip_decompress(data):
+    return gzip.decompress(data)
 
 
 try:

--- a/tests/integration/instruments/test_elasticsearch.py
+++ b/tests/integration/instruments/test_elasticsearch.py
@@ -11,7 +11,7 @@ import pytest
 
 from scout_apm.instruments.elasticsearch import CLIENT_METHODS, ensure_installed
 from tests.compat import mock
-from tests.tools import delete_attributes, skip_if_python_2
+from tests.tools import delete_attributes
 
 skip_if_elasticsearch_v7 = pytest.mark.skipif(
     elasticsearch.VERSION < (8, 0, 0), reason="Requires ElasticSearch 8"
@@ -48,7 +48,6 @@ def test_all_client_methods_exist(method_name):
     assert hasattr(elasticsearch.Elasticsearch, method_name)
 
 
-@skip_if_python_2
 @pytest.mark.parametrize(
     ["method_name", "takes_index_argument"],
     [[m.name, m.takes_index_argument] for m in CLIENT_METHODS],
@@ -199,7 +198,6 @@ def test_search(elasticsearch_client, tracked_request):
     assert span.operation == "Elasticsearch/Unknown/Search"
 
 
-@skip_if_python_2  # Cannot unwrap decorators on Python 2
 def test_search_arg_named_index(elasticsearch_client, tracked_request):
     with pytest.raises(elasticsearch.exceptions.NotFoundError):
         # body, index

--- a/tests/integration/test_celery.py
+++ b/tests/integration/test_celery.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import logging
 from contextlib import contextmanager
+from types import SimpleNamespace
 
 import celery
 import pytest
@@ -13,7 +14,7 @@ import scout_apm.celery
 from scout_apm.api import Config
 from scout_apm.compat import kwargs_only
 from scout_apm.core.config import scout_config
-from tests.compat import SimpleNamespace, mock
+from tests.compat import mock
 
 # http://docs.celeryproject.org/en/latest/userguide/testing.html#py-test
 skip_unless_celery_4_plus = pytest.mark.skipif(

--- a/tests/integration/test_django.py
+++ b/tests/integration/test_django.py
@@ -5,6 +5,7 @@ import datetime as dt
 import os
 import sys
 from contextlib import contextmanager
+from pathlib import Path
 
 import django
 import pytest
@@ -32,19 +33,12 @@ from tests.tools import (
     delete_attributes,
     n_plus_one_thresholds,
     pretend_package_unavailable,
-    skip_if_python_2,
 )
 
 try:
     from django.urls import resolve
 except ImportError:
     from django.core.urlresolvers import resolve
-
-
-if sys.version_info >= (3,):
-    from pathlib import Path
-else:
-    Path = None
 
 
 skip_unless_new_style_middleware = pytest.mark.skipif(
@@ -121,7 +115,6 @@ def test_on_setting_changed_application_root():
     assert scout_config.value("application_root") == os.getcwd()
 
 
-@skip_if_python_2
 def test_on_setting_changed_application_root_pathlib():
     with app_with_scout(BASE_DIR=Path("/tmp/foobar")):
         value = scout_config.value("application_root")
@@ -642,7 +635,6 @@ def test_tastypie_api_operation_name_fail_no_tastypie(tracked_requests):
     assert span.operation == "Controller/tastypie.resources.wrapper"
 
 
-@skip_if_python_2
 def test_tastypie_api_operation_name_fail_no_wrapper(tracked_requests):
     with app_with_scout() as app:
         skip_if_no_tastypie()
@@ -656,7 +648,6 @@ def test_tastypie_api_operation_name_fail_no_wrapper(tracked_requests):
     assert span.operation == "Controller/tastypie.resources.wrapper"
 
 
-@skip_if_python_2
 def test_tastypie_api_operation_name_fail_no_closure(tracked_requests):
     with app_with_scout() as app:
         skip_if_no_tastypie()

--- a/tests/integration/test_rq.py
+++ b/tests/integration/test_rq.py
@@ -12,7 +12,7 @@ from rq.version import VERSION
 
 import scout_apm.rq
 from scout_apm.api import Config
-from scout_apm.compat import kwargs_only, string_type
+from scout_apm.compat import kwargs_only
 from scout_apm.instruments.redis import ensure_installed
 
 
@@ -80,7 +80,7 @@ def test_hello(redis_conn, tracked_requests):
     assert len(tracked_requests) == 1
     tracked_request = tracked_requests[0]
     task_id = tracked_request.tags["task_id"]
-    assert isinstance(task_id, string_type) and len(task_id) == 36
+    assert isinstance(task_id, str) and len(task_id) == 36
     assert tracked_request.tags["queue"] == "myqueue"
     assert 0.0 < tracked_request.tags["queue_time"] < 60.0
     assert len(tracked_request.complete_spans) == 2
@@ -98,7 +98,7 @@ def test_fail(redis_conn, tracked_requests):
 
     tracked_request = tracked_requests[0]
     task_id = tracked_request.tags["task_id"]
-    assert isinstance(task_id, string_type) and len(task_id) == 36
+    assert isinstance(task_id, str) and len(task_id) == 36
     assert tracked_request.tags["queue"] == "myqueue"
     assert 0.0 < tracked_request.tags["queue_time"] < 60.0
     assert tracked_request.tags["error"] == "true"

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -15,13 +15,6 @@ from scout_apm.core import objtrace
 from scout_apm.core.n_plus_one_tracker import NPlusOneTracker
 from tests.compat import mock, nullcontext
 
-skip_if_python_2 = pytest.mark.skipif(
-    sys.version_info[0] < 3, reason="Requires Python 3"
-)
-skip_if_python_3 = pytest.mark.skipif(
-    sys.version_info[0] >= 3, reason="Requires Python 2"
-)
-
 skip_if_objtrace_not_extension = pytest.mark.skipif(
     not objtrace.is_extension, reason="Requires objtrace C extension"
 )

--- a/tests/unit/core/agent/test_manager.py
+++ b/tests/unit/core/agent/test_manager.py
@@ -115,7 +115,7 @@ class TestParseManifest(object):
         mock_open = mock.patch(
             "scout_apm.core.agent.manager.open",
             create=True,
-            side_effect=errno.EACCES,
+            side_effect=OSError(errno.EACCES),
         )
 
         with mock_open:

--- a/tests/unit/core/agent/test_manager.py
+++ b/tests/unit/core/agent/test_manager.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import errno
 import logging
-import sys
 
 from scout_apm.core.agent.manager import (
     CoreAgentManager,
@@ -113,14 +112,10 @@ class TestParseManifest(object):
 
     def test_fail_other_open_error(self, caplog, tmp_path):
         filename = str(tmp_path / "does-not-exist.json")
-        if sys.version_info[0] == 2:
-            error = IOError("Woops", errno.EACCES)
-        else:
-            error = OSError(errno.EACCES)
         mock_open = mock.patch(
             "scout_apm.core.agent.manager.open",
             create=True,
-            side_effect=error,
+            side_effect=errno.EACCES,
         )
 
         with mock_open:

--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import logging
 import os
 import pprint
-import sys
 
 import pytest
 
@@ -83,10 +82,7 @@ def test_get_undefined_config_value_null_layer_removed():
         config.value("unknown value")
 
     assert isinstance(excinfo.value, ValueError)
-    if sys.version_info[0] == 2:
-        expected_msg = "key u'unknown value' not found in any layer"
-    else:
-        expected_msg = "key 'unknown value' not found in any layer"
+    expected_msg = "key 'unknown value' not found in any layer"
     assert excinfo.value.args == (expected_msg,)
 
 

--- a/tests/unit/core/test_metadata.py
+++ b/tests/unit/core/test_metadata.py
@@ -1,8 +1,6 @@
 # coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import sys
-
 import pytest
 
 from scout_apm.core.agent.socket import CoreAgentSocketThread
@@ -29,10 +27,7 @@ def test_report_app_metadata(mock_send):
 
 @mock.patch.object(CoreAgentSocketThread, "send")
 def test_report_app_metadata_no_importlib_metadata(mock_send):
-    if sys.version_info >= (3, 8):
-        module_name = "importlib"
-    else:
-        module_name = "importlib_metadata"
+    module_name = "importlib"
     with pretend_package_unavailable(module_name):
         report_app_metadata()
 
@@ -46,10 +41,7 @@ def test_report_app_metadata_no_importlib_metadata(mock_send):
 
 
 def test_get_python_packages_versions_None_package():
-    if sys.version_info >= (3, 8):
-        target = "importlib.metadata.distributions"
-    else:
-        target = "importlib_metadata.distributions"
+    target = "importlib.metadata.distributions"
 
     def yielding_nones():
         yield SimpleNamespace(metadata={"Name": "first-package", "Version": "1.0.0"})

--- a/tests/unit/core/test_metadata.py
+++ b/tests/unit/core/test_metadata.py
@@ -1,11 +1,13 @@
 # coding=utf-8
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from types import SimpleNamespace
+
 import pytest
 
 from scout_apm.core.agent.socket import CoreAgentSocketThread
 from scout_apm.core.metadata import get_python_packages_versions, report_app_metadata
-from tests.compat import SimpleNamespace, mock
+from tests.compat import mock
 from tests.tools import pretend_package_unavailable
 
 

--- a/tests/unit/core/test_platform_detection.py
+++ b/tests/unit/core/test_platform_detection.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import pytest
 
-from scout_apm.compat import string_type
 from scout_apm.core import platform_detection
 from tests.compat import mock
 
@@ -11,7 +10,7 @@ from tests.compat import mock
 def test_get_triple():
     triple = platform_detection.get_triple()
 
-    assert isinstance(triple, string_type)
+    assert isinstance(triple, str)
     assert platform_detection.is_valid_triple(triple)
 
 

--- a/tests/unit/core/test_tracked_request.py
+++ b/tests/unit/core/test_tracked_request.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import datetime as dt
 import logging
-import sys
 
 import pytest
 
@@ -77,10 +76,7 @@ def test_span_repr(tracked_request):
     tracked_request.stop_span()
 
     assert repr_.startswith("<Span(")
-    if sys.version_info[0] == 2:
-        assert "operation=u'myoperation'" in repr_
-    else:
-        assert "operation='myoperation'" in repr_
+    assert "operation='myoperation'" in repr_
 
 
 def test_tag_span(tracked_request):

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import datetime as dt
 import functools
-import sys
 
 import pytest
 
@@ -86,8 +85,5 @@ def test_unwrap_decorators_one_decorator():
     @functools.wraps(foo)
     def bar():
         return foo()
-
-    if sys.version_info < (3,):
-        bar.__wrapped__ = foo
 
     assert unwrap_decorators(bar) is foo


### PR DESCRIPTION
As we only support Py3.8+ in the coming version of the agent, there is no need for all of these version checks in the code.