### PR TITLE
Bump version to 3.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Pending
 
+## [3.5.0] 2025-10-31
+### Added
+- Instrumentation for [FastMCP](https://github.com/jlowin/fastmcp) via `fastmcp.ScoutMiddleware` (#818)
+- Formal support for Python 3.13 and 3.14 (#819)
+- Formal support for Django 5.1 and 5.2
+- Use strict data filter for tar extraction (#820)
+
+### Removed
+- Formal Python 3.9 support.
+
 ## [3.4.0] 2025-05-08
 ### Fixed
 - urllib3 dependency un-pin (#810)

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ else:
 
 setup(
     name="scout_apm",
-    version="3.4.0",
+    version="3.5.0",
     description="Scout Application Performance Monitoring Agent",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## Changes
- Bumps version to 3.5.0

note:
if https://github.com/scoutapp/scout_apm_python/pull/820 is merged first, will update changelog to reflect this. -- DONE 
