### PR TITLE
Update Documentation / Fix pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,3 +42,4 @@ repos:
     hooks:
     - id: check-manifest
       args: [--no-build-isolation]
+      additional_dependencies: [setuptools, wheel, setuptools-scm]

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To use Scout, you'll need to
 
 For full installation instructions, including information on configuring Scout
 via environment variables and troubleshooting, see our
-[Python docs](https://docs.scoutapm.com/#python-agent).
+[Python docs](https://scoutapm.com/docs/python).
 
 ## Support
 


### PR DESCRIPTION
## Changes
- Updates docs link to the latest scoutapm python docs
- Fixes failing pre-commit hook by explicitly providing dependencies. (required when using `--no-build-isolation` flag]