### PR TITLE
update release action versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,9 @@ jobs:
         # Disable for platforms where pure Python wheels would be generated
         cibw_skip: [ "pp38-* pp39-* pp310-* pp311-* pp312-* cp312-*" ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
           python-version: ${{ matrix.python }}
@@ -47,7 +47,7 @@ jobs:
           CIBW_ARCHS_LINUX: "auto aarch64"
         run: python -m cibuildwheel
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
 
@@ -58,9 +58,9 @@ jobs:
       matrix:
         python: [3.9]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
           python-version: ${{ matrix.python-version }}
@@ -73,7 +73,7 @@ jobs:
           SCOUT_DISABLE_EXTENSIONS: "1"
         run: python setup.py bdist_wheel
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: dist/*.whl
 
@@ -81,9 +81,9 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v3
         name: Install Python
         with:
           python-version: 3.9
@@ -91,7 +91,7 @@ jobs:
       - name: Build sdist
         run: python setup.py sdist
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: dist/*.tar.gz
 
@@ -100,7 +100,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Download distributions for publishing.
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: artifact
           path: dist


### PR DESCRIPTION
We were seeing warnings in github actions from using outdated versions. 
This bumps versions to latest major release. 