### PR TITLE
build with python 3.14

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,6 @@ jobs:
         os: [ ubuntu-22.04 ]
         python: ["3.14"]
         manylinux_image: [ manylinux2014, manylinux_2_28 ]
-        # Disable for platforms where pure Python wheels would be generated
-        cibw_skip: [ "pp38-* pp39-* pp310-* pp311-*" ]
     steps:
       - uses: actions/checkout@v4
 
@@ -72,7 +70,6 @@ jobs:
           python -m pip install --upgrade pip cibuildwheel
       - name: Build binary wheels
         env:
-          CIBW_SKIP: "pp38-* pp39-* pp310-* pp311-*"
           CIBW_BUILD_VERBOSITY: 1
           CIBW_ARCHS_MACOS: "x86_64 arm64"
         run: python -m cibuildwheel


### PR DESCRIPTION
## Changes
- We haven't been CPython for 3.14. Bumps build environment python versions to address that. 
- Later (>3.10) Python versions will install the latest `cibuildwheel`


closes #825