### PR TITLE
Mac OS platform handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Pending
+
+### Fixed
+- Core Agent fails to download on newer Mac OS/Apple Silicon (Issue #779)
+
 ## [3.0.0rc1] 2023-09-08
 
 Version 3.0.0 drops support for Python 2.7 and < 3.8, as well as Django < 3.2.

--- a/src/scout_apm/core/agent/manager.py
+++ b/src/scout_apm/core/agent/manager.py
@@ -167,6 +167,8 @@ class CoreAgentDownloader(object):
                 downloaded = self.download_package()
                 if downloaded:
                     self.untar()
+                else:
+                    logger.debug("Core Agent download failed: bad http response.")
             except (OSError, HTTPError):
                 logger.exception("Exception raised while downloading Core Agent")
             finally:

--- a/src/scout_apm/core/platform_detection.py
+++ b/src/scout_apm/core/platform_detection.py
@@ -42,6 +42,10 @@ def get_arch():
         return "x86_64"
     elif arch == "aarch64":
         return "aarch64"
+    elif arch == "arm64":
+        # We treat these as synonymous and name them "aarch64" for consistency
+        # Mac OS, for example, uses "arm64"
+        return "aarch64"
     else:
         return "unknown"
 

--- a/src/scout_apm/core/tracked_request.py
+++ b/src/scout_apm/core/tracked_request.py
@@ -266,6 +266,7 @@ class Span(object):
 
     def add_allocation_tags(self):
         if not objtrace.is_extension:
+            logger.debug("Not adding allocation tags: extension not loaded")
             return
 
         start_allocs = (


### PR DESCRIPTION
- Alias "arm64" to "aarch64" to use existing overrides/builds
- Add a hint that core agent download failed http response check