### PR TITLE
Update core-agent version to 1.5.0

### DIFF
--- a/src/scout_apm/core/config.py
+++ b/src/scout_apm/core/config.py
@@ -221,7 +221,7 @@ class Defaults(object):
             "core_agent_log_level": "info",
             "core_agent_permissions": 700,
             "core_agent_socket_path": "tcp://127.0.0.1:6590",
-            "core_agent_version": "v1.4.0",  # can be an exact tag name, or 'latest'
+            "core_agent_version": "v1.5.0",  # can be an exact tag name, or 'latest'
             "disabled_instruments": [],
             "download_url": "https://s3-us-west-1.amazonaws.com/scout-public-downloads/apm_core_agent/release",  # noqa: B950
             "errors_batch_size": 5,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -170,6 +170,7 @@ def terminate_core_agent_processes():
     for process in psutil.process_iter(["name"]):
         if process.name() == "core-agent":
             process.terminate()
+            process.wait()
 
 
 # Make all timeouts shorter so that tests exercising them run faster.


### PR DESCRIPTION
Updates the core agent version to use 1.5.0.

Changes to the core-agent include flushing batched payloads on receiving of termination signals, capturing latency and allocation metrics for background jobs, as well as a few changes to the exit codes of the core agent.

This core agent docs will also be updated and can be found here:
https://scoutapm.com/docs/core-agent

With updates to the core-agent, now flushing payloads on a couple signals, we need to wait for the process to terminate in the tests.