### PR TITLE
Unpin urllib3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,8 +99,8 @@ jobs:
       REDIS_URL: redis://localhost:6379/0
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Upgrade packaging tools

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,6 @@ jobs:
         - "3.10"
         - "3.11"
         - "3.12"
-        - "3.13"
 
     services:
       elasticsearch:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,64 +19,15 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-        - "3.8"
         - "3.9"
         - "3.10"
         - "3.11"
         - "3.12"
+        - "3.13"
 
     services:
       elasticsearch:
         image: elasticsearch:8.7.0
-        ports:
-        - 9200:9200
-        env:
-          discovery.type: single-node
-          xpack.security.enabled: false
-
-      mongodb:
-        image: mongo:4
-        ports:
-        - 27017:27017
-
-      redis:
-        image: redis:6
-        ports:
-        - 6379:6379
-
-    env:
-      ELASTICSEARCH_URL: http://localhost:9200/
-      MONGODB_URL: mongodb://localhost:27017/
-      REDIS_URL: redis://localhost:6379/0
-
-    steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Upgrade packaging tools
-      run: python -m pip install --upgrade pip setuptools importlib_metadata virtualenv
-    - name: Install dependencies
-      run: python -m pip install --upgrade tox
-    - name: Run tox targets for ${{ matrix.python-version }}
-      run: |
-        ENV_PREFIX=$(tr -C -d "0-9" <<< "${{ matrix.python-version }}" | cut -c -3)
-        TOXENV=$(tox --listenvs | grep "^py$ENV_PREFIX" | tr '\n' ',') python -m tox
-
-  tests-ubuntu-20:
-    name: Python ${{ matrix.python-version }} Ubuntu 20
-    runs-on: ubuntu-20.04
-
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version:
-        - "3.8"
-        - "3.9"
-
-    services:
-      elasticsearch:
-        image: elasticsearch:7.10.1
         ports:
         - 9200:9200
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,9 @@ jobs:
         # Disable for platforms where pure Python wheels would be generated
         cibw_skip: [ "pp38-* pp39-* pp310-* pp311-*" ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         name: Install Python
         with:
           python-version: ${{ matrix.python }}
@@ -47,7 +47,7 @@ jobs:
           CIBW_ARCHS_LINUX: "auto aarch64"
         run: python -m cibuildwheel
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
 
@@ -55,7 +55,7 @@ jobs:
     name: Build macos wheels (cross-compiles arm64)
     runs-on: macos-13
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v4
         name: Install Python
@@ -72,7 +72,7 @@ jobs:
           CIBW_ARCHS_MACOS: "x86_64 arm64"
         run: python -m cibuildwheel
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
 
@@ -83,9 +83,9 @@ jobs:
       matrix:
         python: [3.9]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         name: Install Python
         with:
           python-version: ${{ matrix.python-version }}
@@ -106,9 +106,9 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v5
         name: Install Python
         with:
           python-version: 3.9
@@ -116,7 +116,7 @@ jobs:
       - name: Build sdist
         run: python setup.py sdist
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: dist/*.tar.gz
 
@@ -125,7 +125,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Download distributions for publishing.
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: artifact
           path: dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,7 +104,7 @@ jobs:
 
   build_sdist:
     name: Build source distribution
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,7 @@ jobs:
           SCOUT_DISABLE_EXTENSIONS: "1"
         run: python setup.py bdist_wheel
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: dist/*.whl
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,6 +127,8 @@ jobs:
   upload_pypi:
     needs: [cibuildwheel_py38plus, build_pure_wheels, build_sdist, build_macos_wheels]
     runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
     steps:
       - name: Download distributions for publishing.
         uses: actions/download-artifact@v4
@@ -139,7 +141,7 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.TEST_TWINE_PASSWORD }}
-          repository_url: https://test.pypi.org/legacy/
+          repository-url: https://test.pypi.org/legacy/
           skip_existing: true
 
       - name: Publish distributions to PyPI
@@ -147,4 +149,3 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
-          password: ${{ secrets.TWINE_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         python: ['3.10']
         manylinux_image: [ manylinux2014, manylinux_2_28 ]
         # Disable for platforms where pure Python wheels would be generated
-        cibw_skip: [ "pp310-* pp311-* pp312-* pp313-*" ]
+        cibw_skip: [ "pp38-* pp39-* pp310-* pp311-* pp312-* pp313-*" ]
     steps:
       - uses: actions/checkout@v4
 
@@ -78,7 +78,7 @@ jobs:
 
   build_pure_wheels:
     name: Build pure python wheels
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         python: [3.9]
@@ -122,7 +122,7 @@ jobs:
 
   upload_pypi:
     needs: [cibuildwheel_py38plus, build_pure_wheels, build_sdist, build_macos_wheels]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Download distributions for publishing.
         uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-20.04 ]
-        python: ['3.10']
+        os: [ ubuntu-22.04 ]
+        python: ['3.10', '3.11', '3.12', '3.13']
         manylinux_image: [ manylinux2014, manylinux_2_28 ]
         # Disable for platforms where pure Python wheels would be generated
-        cibw_skip: [ "pp38-* pp39-* pp310-* pp311-*" ]
+        cibw_skip: [ "pp310-* pp311-* pp312-* pp313-*" ]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
+          name: ${{ matrix.manylinux_image }}-${{ matrix.python }}-${{ matrix.os }}
           path: ./wheelhouse/*.whl
 
   build_macos_wheels:
@@ -57,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         name: Install Python
         with:
           python-version: "3.10"
@@ -74,6 +75,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
+          name: macos
           path: ./wheelhouse/*.whl
 
   build_pure_wheels:
@@ -81,14 +83,14 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        python: [3.9]
+        python: [3.8, 3.9]
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
         name: Install Python
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.python }}
       - name: Install packaging tools
         run: |
           python -m pip install --upgrade pip setuptools importlib_metadata wheel
@@ -100,6 +102,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
+          name: pp${{ matrix.python }}
           path: dist/*.whl
 
   build_sdist:
@@ -118,6 +121,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
+          name: sdist
           path: dist/*.tar.gz
 
   upload_pypi:
@@ -127,8 +131,8 @@ jobs:
       - name: Download distributions for publishing.
         uses: actions/download-artifact@v4
         with:
-          name: artifact
           path: dist
+          merge-multiple: true
 
       - name: Publish distributions to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-22.04 ]
-        python: ['3.10', '3.11', '3.12', '3.13']
+        python: ['3.10']
         manylinux_image: [ manylinux2014, manylinux_2_28 ]
         # Disable for platforms where pure Python wheels would be generated
         cibw_skip: [ "pp310-* pp311-* pp312-* pp313-*" ]

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
     install_requires=[
         "asgiref",
         "psutil>=5",
-        "urllib3~=2.2.0",
+        "urllib3",
         "certifi",
         "wrapt>=1.10,<2.0",
     ],

--- a/src/scout_apm/rq.py
+++ b/src/scout_apm/rq.py
@@ -73,6 +73,8 @@ def wrap_perform(wrapped, instance, args, kwargs):
     # assumption here.
     if instance.enqueued_at.tzinfo is None:
         queued_at = instance.enqueued_at.replace(tzinfo=dt.timezone.utc)
+    else:
+        queued_at = instance.enqueued_at
     queue_time = (dt.datetime.now(dt.timezone.utc) - queued_at).total_seconds()
     tracked_request.tag("queue_time", queue_time)
     operation = "Job/{}".format(instance.func_name)

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 isolated_build = True
 envlist =
-    {py38,py39,py310,py311,py312}-django{40,41,42},
-    {py310,py311,py312}-django{50a},
+    {py39,py310,py311,py312,py313}-django{40,41,42},
+    {py310,py311,py312,py313}-django{52},
 [testenv]
 passenv =
     ELASTICSEARCH_URL
@@ -46,7 +46,6 @@ deps =
     redis
     rq
     six
-    sqlalchemy < 2.0.0 ; python_version <= "3.8"
     sqlalchemy
     starlette
     webtest
@@ -54,6 +53,6 @@ commands =
     pytest {posargs}
 
 # For newer versions of python use --asyncio-mode=auto usage.
-[testenv:py{38,39,310,311}-django{40,41,42}]
+[testenv:py{310,311,312,313}-django{42,52}]
 commands =
     pytest {posargs} --asyncio-mode=auto

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 isolated_build = True
 envlist =
     {py39,py310,py311,py312,py313}-django{40,41,42},
-    {py310,py311,py312,py313}-django{50a},
+    {py310,py311,py312}-django{50a},
 [testenv]
 passenv =
     ELASTICSEARCH_URL

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 isolated_build = True
 envlist =
     {py39,py310,py311,py312,py313}-django{40,41,42},
-    {py310,py311,py312,py313}-django{52},
+    {py310,py311,py312,py313}-django{50a},
 [testenv]
 passenv =
     ELASTICSEARCH_URL
@@ -20,8 +20,8 @@ deps =
     django41: djangorestframework
     django42: Django>4.1,<5
     django42: djangorestframework
-    django52: Django>=5.2,<5.3
-    django52: djangorestframework
+    django50a: Django>=5.0a1,<5.1
+    django50a: djangorestframework
     dramatiq>=1.0.0
     elasticsearch<8.0.0; python_version <= "3.9"
     elasticsearch<9; python_version > "3.9"

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ deps =
     django52: djangorestframework
     dramatiq>=1.0.0
     elasticsearch<8.0.0; python_version <= "3.9"
-    elasticsearch ; python_version > "3.9"
+    elasticsearch<9; python_version > "3.9"
     falcon
     flask
     flask-sqlalchemy

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 isolated_build = True
 envlist =
-    {py39,py310,py311,py312,py313}-django{40,41,42},
+    {py39,py310,py311,py312}-django{40,41,42},
     {py310,py311,py312}-django{50a},
 [testenv]
 passenv =
@@ -51,6 +51,6 @@ commands =
     pytest {posargs}
 
 # For newer versions of python use --asyncio-mode=auto usage.
-[testenv:py{310,311,312,313}-django{42,52}]
+[testenv:py{38,39,310,311,312,313}-django{40,41,42,50a}]
 commands =
     pytest {posargs} --asyncio-mode=auto

--- a/tox.ini
+++ b/tox.ini
@@ -14,16 +14,14 @@ deps =
     cherrypy
     celery!=4.4.4  # https://github.com/celery/celery/issues/6153
     cryptography
-    django32: Django>=3.2,<3.3
-    django32: djangorestframework
     django40: Django>=4.0,<4.1
     django40: djangorestframework
     django41: Django>4.0,<4.2
     django41: djangorestframework
     django42: Django>4.1,<5
     django42: djangorestframework
-    django50a: Django>=5.0a1,<5.1
-    django50a: djangorestframework
+    django52: Django>=5.2,<5.3
+    django52: djangorestframework
     dramatiq>=1.0.0
     elasticsearch<8.0.0; python_version <= "3.9"
     elasticsearch ; python_version > "3.9"

--- a/tox.ini
+++ b/tox.ini
@@ -33,9 +33,9 @@ deps =
     hiredis
     huey
     hug>=2.5.1
-    httpretty
     importlib_metadata
     jinja2
+    mocket
     psutil
     pymongo
     pyramid


### PR DESCRIPTION
- Replaced httpretty with python-mocket
  - httpretty had gone unmaintained
  - Squelched some socket-not-closed warnings; looks like internal library handling and the semantics of our agent haven't changed around urllib `PoolManager`
- Updated upload/download-artifact to new v4/non-deprecated versions
  - Manually name and differentiate artifacts within the run to avoid collision
- update setup-python and checkout action versions
- Remove deprecated `ubuntu-20.04` runners
- Fix `rq` instrument to handle timezone-aware processing within the lib (🎉 )
- Removed EOL python 3.8 tests
- Created issues to verify Django 5.1/5.2, Elasticsearch 9 and python 3.13 as follow-up