### PR TITLE
Add transaction_id in error context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Pending
+### Fixed
+- Attach `transaction_id` to error context to support querying for matching logs in errors service.
 
 ## [3.5.0] 2025-10-31
 ### Added

--- a/src/scout_apm/core/error.py
+++ b/src/scout_apm/core/error.py
@@ -45,6 +45,7 @@ class ErrorMonitor(object):
 
         context = {}
         context.update(tracked_request.tags)
+        context["transaction_id"] = tracked_request.request_id
 
         if custom_params:
             context["custom_params"] = custom_params

--- a/tests/unit/core/test_error.py
+++ b/tests/unit/core/test_error.py
@@ -74,7 +74,7 @@ def test_monitor_ignore_exceptions(error_monitor_errors):
                 "request_session": None,
                 "environment": None,
                 "request_components": None,
-                "context": {"spam": "foo"},
+                "context": {"spam": "foo", "transaction_id": "sample_id"},
                 "host": None,
                 "revision_sha": "",
             },
@@ -101,7 +101,7 @@ def test_monitor_ignore_exceptions(error_monitor_errors):
                     "controller": "test-controller",
                     "action": None,
                 },
-                "context": {"spam": "foo"},
+                "context": {"spam": "foo", "transaction_id": "sample_id"},
                 "host": None,
                 "revision_sha": "",
             },
@@ -128,7 +128,7 @@ def test_monitor_ignore_exceptions(error_monitor_errors):
                     "controller": "DataView",
                     "action": "detail",
                 },
-                "context": {"spam": "foo"},
+                "context": {"spam": "foo", "transaction_id": "sample_id"},
                 "host": None,
                 "revision_sha": "",
             },
@@ -155,7 +155,11 @@ def test_monitor_ignore_exceptions(error_monitor_errors):
                     "controller": "test-controller",
                     "action": "detail",
                 },
-                "context": {"spam": "foo", "custom_params": {"baz": 3}},
+                "context": {
+                    "spam": "foo",
+                    "transaction_id": "sample_id",
+                    "custom_params": {"baz": 3},
+                },
                 "host": None,
                 "revision_sha": "",
             },
@@ -247,7 +251,7 @@ def test_monitor_with_logged_payload(
     assert "ZeroDivisionError" in actual_message
     assert "division by zero" in actual_message
     assert (
-        "tests/unit/core/test_error.py:227:in test_monitor_with_logged_payload"
+        "tests/unit/core/test_error.py:231:in test_monitor_with_logged_payload"
         in actual_message
     )
     assert "sample.app" in actual_message


### PR DESCRIPTION
## Changes
- Adds `transaction_id` to the error context object.
- This, along with PR in python logging agent, will allow linking from errors service to logs.  