### PR TITLE
Remove use of datetime.utcnow()

### DIFF
--- a/src/scout_apm/celery.py
+++ b/src/scout_apm/celery.py
@@ -29,7 +29,9 @@ logger = logging.getLogger(__name__)
 
 def before_task_publish_callback(headers=None, properties=None, **kwargs):
     if "scout_task_start" not in headers:
-        headers["scout_task_start"] = datetime_to_timestamp(dt.datetime.utcnow())
+        headers["scout_task_start"] = datetime_to_timestamp(
+            dt.datetime.now(dt.timezone.utc)
+        )
 
 
 def task_prerun_callback(task=None, **kwargs):

--- a/src/scout_apm/core/metadata.py
+++ b/src/scout_apm/core/metadata.py
@@ -15,7 +15,7 @@ def report_app_metadata():
             event_type="scout.metadata",
             event_value=get_metadata(),
             source="Pid: " + str(getpid()),
-            timestamp=dt.datetime.utcnow(),
+            timestamp=dt.datetime.now(dt.timezone.utc),
         )
     )
 
@@ -24,7 +24,7 @@ def get_metadata():
     data = {
         "language": "python",
         "language_version": "{}.{}.{}".format(*sys.version_info[:3]),
-        "server_time": dt.datetime.utcnow().isoformat() + "Z",
+        "server_time": dt.datetime.now(dt.timezone.utc).isoformat() + "Z",
         "framework": scout_config.value("framework"),
         "framework_version": scout_config.value("framework_version"),
         "environment": "",

--- a/src/scout_apm/core/queue_time.py
+++ b/src/scout_apm/core/queue_time.py
@@ -86,7 +86,7 @@ def track_job_queue_time(
         bool: Whether we succeeded in marking queue time for the job. Used for testing.
     """
     if header_value is not None:
-        now = datetime_to_timestamp(dt.datetime.utcnow()) * 1e9
+        now = datetime_to_timestamp(dt.datetime.now(dt.timezone.utc)) * 1e9
         try:
             ambiguous_float_start = typing.cast(float, header_value)
             start = _convert_ambiguous_timestamp_to_ns(ambiguous_float_start)

--- a/src/scout_apm/core/samplers/cpu.py
+++ b/src/scout_apm/core/samplers/cpu.py
@@ -14,7 +14,7 @@ class Cpu(object):
     human_name = "Process CPU"
 
     def __init__(self):
-        self.last_run = dt.datetime.utcnow()
+        self.last_run = dt.datetime.now(dt.timezone.utc)
         self.last_cpu_times = psutil.Process().cpu_times()
         self.num_processors = psutil.cpu_count()
         if self.num_processors is None:
@@ -22,7 +22,7 @@ class Cpu(object):
             self.num_processors = 1
 
     def run(self):
-        now = dt.datetime.utcnow()
+        now = dt.datetime.now(dt.timezone.utc)
         process = psutil.Process()  # get a handle on the current process
         cpu_times = process.cpu_times()
 

--- a/src/scout_apm/core/samplers/thread.py
+++ b/src/scout_apm/core/samplers/thread.py
@@ -30,7 +30,7 @@ class SamplersThread(SingletonThread):
                     event = ApplicationEvent(
                         event_value=event_value,
                         event_type=event_type,
-                        timestamp=dt.datetime.utcnow(),
+                        timestamp=dt.datetime.now(dt.timezone.utc),
                         source="Pid: " + str(os.getpid()),
                     )
                     CoreAgentSocketThread.send(event)

--- a/src/scout_apm/core/tracked_request.py
+++ b/src/scout_apm/core/tracked_request.py
@@ -49,7 +49,7 @@ class TrackedRequest(object):
 
     def __init__(self):
         self.request_id = "req-" + str(uuid4())
-        self.start_time = dt.datetime.utcnow()
+        self.start_time = dt.datetime.now(dt.timezone.utc)
         self.end_time = None
         self.active_spans = []
         self.complete_spans = []
@@ -147,7 +147,7 @@ class TrackedRequest(object):
 
         logger.debug("Stopping request: %s", self.request_id)
         if self.end_time is None:
-            self.end_time = dt.datetime.utcnow()
+            self.end_time = dt.datetime.now(dt.timezone.utc)
 
         if self.is_real_request:
             self.tag("mem_delta", self._get_mem_delta())
@@ -219,7 +219,7 @@ class Span(object):
         should_capture_backtrace=True,
     ):
         self.span_id = "span-" + str(uuid4())
-        self.start_time = dt.datetime.utcnow()
+        self.start_time = dt.datetime.now(dt.timezone.utc)
         self.end_time = None
         self.request_id = request_id
         self.operation = operation
@@ -238,7 +238,7 @@ class Span(object):
         )
 
     def stop(self):
-        self.end_time = dt.datetime.utcnow()
+        self.end_time = dt.datetime.now(dt.timezone.utc)
         self.end_objtrace_counts = objtrace.get_counts()
 
     def tag(self, key, value):
@@ -254,7 +254,7 @@ class Span(object):
             return (self.end_time - self.start_time).total_seconds()
         else:
             # Current, running duration
-            return (dt.datetime.utcnow() - self.start_time).total_seconds()
+            return (dt.datetime.now() - self.start_time).total_seconds()
 
     # Add any interesting annotations to the span. Assumes that we are in the
     # process of stopping this span.

--- a/src/scout_apm/rq.py
+++ b/src/scout_apm/rq.py
@@ -65,7 +65,9 @@ def wrap_perform(wrapped, instance, args, kwargs):
     tracked_request.is_real_request = True
     tracked_request.tag("task_id", instance.get_id())
     tracked_request.tag("queue", instance.origin)
-    queue_time = (dt.datetime.utcnow() - instance.enqueued_at).total_seconds()
+    queue_time = (
+        dt.datetime.now(dt.timezone.utc) - instance.enqueued_at
+    ).total_seconds()
     tracked_request.tag("queue_time", queue_time)
     operation = "Job/{}".format(instance.func_name)
     tracked_request.operation = operation

--- a/tests/integration/test_bottle.py
+++ b/tests/integration/test_bottle.py
@@ -136,7 +136,7 @@ def test_user_ip_collection_disabled(tracked_requests):
 @parametrize_queue_time_header_name
 def test_queue_time(header_name, tracked_requests):
     # Not testing floats due to Python 2/3 rounding differences
-    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow())) - 2
+    queue_start = int(datetime_to_timestamp(dt.datetime.now())) - 2
     with app_with_scout() as app:
         response = TestApp(app).get(
             "/", headers={header_name: str("t=") + str(queue_start)}

--- a/tests/integration/test_django.py
+++ b/tests/integration/test_django.py
@@ -861,7 +861,7 @@ def test_old_style_urlconf(tracked_requests):
 @parametrize_queue_time_header_name
 def test_queue_time(header_name, tracked_requests):
     # Not testing floats due to Python 2/3 rounding differences
-    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow())) - 2
+    queue_start = int(datetime_to_timestamp(dt.datetime.now())) - 2
     with app_with_scout() as app:
         response = TestApp(app).get(
             "/", headers={header_name: str("t=") + str(queue_start)}

--- a/tests/integration/test_falcon.py
+++ b/tests/integration/test_falcon.py
@@ -218,7 +218,7 @@ def test_filtered_params(params, expected_path, tracked_requests):
 @parametrize_queue_time_header_name
 def test_queue_time(header_name, tracked_requests):
     # Not testing floats due to Python 2/3 rounding differences
-    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow())) - 2
+    queue_start = int(datetime_to_timestamp(dt.datetime.now())) - 2
     with app_with_scout() as app:
         response = TestApp(app).get(
             "/", headers={header_name: str("t=") + str(queue_start)}

--- a/tests/integration/test_flask.py
+++ b/tests/integration/test_flask.py
@@ -131,7 +131,7 @@ def test_user_ip_collection_disabled(tracked_requests):
 @parametrize_queue_time_header_name
 def test_queue_time(header_name, tracked_requests):
     # Not testing floats due to Python 2/3 rounding differences
-    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow())) - 2
+    queue_start = int(datetime_to_timestamp(dt.datetime.now())) - 2
     with app_with_scout() as app:
         response = TestApp(app).get(
             "/", headers={header_name: str("t=") + str(queue_start)}

--- a/tests/integration/test_starlette.py
+++ b/tests/integration/test_starlette.py
@@ -295,7 +295,7 @@ async def test_user_ip_collection_disabled(tracked_requests):
 @pytest.mark.asyncio
 async def test_queue_time(header_name, tracked_requests):
     # Not testing floats due to Python 2/3 rounding differences
-    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow())) - 2
+    queue_start = int(datetime_to_timestamp(dt.datetime.now())) - 2
     with app_with_scout() as app:
         communicator = ApplicationCommunicator(
             app,

--- a/tests/unit/core/samplers/test_cpu.py
+++ b/tests/unit/core/samplers/test_cpu.py
@@ -11,7 +11,7 @@ from tests.compat import mock
 
 def test_run_negative_time_elapsed(caplog):
     cpu = Cpu()
-    cpu.last_run = dt.datetime.utcnow() + dt.timedelta(days=100)
+    cpu.last_run = dt.datetime.now() + dt.timedelta(days=100)
 
     result = cpu.run()
 

--- a/tests/unit/core/samplers/test_cpu.py
+++ b/tests/unit/core/samplers/test_cpu.py
@@ -11,7 +11,7 @@ from tests.compat import mock
 
 def test_run_negative_time_elapsed(caplog):
     cpu = Cpu()
-    cpu.last_run = dt.datetime.now() + dt.timedelta(days=100)
+    cpu.last_run = dt.datetime.now(dt.timezone.utc) + dt.timedelta(days=100)
 
     result = cpu.run()
 

--- a/tests/unit/core/test_queue_time.py
+++ b/tests/unit/core/test_queue_time.py
@@ -16,7 +16,7 @@ from scout_apm.core.queue_time import (
 
 @pytest.mark.parametrize("with_t", [True, False])
 def test_track_request_queue_time_valid(with_t, tracked_request):
-    queue_start = int(datetime_to_timestamp(dt.datetime.utcnow())) - 2
+    queue_start = int(datetime_to_timestamp(dt.datetime.now(dt.timezone.utc))) - 2
     if with_t:
         header_value = str("t=") + str(queue_start)
     else:
@@ -35,7 +35,9 @@ def test_track_request_queue_time_valid(with_t, tracked_request):
         str(""),
         str("t=X"),  # first character not a digit
         str("t=0.3f"),  # raises ValueError on float() conversion
-        str(datetime_to_timestamp(dt.datetime.utcnow()) + 3600.0),  # one hour in future
+        str(
+            datetime_to_timestamp(dt.datetime.now(dt.timezone.utc)) + 3600.0
+        ),  # one hour in future
         str(datetime_to_timestamp(dt.datetime(2009, 1, 1))),  # before ambig cutoff
     ],
 )
@@ -48,7 +50,7 @@ def test_track_request_queue_time_invalid(header_value, tracked_request):
 
 @pytest.mark.parametrize("with_t", [True, False])
 def test_track_job_queue_time_valid(with_t, tracked_request):
-    queue_start = datetime_to_timestamp(dt.datetime.utcnow()) - 2.0
+    queue_start = datetime_to_timestamp(dt.datetime.now(dt.timezone.utc)) - 2.0
     result = track_job_queue_time(queue_start, tracked_request)
 
     assert result is True
@@ -61,7 +63,9 @@ def test_track_job_queue_time_valid(with_t, tracked_request):
     [
         str(""),
         str("123"),
-        str(datetime_to_timestamp(dt.datetime.utcnow()) + 3600.0),  # one hour in future
+        str(
+            datetime_to_timestamp(dt.datetime.now(dt.timezone.utc)) + 3600.0
+        ),  # one hour in future
         str(datetime_to_timestamp(dt.datetime(2009, 1, 1))),  # before ambig cutoff
     ],
 )

--- a/tests/unit/core/test_tracked_request.py
+++ b/tests/unit/core/test_tracked_request.py
@@ -167,7 +167,7 @@ def test_start_span_at_max_ignores_span(caplog, tracked_request):
 def test_span_captures_backtrace(tracked_request):
     span = tracked_request.start_span(operation="Sql/Work")
     # Pretend it was started 1 second ago
-    span.start_time = dt.datetime.utcnow() - dt.timedelta(seconds=1)
+    span.start_time = dt.datetime.now(dt.timezone.utc) - dt.timedelta(seconds=1)
     tracked_request.stop_span()
     assert "stack" in span.tags
 


### PR DESCRIPTION
Fixes #799.

This needs further testing to check whether the issue from #400 is fixed in the core agent or if it needs handling here, by changing the formatting to remove timezone info.

I no longer have a working dev setup for this though, so I will leave that testing in your hands. (I used to be the maintainer of this package.)