### PR TITLE
update macos build image to macos-15

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
 
   build_macos_wheels:
     name: Build macos wheels (cross-compiles arm64)
-    runs-on: macos-13
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
The macos-13 (ventura) image was deprecated and no longer supported. This caused a failed release action. 
https://github.com/actions/runner-images/issues/13046