### PR TITLE
Python 3.12 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,7 @@ jobs:
         - "3.9"
         - "3.10"
         - "3.11"
+        - "3.12"
 
     services:
       elasticsearch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         python: ['3.10']
         manylinux_image: [ manylinux2014, manylinux_2_28 ]
         # Disable for platforms where pure Python wheels would be generated
-        cibw_skip: [ "pp38-* pp39-* pp310-* pp311-* pp312-* cp312-*" ]
+        cibw_skip: [ "pp38-* pp39-* pp310-* pp311-*" ]
     steps:
       - uses: actions/checkout@v3
 

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ src/*.egg-info/
 .coverage
 
 .idea/
+.DS_Store

--- a/pytest.ini
+++ b/pytest.ini
@@ -59,3 +59,5 @@ filterwarnings =
     ; Triggerd by celery with python 3.12
     ignore:.*utcfromtimestamp\(\) is deprecated.*:DeprecationWarning
     ignore:.*utcnow\(\) is deprecated.*:DeprecationWarning
+    ; Triggered by CoreAgentManager with python 3.12
+    ignore:Python 3.14 will, by default, filter extracted tar archives and reject files or modify their metadata.*:DeprecationWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -56,3 +56,6 @@ filterwarnings =
     ; Triggered by rq -> rq/job.py
     ignore:The `push_connection` function is deprecated\. Pass the `connection` explicitly instead\.:DeprecationWarning
     ignore:'cgi' is deprecated and slated for removal in Python 3.13
+    ; triggerd by celery with python 3.12
+    ignore:.*utcfromtimestamp\(\) is deprecated.*:DeprecationWarning
+    ignore:.*utcnow\(\) is deprecated.*:DeprecationWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -56,6 +56,6 @@ filterwarnings =
     ; Triggered by rq -> rq/job.py
     ignore:The `push_connection` function is deprecated\. Pass the `connection` explicitly instead\.:DeprecationWarning
     ignore:'cgi' is deprecated and slated for removal in Python 3.13
-    ; triggerd by celery with python 3.12
+    ; Triggerd by celery with python 3.12
     ignore:.*utcfromtimestamp\(\) is deprecated.*:DeprecationWarning
     ignore:.*utcnow\(\) is deprecated.*:DeprecationWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -59,5 +59,6 @@ filterwarnings =
     ; Triggerd by celery with python 3.12
     ignore:.*utcfromtimestamp\(\) is deprecated.*:DeprecationWarning
     ignore:.*utcnow\(\) is deprecated.*:DeprecationWarning
+    ignore:.*broker_connection_retry configuration setting will no longer determine.*:PendingDeprecationWarning
     ; Triggered by CoreAgentManager with python 3.12
     ignore:Python 3.14 will, by default, filter extracted tar archives and reject files or modify their metadata.*:DeprecationWarning

--- a/setup.py
+++ b/setup.py
@@ -84,5 +84,6 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
 )

--- a/tests/integration/test_falcon.py
+++ b/tests/integration/test_falcon.py
@@ -147,7 +147,6 @@ def test_home_without_set_api(recwarn, tracked_requests):
         == "Controller/tests.integration.test_falcon.HomeResource.GET"
     )
     assert tracked_request.complete_spans[1].operation == "Middleware"
-    assert len(recwarn) == 1
     warning = recwarn.pop(RuntimeWarning)
     assert str(warning.message) == (
         "ScoutMiddleware.set_api() should be called before requests begin for"

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 isolated_build = True
 envlist =
-    {py38,py39,py310,py311,py312}-django{40,41,42,50a}
-
+    {py38,py39,py310,py311,py312}-django{40,41,42},
+    {py310,py311,py312}-django{50a},
 [testenv]
 passenv =
     ELASTICSEARCH_URL

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 isolated_build = True
 envlist =
-    {py38,py39,py310,py311}-django{40,41,42}
+    {py38,py39,py310,py311,py312}-django{40,41,42,50a}
 
 [testenv]
 passenv =
@@ -22,6 +22,7 @@ deps =
     django41: djangorestframework
     django42: Django>4.1,<5
     django42: djangorestframework
+    django50a: Django>=5.0a1,<5.1
     dramatiq>=1.0.0
     elasticsearch<8.0.0; python_version <= "3.9"
     elasticsearch ; python_version > "3.9"

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,7 @@ deps =
     django42: Django>4.1,<5
     django42: djangorestframework
     django50a: Django>=5.0a1,<5.1
+    django50a: djangorestframework
     dramatiq>=1.0.0
     elasticsearch<8.0.0; python_version <= "3.9"
     elasticsearch ; python_version > "3.9"


### PR DESCRIPTION
## Changes
- add build for python 3.12
- add tox env for python 3.12 
- add tox env for django5 pre release. Django 5 only supports python >3.10. 
- add warning ignores to pytest config for new deprecation warnings (from dependencies) in python 3.12. 
- removes assertion of recwarn length in falcon tests due to new deprecation warnings in tests. 