### PR TITLE
Check for already running status code when launching core agent.

### DIFF
--- a/src/scout_apm/core/agent/manager.py
+++ b/src/scout_apm/core/agent/manager.py
@@ -74,11 +74,12 @@ class CoreAgentManager(object):
                     stdout=devnull,
                 )
         except subprocess.CalledProcessError as err:
-            if err.returncode in [signal.SIGTERM, signal.SIGQUIT]:
-                logger.debug("Core agent returned signal: {}".format(err.returncode))
-            elif err.returncode == CA_ALREADY_RUNNING_EXIT_CODE:
+            if err.returncode == CA_ALREADY_RUNNING_EXIT_CODE:
                 # Other processes may have already started the core agent.
                 logger.debug("Core agent already running.")
+                return True
+            elif err.returncode in [signal.SIGTERM, signal.SIGQUIT]:
+                logger.debug("Core agent returned signal: {}".format(err.returncode))
             else:
                 logger.exception("CalledProcessError running Core Agent")
             return False

--- a/src/scout_apm/core/agent/manager.py
+++ b/src/scout_apm/core/agent/manager.py
@@ -5,7 +5,6 @@ import hashlib
 import json
 import logging
 import os
-import signal
 import subprocess
 import tarfile
 import time
@@ -18,6 +17,7 @@ from scout_apm.core.config import scout_config
 logger = logging.getLogger(__name__)
 
 CA_ALREADY_RUNNING_EXIT_CODE = 3
+
 
 class CoreAgentManager(object):
     def __init__(self):

--- a/src/scout_apm/core/agent/manager.py
+++ b/src/scout_apm/core/agent/manager.py
@@ -78,8 +78,6 @@ class CoreAgentManager(object):
                 # Other processes may have already started the core agent.
                 logger.debug("Core agent already running.")
                 return True
-            elif err.returncode in [signal.SIGTERM, signal.SIGQUIT]:
-                logger.debug("Core agent returned signal: {}".format(err.returncode))
             else:
                 logger.exception("CalledProcessError running Core Agent")
             return False

--- a/src/scout_apm/core/agent/manager.py
+++ b/src/scout_apm/core/agent/manager.py
@@ -17,6 +17,7 @@ from scout_apm.core.config import scout_config
 
 logger = logging.getLogger(__name__)
 
+CA_ALREADY_RUNNING_EXIT_CODE = 3
 
 class CoreAgentManager(object):
     def __init__(self):
@@ -75,6 +76,9 @@ class CoreAgentManager(object):
         except subprocess.CalledProcessError as err:
             if err.returncode in [signal.SIGTERM, signal.SIGQUIT]:
                 logger.debug("Core agent returned signal: {}".format(err.returncode))
+            elif err.returncode == CA_ALREADY_RUNNING_EXIT_CODE:
+                # Other processes may have already started the core agent.
+                logger.debug("Core agent already running.")
             else:
                 logger.exception("CalledProcessError running Core Agent")
             return False

--- a/tests/integration/core/agent/test_manager.py
+++ b/tests/integration/core/agent/test_manager.py
@@ -127,23 +127,6 @@ def test_launch_error(caplog, core_agent_manager):
     assert caplog.records[0].exc_info[1] is exception
 
 
-@pytest.mark.parametrize(["signal_code"], [[signal.SIGQUIT], [signal.SIGTERM]])
-def test_launch_expected_signal_error(signal_code, caplog, core_agent_manager):
-    caplog.set_level(logging.ERROR)
-    exception = subprocess.CalledProcessError(signal_code, "err")
-    with mock.patch.object(
-        manager.CoreAgentManager,
-        "agent_binary",
-        side_effect=exception,
-    ):
-        result = core_agent_manager.launch()
-
-    assert not result
-    assert not core_agent_is_running()
-    # Caplog doesn't contain debug messages
-    assert caplog.record_tuples == []
-
-
 def test_launch_unexpected_signal_error(caplog, core_agent_manager):
     caplog.set_level(logging.ERROR)
     exception = subprocess.CalledProcessError(signal.SIGINT, "err")


### PR DESCRIPTION
Will check for an already running exit code when launching the core agent. As many processes may try and start the core agent at a similar time, exception logs would be thrown even though the launch of the single core agent instance was successful. 