### PR TITLE
Handle newer urllib3

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -100,7 +100,6 @@ Re-activate the virtualenv to export the env variables:
 
 Run the test app:
 
-
     $ PYTHONPATH=. tests/integration/app.py
 
 You can also run it with gunicorn:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -100,6 +100,7 @@ Re-activate the virtualenv to export the env variables:
 
 Run the test app:
 
+
     $ PYTHONPATH=. tests/integration/app.py
 
 You can also run it with gunicorn:

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,8 @@ setup(
     install_requires=[
         "asgiref",
         "psutil>=5,<6",
-        "urllib3 < 2",
+        "urllib3",
+        "certifi",
         "wrapt>=1.10,<2.0",
     ],
     keywords=["apm", "performance monitoring", "development"],

--- a/src/scout_apm/instruments/urllib3.py
+++ b/src/scout_apm/instruments/urllib3.py
@@ -10,9 +10,14 @@ from scout_apm.core.tracked_request import TrackedRequest
 
 try:
     from urllib3 import HTTPConnectionPool
-    from urllib3.connectionpool import _url_from_pool
 except ImportError:  # pragma: no cover
     HTTPConnectionPool = None
+
+# Try except separately because _url_from_pool is explicitly imported for urllib3 >= 2.
+# HTTPConnectionPool is always required.
+try:
+    from urllib3.connectionpool import _url_from_pool
+except ImportError:  # pragma: no cover
 
     def _url_from_pool(pool, path):
         pass

--- a/src/scout_apm/instruments/urllib3.py
+++ b/src/scout_apm/instruments/urllib3.py
@@ -2,6 +2,7 @@
 
 import logging
 
+import urllib3
 import wrapt
 
 from scout_apm.core.config import scout_config
@@ -51,7 +52,10 @@ def wrapped_urlopen(wrapped, instance, args, kwargs):
         method = "Unknown"
 
     try:
-        url = str(instance._absolute_url("/"))
+        if int(urllib3.__version__.split(".")[0]) < 2:
+            url = str(instance._absolute_url("/"))
+        else:
+            url = str(instance._url_from_pool("/"))
     except Exception:
         logger.exception("Could not get URL for HTTPConnectionPool")
         url = "Unknown"

--- a/src/scout_apm/instruments/urllib3.py
+++ b/src/scout_apm/instruments/urllib3.py
@@ -10,8 +10,13 @@ from scout_apm.core.tracked_request import TrackedRequest
 
 try:
     from urllib3 import HTTPConnectionPool
+    from urllib3.connectionpool import _url_from_pool
 except ImportError:  # pragma: no cover
     HTTPConnectionPool = None
+
+    def _url_from_pool(pool, path):
+        pass
+
 
 logger = logging.getLogger(__name__)
 
@@ -55,7 +60,7 @@ def wrapped_urlopen(wrapped, instance, args, kwargs):
         if int(urllib3.__version__.split(".")[0]) < 2:
             url = str(instance._absolute_url("/"))
         else:
-            url = str(instance._url_from_pool("/"))
+            url = str(_url_from_pool(instance, "/"))
     except Exception:
         logger.exception("Could not get URL for HTTPConnectionPool")
         url = "Unknown"


### PR DESCRIPTION
This PR updates urllib3 instrumentation to handle version >= 2 and removes the limit requirement. 

urllib3[secure] is being deprecated(see [here](https://github.com/urllib3/urllib3/issues/2680)), however we still need `certifi` so is is now specified in the dependencies.